### PR TITLE
refactor OperatorRegistry

### DIFF
--- a/packages/loopring_v3/contracts/iface/IOperatorRegistry.sol
+++ b/packages/loopring_v3/contracts/iface/IOperatorRegistry.sol
@@ -33,19 +33,19 @@ contract IOperatorRegistry
 
     function createNewState(
         address owner,
-        bool closedOperatorRegistering
+        bool operatorRegistrationClosed
         )
         external;
 
     function getActiveOperatorID(
-        uint32 stateID
+        uint32 stateIdx
         )
         external
         view
         returns (uint32);
 
     function getOperatorOwner(
-        uint32 stateID,
+        uint32 stateIdx,
         uint32 operatorID
         )
         external
@@ -53,7 +53,7 @@ contract IOperatorRegistry
         returns (address payable owner);
 
     function ejectOperator(
-        uint32 stateID,
+        uint32 stateIdx,
         uint32 operatorID
         )
         external;

--- a/packages/loopring_v3/contracts/iface/ITokenRegistry.sol
+++ b/packages/loopring_v3/contracts/iface/ITokenRegistry.sol
@@ -59,7 +59,7 @@ contract ITokenRegistry
         returns (address);
 
     function getBurnRate(
-        uint24 tokenID
+        uint16 tokenID
         )
         public
         view

--- a/packages/loopring_v3/contracts/impl/Exchange.sol
+++ b/packages/loopring_v3/contracts/impl/Exchange.sol
@@ -188,7 +188,7 @@ contract Exchange is IExchange, NoDefaultFunc
         uint depositFeeInETH,
         uint withdrawFeeInETH,
         uint maxWithdrawFeeInETH,
-        bool closedOperatorRegistering
+        bool operatorRegistrationClosed
         )
         external
     {
@@ -221,7 +221,7 @@ contract Exchange is IExchange, NoDefaultFunc
 
         IOperatorRegistry(operatorRegistryAddress).createNewState(
             owner,
-            closedOperatorRegistering
+            operatorRegistrationClosed
         );
 
         emit NewState(uint16(states.length - 1), owner);

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1232,7 +1232,7 @@ export class ExchangeTestUtil {
       depositFeeInETH: BN = new BN(web3.utils.toWei("0.0001", "ether")),
       withdrawFeeInETH: BN = new BN(web3.utils.toWei("0.0001", "ether")),
       maxWithdrawFeeInETH: BN = new BN(web3.utils.toWei("0.001", "ether")),
-      closedOperatorRegistering: boolean = false,
+      operatorRegistrationClosed: boolean = false,
     ) {
     // Create the new state
     const tx = await this.exchange.createNewState(
@@ -1240,7 +1240,7 @@ export class ExchangeTestUtil {
       depositFeeInETH,
       withdrawFeeInETH,
       maxWithdrawFeeInETH,
-      closedOperatorRegistering);
+      operatorRegistrationClosed);
     // pjs.logInfo("\x1b[46m%s\x1b[0m", "[NewState] Gas used: " + tx.receipt.gasUsed);
 
     const eventArr: any = await this.getEventsFromContract(this.exchange, "NewState", web3.eth.blockNumber);


### PR DESCRIPTION
I suggest this architecture:

- **ILoopring**: this allows anyone to dynamically create an IExchange instance (associated with a new ETH address), to query the list of IExchange instances, their status, and owners, etc.
- **IExchange**: this is a single DEX with one offchain Merkel Tree. All onchain interactions with this DEX will totally be isolated from activities of other DEXes.

We can totally drop the `State` concept.