### PR TITLE
Protocol3: add pubkey to DepositRequested event

### DIFF
--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -74,7 +74,9 @@ contract IExchange
         uint32  indexed depositIdx,
         uint24  indexed accountID,
         uint16  indexed tokenID,
-        uint96          amount
+        uint96          amount,
+        uint            pubKeyX,
+        uint            pubKeyY
     );
 
     event BlockFeeWithdrawn(

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeDeposits.sol
@@ -40,7 +40,9 @@ library ExchangeDeposits
         uint32  indexed depositIdx,
         uint24  indexed accountID,
         uint16  indexed tokenID,
-        uint96          amount
+        uint96          amount,
+        uint            pubKeyX,
+        uint            pubKeyY
     );
 
     function getNumDepositRequestsProcessed(
@@ -154,7 +156,9 @@ library ExchangeDeposits
             uint32(S.depositChain.length - 1),
             accountID,
             tokenID,
-            amount
+            amount,
+            account.pubKeyX,
+            account.pubKeyY
         );
     }
 


### PR DESCRIPTION
This would allow operators to monitor events and get all data required to process the deposit request.