### PR TITLE
[PROTOCOL3] bitarray encode update

### DIFF
--- a/packages/loopring_v3/test/bitarray.ts
+++ b/packages/loopring_v3/test/bitarray.ts
@@ -7,12 +7,19 @@ export class BitArray {
     this.data = initialData;
   }
 
+  public addBNWithoutLength(value: BN) {
+    const strBits = Array.from(value.toString(2));
+    const numBits = strBits.map(i => Number(i));
+    this.data.push(...numBits);
+  }
+
   public addBN(value: BN, length: number) {
-    const res = new Array(length);
-    for (let i = 0; i < length; i++) {
-      res[i] = value.testn(i) ? 1 : 0;
+    let bits = value.toString(2);
+    if (length > bits.length) {
+      bits = "0".repeat(length - bits.length) + bits;
     }
-    this.data.push(...res);
+    const numBits = Array.from(bits).map(n => Number(n));
+    this.data.push(...numBits);
   }
 
   public addNumber(value: number, length: number) {


### PR DESCRIPTION
Update the BN encoding method, the problem of the current encoding is: 
    const bn0 = new BN("123456789");
    const numBitStr = bn0.toString(2);

    const bitarray1 = new bitarray.BitArray();
    bitarray1.addBN(bn0, bn0.toString(2).length);
    const bitarrayBitStr = bitarray1.getBits().join("");

numBitStr is not equal to numBitStr. This is not convenient for testing.

Furthermore, can we remove the `length` parameter of all functions?

