### PR TITLE
[Protocol2] Made the two updates necessary for Dolomite's launch & re-deployment

### DIFF
--- a/packages/loopring_v2/deployment-source/v2.2-dolomite/RingSubmitter_flat.sol
+++ b/packages/loopring_v2/deployment-source/v2.2-dolomite/RingSubmitter_flat.sol
@@ -1064,6 +1064,18 @@ contract IRingSubmitter {
     event InvalidRing(
         bytes32 _ringHash
     );
+    
+    /// @dev   Event emitted when fee rebates are distributed (waiveFeePercentage < 0)
+    ///         _ringHash   The hash of the ring whose order(s) will receive the rebate
+    ///         _orderHash  The hash of the order that will receive the rebate
+    ///         _feeToken   The address of the token that will be paid to the _orderHash's owner
+    ///         _feeAmount  The amount to be paid to the owner
+    event DistributeFeeRebate(
+        bytes32 indexed _ringHash,
+        bytes32 indexed _orderHash,
+        address         _feeToken,
+        uint            _feeAmount
+    );
 
     /// @dev   Submit order-rings for validation and settlement.
     /// @param data Packed data of all rings.

--- a/packages/loopring_v2/deployment-source/v2.2-dolomite/RingSubmitter_flat.sol
+++ b/packages/loopring_v2/deployment-source/v2.2-dolomite/RingSubmitter_flat.sol
@@ -1745,10 +1745,14 @@ library ParticipationHelper {
         }
 
         if ((p.fillAmountS - p.feeAmountS) >= prevP.fillAmountB) {
-            // The miner (or in a P2P case, the taker) gets the margin
-            p.splitS = (p.fillAmountS - p.feeAmountS) - prevP.fillAmountB;
-            p.fillAmountS = prevP.fillAmountB + p.feeAmountS;
-            return true;
+            // The taker gets the margin
+            // This is the old way of calculating the margin split. GET RID OF IT so the user wins, always :-)
+            //  p.splitS = (p.fillAmountS - p.feeAmountS) - prevP.fillAmountB;
+
+            // Margin is given to the user
+            uint marginSplitS = (p.fillAmountS - p.feeAmountS) - prevP.fillAmountB;
+            p.fillAmountS = prevP.fillAmountB + p.feeAmountS + marginSplitS;
+            p.splitS = 0;
         } else {
             return false;
         }
@@ -1816,6 +1820,18 @@ library RingHelper {
     using MathUint for uint;
     using OrderHelper for Data.Order;
     using ParticipationHelper for Data.Participation;
+    
+    /// @dev   Event emitted when fee rebates are distributed (waiveFeePercentage < 0)
+    ///         _ringHash   The hash of the ring whose order(s) will receive the rebate
+    ///         _orderHash  The hash of the order that will receive the rebate
+    ///         _feeToken   The address of the token that will be paid to the _orderHash's owner
+    ///         _feeAmount  The amount to be paid to the owner
+    event DistributeFeeRebate(
+        bytes32 indexed _ringHash,
+        bytes32 indexed _orderHash,
+        address         _feeToken,
+        uint            _feeAmount
+    );
 
     function updateHash(
         Data.Ring memory ring
@@ -2047,7 +2063,6 @@ library RingHelper {
         Data.Mining memory mining
         )
         internal
-        view
     {
         payFees(ring, ctx, mining);
         transferTokens(ring, ctx, mining.feeRecipient);
@@ -2240,7 +2255,6 @@ library RingHelper {
         Data.Mining memory mining
         )
         internal
-        view
     {
         Data.FeeContext memory feeCtx;
         feeCtx.ring = ring;
@@ -2259,7 +2273,6 @@ library RingHelper {
         Data.Participation memory p
         )
         internal
-        view
         returns (uint)
     {
         feeCtx.walletPercentage = p.order.P2P ? 100 : (
@@ -2293,7 +2306,6 @@ library RingHelper {
         uint totalAmount
         )
         internal
-        view
         returns (uint)
     {
         if (totalAmount == 0) {
@@ -2424,6 +2436,8 @@ library RingHelper {
             if (feeCtx.ring.participations[i].order.waiveFeePercentage < 0) {
                 uint feeToOwner = minerFee
                     .mul(uint(-feeCtx.ring.participations[i].order.waiveFeePercentage)) / feeCtx.ctx.feePercentageBase;
+
+                emit DistributeFeeRebate(feeCtx.ring.hash, feeCtx.ring.participations[i].order.hash, token, feeToOwner);
 
                 feeCtx.ctx.feePtr = addFeePayment(
                     feeCtx.ctx.feeData,


### PR DESCRIPTION
This contains the two changes we need to launch Dolomite on v2 of Loopring:
1. disabling margin splitting
2. Emitting an event when there is a `waiveFeePercentage < 0`

After talking to @Brechtpd , we decided the easiest way to go about this, was to emit an event when there is a negative `waiveFeePercentage`. It was easiest to add the event to the `Library` and change the function declarations to no longer be `view`s.

This was tested via Ganache & Dolomite's backend in Scala. If the proposed changes are okay, can you redeploy this contract? Once it's deployed, Dolomite will be able to settle trades on the mainnet and we'll be ready to launch :)