### PR TITLE
[Protocol3] add support for future address KYC/whitelist

### DIFF
--- a/packages/loopring_v3/contracts/iface/IAddressWhitelist.sol
+++ b/packages/loopring_v3/contracts/iface/IAddressWhitelist.sol
@@ -17,9 +17,9 @@
 pragma solidity 0.5.7;
 
 
-/// @title IWhitelist
+/// @title IAddressWhitelist
 /// @author Daniel Wang  - <daniel@loopring.org>
-contract IWhitelist
+contract IAddressWhitelist
 {
     /// @dev Check if an address is in a whitelist.
     /// @return Returns true if the address is in the whitelist, false otehrwise.

--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -17,7 +17,7 @@
 pragma solidity 0.5.7;
 
 
-/// @title An Implementation of IExchange.
+/// @title IExchange.
 /// @author Brecht Devos - <brecht@loopring.org>
 /// @author Daniel Wang  - <daniel@loopring.org>
 contract IExchange
@@ -923,6 +923,16 @@ contract IExchange
         )
         external
         returns (address payable oldOperator);
+
+    /// @dev Set the account whitelist contract address.
+    /// @param accountWhitelist The new whitelist manager's address.
+    ///        Setting this to '0x0' will disable address checking for account creation/update.
+    /// @return oldAccountWhitelist The old Whitelist manager's address
+    function setAccountWhitelist(
+        address accountWhitelist
+        )
+        external
+        returns (address oldAccountWhitelist);
 
     /// @dev Update fee settings.
     ///      This function is only callable by the exchange owner.

--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -50,6 +50,12 @@ contract IExchange
         address         newOperator
     );
 
+    event AddressWhitelistChanged(
+        uint    indexed exchangeId,
+        address         oldAddressWhitelist,
+        address         newAddressWhitelist
+    );
+
     event FeesUpdated(
         uint    indexed exchangeId,
         uint            accountCreationFeeETH,

--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -924,15 +924,15 @@ contract IExchange
         external
         returns (address payable oldOperator);
 
-    /// @dev Set the account whitelist contract address.
-    /// @param accountWhitelist The new whitelist manager's address.
-    ///        Setting this to '0x0' will disable address checking for account creation/update.
-    /// @return oldAccountWhitelist The old Whitelist manager's address
-    function setAccountWhitelist(
-        address accountWhitelist
+    /// @dev Set the address whitelist contract address.
+    /// @param addressWhitelist The new whitelist manager's address.
+    ///        Setting this to '0x0' will disable address checking for account creation.
+    /// @return oldAddressWhitelist The old Whitelist manager's address
+    function setAddressWhitelist(
+        address addressWhitelist
         )
         external
-        returns (address oldAccountWhitelist);
+        returns (address oldAddressWhitelist);
 
     /// @dev Update fee settings.
     ///      This function is only callable by the exchange owner.

--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -925,9 +925,9 @@ contract IExchange
         returns (address payable oldOperator);
 
     /// @dev Set the address whitelist contract address.
-    /// @param addressWhitelist The new whitelist manager's address.
+    /// @param addressWhitelist The new whitelist contract address.
     ///        Setting this to '0x0' will disable address checking for account creation.
-    /// @return oldAddressWhitelist The old Whitelist manager's address
+    /// @return oldAddressWhitelist The old Whitelist contract address
     function setAddressWhitelist(
         address addressWhitelist
         )

--- a/packages/loopring_v3/contracts/iface/IWhitelist.sol
+++ b/packages/loopring_v3/contracts/iface/IWhitelist.sol
@@ -1,0 +1,30 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity 0.5.7;
+
+
+/// @title IWhitelist
+/// @author Daniel Wang  - <daniel@loopring.org>
+contract IWhitelist
+{
+    /// @dev Check if an address is in a whitelist.
+    /// @return Returns true if the address is in the whitelist, false otehrwise.
+    function isWhitelisted(address addr)
+        external
+        view
+        returns (bool);
+}

--- a/packages/loopring_v3/contracts/impl/Exchange.sol
+++ b/packages/loopring_v3/contracts/impl/Exchange.sol
@@ -19,8 +19,8 @@ pragma solidity 0.5.7;
 import "../lib/Claimable.sol";
 import "../lib/ReentrancyGuard.sol";
 
-import "../iface/IExchange.sol";
 import "../iface/IAddressWhitelist.sol";
+import "../iface/IExchange.sol";
 
 import "./libexchange/ExchangeAccounts.sol";
 import "./libexchange/ExchangeAdmins.sol";

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
@@ -67,16 +67,16 @@ library ExchangeAdmins
         );
     }
 
-    function setAccountWhitelist(
+    function setAddressWhitelist(
         ExchangeData.State storage S,
-        address _accountWhitelist
+        address _addressWhitelist
         )
         public
-        returns (address oldAccountWhitelist)
+        returns (address oldAddressWhitelist)
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
-        oldAccountWhitelist = S.accountWhitelist;
-        S.accountWhitelist = _accountWhitelist;
+        oldAddressWhitelist = S.addressWhitelist; // allows '0x0'
+        S.addressWhitelist = _addressWhitelist;
     }
 
     function setFees(

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
@@ -67,6 +67,18 @@ library ExchangeAdmins
         );
     }
 
+    function setAccountWhitelist(
+        ExchangeData.State storage S,
+        address _accountWhitelist
+        )
+        public
+        returns (address oldAccountWhitelist)
+    {
+        require(!S.isInWithdrawalMode(), "INVALID_MODE");
+        oldAccountWhitelist = S.accountWhitelist;
+        S.accountWhitelist = _accountWhitelist;
+    }
+
     function setFees(
         ExchangeData.State storage S,
         uint _accountCreationFeeETH,

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeAdmins.sol
@@ -40,6 +40,12 @@ library ExchangeAdmins
         address         newOperator
     );
 
+    event AddressWhitelistChanged(
+        uint    indexed exchangeId,
+        address         oldAddressWhitelist,
+        address         newAddressWhitelist
+    );
+
     event FeesUpdated(
         uint    indexed exchangeId,
         uint            accountCreationFeeETH,
@@ -57,6 +63,7 @@ library ExchangeAdmins
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
         require(address(0) != _operator, "ZERO_ADDRESS");
+        require(S.operator != _operator, "SAME_ADDRESS");
         oldOperator = S.operator;
         S.operator = _operator;
 
@@ -75,8 +82,15 @@ library ExchangeAdmins
         returns (address oldAddressWhitelist)
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
+        require(S.addressWhitelist != _addressWhitelist, "SAME_ADDRESS");
         oldAddressWhitelist = S.addressWhitelist; // allows '0x0'
         S.addressWhitelist = _addressWhitelist;
+
+        emit AddressWhitelistChanged(
+            S.id,
+            oldAddressWhitelist,
+            _addressWhitelist
+        );
     }
 
     function setFees(

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -200,6 +200,7 @@ library ExchangeData
         IBlockVerifier blockVerifier;
 
         address lrcAddress;
+        address accountWhitelist;
 
         uint    totalTimeInMaintenanceSeconds;
         uint    numDowntimeMinutes;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -200,7 +200,9 @@ library ExchangeData
         IBlockVerifier blockVerifier;
 
         address lrcAddress;
-        address addressWhitelist; // to manage addresses who can create/update accounts.
+        address addressWhitelist; // an IAddressWhitelist contract to manage which addresses
+                                  // can create accounts. Note that account update can be done
+                                  // once an address is created.
 
         uint    totalTimeInMaintenanceSeconds;
         uint    numDowntimeMinutes;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -200,7 +200,7 @@ library ExchangeData
         IBlockVerifier blockVerifier;
 
         address lrcAddress;
-        address accountWhitelist;
+        address addressWhitelist; // to manage addresses who can create/update accounts.
 
         uint    totalTimeInMaintenanceSeconds;
         uint    numDowntimeMinutes;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
@@ -56,6 +56,7 @@ library ExchangeGenesis
         ILoopringV3 loopring = ILoopringV3(_loopringAddress);
         S.blockVerifier = IBlockVerifier(loopring.blockVerifierAddress());
         S.lrcAddress = loopring.lrcAddress();
+        S.addressWhitelist = address(0);
 
         ExchangeData.Block memory genesisBlock = ExchangeData.Block(
             ExchangeData.GENESIS_MERKLE_ROOT(),


### PR DESCRIPTION
The address white list will only be checked against when new accounts are created. We always allow existing accounts to update account settings. For accounts that have created, the operator can maintain an off-chain whitelist and use it to decide not to match some users' orders anymore.