### PR TITLE
[Protocol3] Added circuit testing support + small improvements

### DIFF
--- a/packages/loopring_v3/README.md
+++ b/packages/loopring_v3/README.md
@@ -10,21 +10,21 @@ To understand the overall design for Loopring 3.0, including Ethereum smart cont
 
 ### Performance
 
-|  | Loopring 2.x | Loopring 3.0 <br> (w/ Data Availability) | Loopring 3.0 <br> (w/o Data Availability)  |
-| :----- |:-------------: |:---------------:| :-------------:|
-| Trades per Ethereum Block | 26      | 5350 |      92000|
-| Trades per Second | ~2      | 350        |           6150 |
-| Cost per Trade | ~300,000 gas | 1500 gas | 87 gas|
+|                           | Loopring 2.x | Loopring 3.0 <br> (w/ Data Availability) | Loopring 3.0 <br> (w/o Data Availability) |
+| :------------------------ | :----------: | :--------------------------------------: | :---------------------------------------: |
+| Trades per Ethereum Block |      26      |                   5350                   |                   92000                   |
+| Trades per Second         |      ~2      |                   350                    |                   6150                    |
+| Cost per Trade            | ~300,000 gas |                 1500 gas                 |                  87 gas                   |
 
 After Istanbul:
 
-|  | Loopring 2.x | Loopring 3.0 <br> (w/ Data Availability) | Loopring 3.0 <br> (w/o Data Availability)  |
-| :----- |:-------------: |:---------------:| :-------------:|
-| Trades per Ethereum Block | 26      | 20800 |      140000|
-| Trades per Second | ~2      | 1400        |           9350 |
-| Cost per Trade | ~300,000 gas | 385 gas | 57 gas|
+|                           | Loopring 2.x | Loopring 3.0 <br> (w/ Data Availability) | Loopring 3.0 <br> (w/o Data Availability) |
+| :------------------------ | :----------: | :--------------------------------------: | :---------------------------------------: |
+| Trades per Ethereum Block |      26      |                  20800                   |                  140000                   |
+| Trades per Second         |      ~2      |                   1400                   |                   9350                    |
+| Cost per Trade            | ~300,000 gas |                 385 gas                  |                  57 gas                   |
 
-* *Cost in USD per Trade* in the table does not cover off-chain proof generation.
+- _Cost in USD per Trade_ in the table does not cover off-chain proof generation.
 
 ## Top Features
 
@@ -45,6 +45,7 @@ After Istanbul:
 - and more...
 
 ## Challenges
+
 - SNARKs require trusted setups
 
 ## Build
@@ -59,7 +60,10 @@ The code of our circuits is currently not open source. If you have access to the
 make
 ```
 
+The circuit tests can be run with `npm run test-circuits`. A single test can be run with `npm run test-circuits <test_name>`.
+
 ## Run Unit Tests
+
 - please clone the circuits repository `https://github.com/Loopring/protocol3-circuits.git` to the same directory as this project.
 - please make sure you run `npm run build` for the first time.
 - run `npm run ganache` from project's root directory in terminal.

--- a/packages/loopring_v3/circuit/CMakeLists.txt
+++ b/packages/loopring_v3/circuit/CMakeLists.txt
@@ -7,4 +7,9 @@ set(circuit_src_folder "../../../../protocol3-circuits/")
 add_executable(dex_circuit "${circuit_src_folder}/main.cpp")
 target_link_libraries(dex_circuit ethsnarks_jubjub)
 
+file(GLOB test_filenames
+    "${circuit_src_folder}/test/*.cpp"
+)
 
+add_executable(dex_circuit_tests ${test_filenames})
+target_link_libraries(dex_circuit_tests ethsnarks_jubjub)

--- a/packages/loopring_v3/package.json
+++ b/packages/loopring_v3/package.json
@@ -40,7 +40,8 @@
     "truffle": "truffle",
     "clean": "rm -rf build/contracts",
     "v": "node -v",
-    "preinstall": "rm -rf node_modules/websocket/.git"
+    "preinstall": "rm -rf node_modules/websocket/.git",
+    "test-circuits": "./build/circuit/dex_circuit_tests"
   },
   "license": "ISC",
   "devDependencies": {

--- a/packages/loopring_v3/test/testExchangeRingSettlement.ts
+++ b/packages/loopring_v3/test/testExchangeRingSettlement.ts
@@ -841,6 +841,68 @@ contract("Exchange", (accounts: string[]) => {
       await verify();
     });
 
+    it("Insufficient funds available (buy order)", async () => {
+      const ring: RingInfo = {
+        orderA: {
+          tokenS: "ETH",
+          tokenB: "GTO",
+          amountS: new BN(web3.utils.toWei("100", "ether")),
+          amountB: new BN(web3.utils.toWei("10", "ether")),
+          balanceS: new BN(web3.utils.toWei("40", "ether")),
+          buy: true
+        },
+        orderB: {
+          tokenS: "GTO",
+          tokenB: "ETH",
+          amountS: new BN(web3.utils.toWei("20", "ether")),
+          amountB: new BN(web3.utils.toWei("200", "ether"))
+        },
+        expected: {
+          orderA: { filledFraction: 0.4, spread: new BN(0) },
+          orderB: { filledFraction: 0.2 }
+        }
+      };
+
+      await exchangeTestUtil.setupRing(ring);
+      await exchangeTestUtil.sendRing(exchangeID, ring);
+
+      await exchangeTestUtil.commitDeposits(exchangeID);
+      await exchangeTestUtil.commitRings(exchangeID);
+
+      await verify();
+    });
+
+    it("Insufficient funds available (sell order)", async () => {
+      const ring: RingInfo = {
+        orderA: {
+          tokenS: "ETH",
+          tokenB: "GTO",
+          amountS: new BN(web3.utils.toWei("100", "ether")),
+          amountB: new BN(web3.utils.toWei("10", "ether")),
+          balanceS: new BN(web3.utils.toWei("40", "ether")),
+          buy: false
+        },
+        orderB: {
+          tokenS: "GTO",
+          tokenB: "ETH",
+          amountS: new BN(web3.utils.toWei("20", "ether")),
+          amountB: new BN(web3.utils.toWei("200", "ether"))
+        },
+        expected: {
+          orderA: { filledFraction: 0.4, spread: new BN(0) },
+          orderB: { filledFraction: 0.2 }
+        }
+      };
+
+      await exchangeTestUtil.setupRing(ring);
+      await exchangeTestUtil.sendRing(exchangeID, ring);
+
+      await exchangeTestUtil.commitDeposits(exchangeID);
+      await exchangeTestUtil.commitRings(exchangeID);
+
+      await verify();
+    });
+
     it("allOrNone (Buy, successful)", async () => {
       const ring: RingInfo = {
         orderA: {

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -2978,7 +2978,7 @@ export class ExchangeTestUtil {
           const tradeHistoryValueA =
             balanceValueA.tradeHistory[Number(orderID)];
           const tradeHistoryValueB =
-            balanceValueA.tradeHistory[Number(orderID)];
+            balanceValueB.tradeHistory[Number(orderID)];
 
           assert(
             tradeHistoryValueA.filled.eq(tradeHistoryValueB.filled),
@@ -3287,8 +3287,46 @@ export class ExchangeTestUtil {
         );
       }
 
-      // const accountBefore = latestState.accounts[cancel.accountID];
-      // const accountAfter = simulatorReport.exchangeStateAfter.accounts[cancel.accountID];
+      const accountBefore = latestState.accounts[cancel.accountID];
+      const accountAfter =
+        simulatorReport.exchangeStateAfter.accounts[cancel.accountID];
+
+      const tradeHistorySlot =
+        cancel.orderID % 2 ** constants.TREE_DEPTH_TRADING_HISTORY;
+      let tradeHistoryBefore =
+        accountBefore.balances[cancel.orderTokenID].tradeHistory[
+          tradeHistorySlot
+        ];
+      if (!tradeHistoryBefore) {
+        tradeHistoryBefore = {
+          filled: new BN(0),
+          cancelled: false,
+          orderID: 0
+        };
+      }
+      const tradeHistoryAfter =
+        accountAfter.balances[cancel.orderTokenID].tradeHistory[
+          tradeHistorySlot
+        ];
+      logInfo("Slot " + tradeHistorySlot + " (" + cancel.orderID + "):");
+      logInfo(
+        "- cancelled: " +
+          tradeHistoryBefore.cancelled +
+          " -> " +
+          tradeHistoryAfter.cancelled
+      );
+      logInfo(
+        "- filled: " +
+          tradeHistoryBefore.filled.toString(10) +
+          " -> " +
+          tradeHistoryAfter.filled.toString(10)
+      );
+      logInfo(
+        "- orderID: " +
+          tradeHistoryBefore.orderID +
+          " -> " +
+          tradeHistoryAfter.orderID
+      );
 
       latestState = simulatorReport.exchangeStateAfter;
     }
@@ -3862,7 +3900,9 @@ export class ExchangeTestUtil {
         "% -> " +
         filledAfterPercentage.toString(10) +
         "%)" +
-        " (" +
+        " (slot " +
+        tradeHistorySlot +
+        ": " +
         this.getPrettyCancelled(before.cancelled) +
         " -> " +
         this.getPrettyCancelled(after.cancelled) +


### PR DESCRIPTION
- The circuits testing executable is made with `make`. All tests can be run with `npm run test-circuits`.
- The rounding error check is now done on the rate of the actual trade (fillS/fillB) instead of on the rounding error on the division to calculate `fillB`. This should be more accurate and is cheaper.
- When cancelling an order with an `orderID` > `tradingHistory.orderID` the filled amount is reset to 0. This accurately represent the filled amount of the `orderID` stored in the trading history (but the order is cancelled, so it doesn't actually matter for the protocol).