### PR TITLE
[Lightcone_V2.js] Update the value of gasLimit in exchange.ts in lightcone_v2.js

### DIFF
--- a/packages/lightcone_v2.js/src/sign/exchange.ts
+++ b/packages/lightcone_v2.js/src/sign/exchange.ts
@@ -25,6 +25,8 @@ import {
   SimpleOrderCancellationReq
 } from "../grpc/proto_gen/service_dex_pb";
 
+const MOCK_EXCHANGE_GAS_LIMIT = "0xf0f09f0";
+
 // TODO: Rename Exchange
 export class Exchange {
   private currentDexAccount: DexAccount;
@@ -195,7 +197,7 @@ export class Exchange {
         chainId: config.getChainId(),
         nonce: fm.toHex(await ethereum.wallet.getNonce(this.getAddress())),
         gasPrice: fm.toHex(fm.toBig(gasPrice).times(1e9)),
-        gasLimit: fm.toHex(config.getGasLimitByType("eth_transfer").gasLimit) // TODO: new gas limit
+        gasLimit: fm.toHex(MOCK_EXCHANGE_GAS_LIMIT) // TODO: new gas limit
       });
       console.log("CreateOrUpdateAccount");
     } catch (err) {
@@ -230,7 +232,7 @@ export class Exchange {
           chainId: config.getChainId(),
           nonce: fm.toHex(await ethereum.wallet.getNonce(this.getAddress())),
           gasPrice: fm.toHex(fm.toBig(gasPrice).times(1e9)),
-          gasLimit: fm.toHex(config.getGasLimitByType("eth_transfer").gasLimit) // TODO: new gas limit
+          gasLimit: fm.toHex(MOCK_EXCHANGE_GAS_LIMIT) // TODO: new gas limit
         });
       }
     } catch (err) {
@@ -269,7 +271,7 @@ export class Exchange {
           chainId: config.getChainId(),
           nonce: fm.toHex(await ethereum.wallet.getNonce(this.getAddress())),
           gasPrice: fm.toHex(fm.toBig(gasPrice).times(1e9)),
-          gasLimit: fm.toHex(config.getGasLimitByType("eth_transfer").gasLimit) // TODO: new gas limit
+          gasLimit: fm.toHex(MOCK_EXCHANGE_GAS_LIMIT) // TODO: new gas limit
         });
       }
     } catch (err) {


### PR DESCRIPTION
If we use ```config.getGasLimitByType("eth_transfer").gasLimit```, it will return an error: 
```
"Error: base fee exceeds gas limit
    at /usr/lib/node_modules/ganache-cli/build/ganache-core.node.cli.js:61:1851624
    at /usr/lib/node_modules/ganache-cli/build/ganache-core.node.cli.js:2:21647
    at process._tickCallback (internal/process/next_tick.js:61:11)"
```