### PR TITLE
[Protocol3] Move genesis hash to Exchange.sol

### DIFF
--- a/packages/loopring_v3/contracts/iface/IExchange.sol
+++ b/packages/loopring_v3/contracts/iface/IExchange.sol
@@ -26,7 +26,8 @@ import "../lib/ReentrancyGuard.sol";
 /// @author Daniel Wang  - <daniel@loopring.org>
 contract IExchange is Claimable, ReentrancyGuard, Cloneable
 {
-    string constant public version = ""; // override this
+    string  constant public version          = ""; // must override this
+    bytes32 constant public genesisBlockHash = 0;  // must override this
 
     /// @dev Clone an exchange without any initialization
     /// @return  cloneAddress The address of the new exchange.

--- a/packages/loopring_v3/contracts/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/impl/ExchangeV3.sol
@@ -37,7 +37,9 @@ import "../iface/IExchangeV3.sol";
 /// @author Daniel Wang  - <daniel@loopring.org>
 contract ExchangeV3 is IExchangeV3
 {
-    string constant public version = "3.0-beta3";
+    string  constant public version = "3.0-beta3";
+    bytes32 constant public genesisBlockHash =
+        0x2b4827daf74c0ab30deb68b1c337dec40579bb3ff45ce9478288e1a2b83a3a01;
 
     using ExchangeAdmins        for ExchangeData.State;
     using ExchangeAccounts      for ExchangeData.State;
@@ -85,7 +87,8 @@ contract ExchangeV3 is IExchangeV3
             _id,
             _loopringAddress,
             _operator,
-            _onchainDataAvailability
+            _onchainDataAvailability,
+            genesisBlockHash
         );
     }
 

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -161,9 +161,9 @@ library ExchangeData
         uint96 amount;
     }
 
-    function GENESIS_MERKLE_ROOT() internal pure returns (bytes32) {
-        return 0x2b4827daf74c0ab30deb68b1c337dec40579bb3ff45ce9478288e1a2b83a3a01;
-    }
+    // function GENESIS_MERKLE_ROOT() internal pure returns (bytes32) {
+    //     return 0x2b4827daf74c0ab30deb68b1c337dec40579bb3ff45ce9478288e1a2b83a3a01;
+    // }
 
     function SNARK_SCALAR_FIELD() internal pure returns (uint) {
         // This is the prime number that is used for the alt_bn128 elliptic curve, see EIP-196.
@@ -191,7 +191,6 @@ library ExchangeData
 
     /// @dev Returns a list of constants used by the exchange.
     /// @return constants The list of constants in the following order:
-    ///         GENESIS_MERKLE_ROOT
     ///         SNARK_SCALAR_FIELD
     ///         MAX_PROOF_GENERATION_TIME_IN_SECONDS
     ///         MAX_GAP_BETWEEN_FINALIZED_AND_VERIFIED_BLOCKS
@@ -214,10 +213,9 @@ library ExchangeData
     function getConstants()
         external
         pure
-        returns(uint[20] memory)
+        returns(uint[19] memory)
     {
         return [
-            uint(GENESIS_MERKLE_ROOT()),
             uint(SNARK_SCALAR_FIELD()),
             uint(MAX_PROOF_GENERATION_TIME_IN_SECONDS()),
             uint(MAX_GAP_BETWEEN_FINALIZED_AND_VERIFIED_BLOCKS()),

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -161,10 +161,6 @@ library ExchangeData
         uint96 amount;
     }
 
-    // function GENESIS_MERKLE_ROOT() internal pure returns (bytes32) {
-    //     return 0x2b4827daf74c0ab30deb68b1c337dec40579bb3ff45ce9478288e1a2b83a3a01;
-    // }
-
     function SNARK_SCALAR_FIELD() internal pure returns (uint) {
         // This is the prime number that is used for the alt_bn128 elliptic curve, see EIP-196.
         return 21888242871839275222246405745257275088548364400416034343698204186575808495617;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
@@ -39,14 +39,15 @@ library ExchangeGenesis
         uint    _id,
         address _loopringAddress,
         address payable _operator,
-        bool    _onchainDataAvailability
+        bool    _onchainDataAvailability,
+        bytes32 _genesisBlockHash
         )
         public
     {
         require(0 != _id, "INVALID_ID");
         require(address(0) != _loopringAddress, "ZERO_ADDRESS");
         require(address(0) != _operator, "ZERO_ADDRESS");
-
+        require(_genesisBlockHash != 0, "ZERO_GENESIS_BLOCK_HASH");
         require(S.id == 0, "INITIALIZED_ALREADY");
 
         S.id = _id;
@@ -59,9 +60,8 @@ library ExchangeGenesis
         S.blockVerifier = IBlockVerifier(loopring.blockVerifierAddress());
         S.lrcAddress = loopring.lrcAddress();
 
-
         ExchangeData.Block memory genesisBlock = ExchangeData.Block(
-            ExchangeData.GENESIS_MERKLE_ROOT(),
+            _genesisBlockHash,
             0x0,
             ExchangeData.BlockState.VERIFIED,
             ExchangeData.BlockType(0),

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -236,27 +236,28 @@ export class ExchangeTestUtil {
       new BN(web3.utils.toWei("0.001", "ether"))
     );
 
+    this.GENESIS_MERKLE_ROOT = new BN(await this.exchange.genesisBlockHash());
+
     const constants = await this.exchangeData.getConstants();
-    this.GENESIS_MERKLE_ROOT = new BN(constants[0]);
-    this.SNARK_SCALAR_FIELD = new BN(constants[1]);
-    this.MAX_PROOF_GENERATION_TIME_IN_SECONDS = constants[2].toNumber();
-    this.MAX_GAP_BETWEEN_FINALIZED_AND_VERIFIED_BLOCKS = constants[3].toNumber();
-    this.MAX_OPEN_DEPOSIT_REQUESTS = constants[4].toNumber();
-    this.MAX_OPEN_WITHDRAWAL_REQUESTS = constants[5].toNumber();
-    this.MAX_AGE_UNFINALIZED_BLOCK_UNTIL_WITHDRAW_MODE = constants[6].toNumber();
-    this.MAX_AGE_REQUEST_UNTIL_FORCED = constants[7].toNumber();
-    this.MAX_AGE_REQUEST_UNTIL_WITHDRAW_MODE = constants[8].toNumber();
-    this.MAX_TIME_IN_SHUTDOWN_BASE = constants[9].toNumber();
-    this.MAX_TIME_IN_SHUTDOWN_DELTA = constants[10].toNumber();
-    this.TIMESTAMP_HALF_WINDOW_SIZE_IN_SECONDS = constants[11].toNumber();
-    this.MAX_NUM_TOKENS = constants[12].toNumber();
-    this.MAX_NUM_ACCOUNTS = constants[13].toNumber();
-    this.MAX_TIME_TO_DISTRIBUTE_WITHDRAWALS = constants[14].toNumber();
-    this.FEE_BLOCK_FINE_START_TIME = constants[15].toNumber();
-    this.FEE_BLOCK_FINE_MAX_DURATION = constants[16].toNumber();
-    this.MIN_GAS_TO_DISTRIBUTE_WITHDRAWALS = constants[17].toNumber();
-    this.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED = constants[18].toNumber();
-    this.GAS_LIMIT_SEND_TOKENS = constants[19].toNumber();
+    this.SNARK_SCALAR_FIELD = new BN(constants[0]);
+    this.MAX_PROOF_GENERATION_TIME_IN_SECONDS = constants[1].toNumber();
+    this.MAX_GAP_BETWEEN_FINALIZED_AND_VERIFIED_BLOCKS = constants[2].toNumber();
+    this.MAX_OPEN_DEPOSIT_REQUESTS = constants[3].toNumber();
+    this.MAX_OPEN_WITHDRAWAL_REQUESTS = constants[4].toNumber();
+    this.MAX_AGE_UNFINALIZED_BLOCK_UNTIL_WITHDRAW_MODE = constants[5].toNumber();
+    this.MAX_AGE_REQUEST_UNTIL_FORCED = constants[6].toNumber();
+    this.MAX_AGE_REQUEST_UNTIL_WITHDRAW_MODE = constants[7].toNumber();
+    this.MAX_TIME_IN_SHUTDOWN_BASE = constants[8].toNumber();
+    this.MAX_TIME_IN_SHUTDOWN_DELTA = constants[9].toNumber();
+    this.TIMESTAMP_HALF_WINDOW_SIZE_IN_SECONDS = constants[10].toNumber();
+    this.MAX_NUM_TOKENS = constants[11].toNumber();
+    this.MAX_NUM_ACCOUNTS = constants[12].toNumber();
+    this.MAX_TIME_TO_DISTRIBUTE_WITHDRAWALS = constants[13].toNumber();
+    this.FEE_BLOCK_FINE_START_TIME = constants[14].toNumber();
+    this.FEE_BLOCK_FINE_MAX_DURATION = constants[15].toNumber();
+    this.MIN_GAS_TO_DISTRIBUTE_WITHDRAWALS = constants[16].toNumber();
+    this.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED = constants[17].toNumber();
+    this.GAS_LIMIT_SEND_TOKENS = constants[18].toNumber();
   }
 
   public async setupTestState(exchangeID: number) {


### PR DESCRIPTION
Moving the genesis block value to ExchangeV3 will enable us to reuse ExchangeData for exchanges with different tree height/depth configurations.