### PR TITLE
[Protocol3] Added check for new Merkle root value

### DIFF
--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -260,7 +260,6 @@ library ExchangeBlocks
             merkleRootAfter := mload(add(data, 68))
         }
         require(merkleRootBefore == prevBlock.merkleRoot, "INVALID_MERKLE_ROOT");
-        require(uint256(merkleRootBefore) < ExchangeData.SNARK_SCALAR_FIELD(), "INVALID_MERKLE_ROOT");
         require(uint256(merkleRootAfter) < ExchangeData.SNARK_SCALAR_FIELD(), "INVALID_MERKLE_ROOT");
 
         uint32 numDepositRequestsCommitted = uint32(prevBlock.numDepositRequestsCommitted);

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -260,6 +260,8 @@ library ExchangeBlocks
             merkleRootAfter := mload(add(data, 68))
         }
         require(merkleRootBefore == prevBlock.merkleRoot, "INVALID_MERKLE_ROOT");
+        require(uint256(merkleRootBefore) < ExchangeData.SNARK_SCALAR_FIELD(), "INVALID_MERKLE_ROOT");
+        require(uint256(merkleRootAfter) < ExchangeData.SNARK_SCALAR_FIELD(), "INVALID_MERKLE_ROOT");
 
         uint32 numDepositRequestsCommitted = uint32(prevBlock.numDepositRequestsCommitted);
         uint32 numWithdrawalRequestsCommitted = uint32(prevBlock.numWithdrawalRequestsCommitted);


### PR DESCRIPTION
A safety check I forgot to add for the input aliasing exploit.

This one could actually be dangerous if the value >= SNARK_FIELD gets stored onchain. In withdrawal mode we compare the computed value against the value stored on-chain.