### PR TITLE
[Protocol-2] Changes tokenB fee behavior, fixes issue with Ring Mined events, makes broker transfers more efficient

### DIFF
--- a/packages/loopring_v2/contracts/helper/OrderHelper.sol
+++ b/packages/loopring_v2/contracts/helper/OrderHelper.sol
@@ -278,6 +278,7 @@ library OrderHelper {
                 order.hash,
                 order.sig
             );
+            require(order.valid, 'INVALID_SIGNATURE');
         }
     }
 
@@ -294,6 +295,7 @@ library OrderHelper {
                 miningHash,
                 order.dualAuthSig
             );
+            require(order.valid, 'INVALID_DUAL_AUTH_SIGNATURE');
         }
     }
 
@@ -307,6 +309,10 @@ library OrderHelper {
         if(order.allOrNone) {
             order.valid = order.valid && (order.filledAmountS == order.amountS);
         }
+    }
+
+    function getBrokerHash(Data.Order memory order) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(order.broker, order.tokenS, order.tokenB, order.feeToken));
     }
 
     function getSpendableS(

--- a/packages/loopring_v2/contracts/helper/ParticipationHelper.sol
+++ b/packages/loopring_v2/contracts/helper/ParticipationHelper.sol
@@ -42,7 +42,7 @@ library ParticipationHelper {
             // No need to check the fee balance of the owner if feeToken == tokenB,
             // fillAmountB will be used to pay the fee.
             if (!(p.order.feeToken == p.order.tokenB &&
-                  p.order.owner == p.order.tokenRecipient &&
+                  // p.order.owner == p.order.tokenRecipient &&
                   p.order.feeAmount <= p.order.amountB)) {
                 // Check how much fee needs to be paid. We limit fillAmountS to how much
                 // fee the order owner can pay.
@@ -98,7 +98,7 @@ library ParticipationHelper {
             // If feeToken == tokenB AND owner == tokenRecipient, try to pay using fillAmountB
 
             if (p.order.feeToken == p.order.tokenB &&
-                p.order.owner == p.order.tokenRecipient &&
+                // p.order.owner == p.order.tokenRecipient &&
                 p.fillAmountB >= p.feeAmount) {
                 p.feeAmountB = p.feeAmount;
                 p.feeAmount = 0;

--- a/packages/loopring_v2/contracts/helper/RingHelper.sol
+++ b/packages/loopring_v2/contracts/helper/RingHelper.sol
@@ -395,35 +395,29 @@ library RingHelper {
             addBrokerTokenTransfer(
                 ctx,
                 p.order.feeToken,
-                p.order.owner,
-                p.order.broker,
                 address(ctx.feeHolder),
                 amountFeeToFeeHolder,
+                p.order,
                 true,
-                0,
-                p.orderIndex
+                0
             );
             addBrokerTokenTransfer(
                 ctx,
                 p.order.tokenS,
-                p.order.owner,
-                p.order.broker,
                 address(ctx.feeHolder),
                 amountSToFeeHolder,
+                p.order,
                 true,
-                0,
-                p.orderIndex
+                0
             );
             addBrokerTokenTransfer(
                 ctx,
                 p.order.tokenS,
-                p.order.owner,
-                p.order.broker,
                 prevP.order.tokenRecipient,
                 amountSToBuyer,
+                p.order,
                 false,
-                amountBFromSeller,
-                p.orderIndex
+                amountBFromSeller
             );
         }
         
@@ -443,27 +437,23 @@ library RingHelper {
     function addBrokerTokenTransfer(
         Data.Context memory ctx,
         address token, 
-        address owner, 
-        address broker,
         address to,
         uint amount,
+        Data.Order memory order,
         bool isForFee,
-        uint receivedAmount,
-        uint orderIndex
+        uint receivedAmount
         )
         internal
         pure
     {
         if (amount > 0) {
             ctx.brokerTransfers[ctx.numBrokerTransfers] = Data.BrokerTransfer(
-                orderIndex,
-                owner,
-                broker,
-                isForFee,
-                receivedAmount,
                 token,
                 to,
-                amount);
+                amount,
+                order,
+                isForFee,
+                receivedAmount);
             ctx.numBrokerTransfers++;
         }
     }

--- a/packages/loopring_v2/contracts/iface/IBrokerDelegate.sol
+++ b/packages/loopring_v2/contracts/iface/IBrokerDelegate.sol
@@ -14,7 +14,11 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
+
 pragma solidity 0.5.7;
+pragma experimental ABIEncoderV2;
+
+import { Data } from "../impl/Data.sol";
 
 /**
  * @title IBrokerDelegate
@@ -23,39 +27,12 @@ pragma solidity 0.5.7;
 interface IBrokerDelegate {
 
   /*
-   * Set the allowance on the given token for the specified amount, assuming the 
-   * balance attributed to the owner is sufficient.
-   *
-   * This gets called individually for each transfer required of the broker.
-   * Loopring's RingSubmitter calls this and then performs a transfer on the
-   * broker's token balance. If the tokens for the given owner address are
-   * held in a different contract, they must be moved into the broker's possesion
-   * in the execution of this function. A transfer will not occur if the requestedRecipient
-   * is equal to this broker address, you must handle this case internally if applicable.
-   * Furthermore, it is highly encouraged that one requires that the msg.sender is the
-   * Loopring RingSubmitter contract to ensure the security of funds held in this contract.
-   *
-   * owner - the owner of the order who's attributed funds are being requested
-   * receivedToken - The token that was received (tokenB)
-   * receivedAmount - The amount of the token that was received (amountB)
-   * orderTokenRecipient - the tokenRecipient of the order (this is who received the receivedAmount)
-   * requestedToken - The token who's approval is being requested (tokenS/feeToken)
-   * requestedAmount - The requested amount to be transferred
-   * requestedRecipient - The recipient of the requested funds
-   * extraOrderData - The transferDataS field of the order
-   * isFee - if this is for a fee. If this is true, receivedToken & receivedAmount will be 0 and 0x0
+   * Loopring requests an allowance be set on a given token for a specified amount. Order details
+   * are provided (tokenS, totalAmountS, tokenB, totalAmountB, orderTokenRecipient, extraOrderData)
+   * to aid in any calculations or on-chain exchange of assets that may be required. The last 4
+   * parameters concern the actual token approval being requested of the broker.
    */
-  function brokerRequestAllowance(
-    address owner, 
-    address receivedToken,
-    uint receivedAmount,
-    address orderTokenRecipient,
-    address requestedToken, 
-    uint requestedAmount, 
-    address requestedRecipient,
-    bytes calldata extraOrderData,
-    bool isFee
-  ) external;
+  function brokerRequestAllowance(Data.BrokerApprovalRequest calldata request) external;
 
   /*
    * Get the available token balance controlled by the broker on behalf of an address (owner)

--- a/packages/loopring_v2/contracts/impl/Data.sol
+++ b/packages/loopring_v2/contracts/impl/Data.sol
@@ -36,13 +36,43 @@ library Data {
         uint numSpendables;
     }
 
+    struct BrokerAction {
+        bytes32 hash;
+        address broker;
+        uint[] orderIndices;
+        uint numOrders;
+        uint[] transferIndices;
+        uint numTransfers;
+        address tokenS;
+        address tokenB;
+        address feeToken;
+    }
+
     struct BrokerTransfer {
+        bytes32 hash;
         address token;
-        address recipient;
         uint amount;
-        Order order;
-        bool isFee;
-        uint receivedAmount;
+        address recipient;
+    }
+
+    struct BrokerOrder {
+        address owner;
+        bytes32 orderHash;
+        uint fillAmountB;
+        uint requestedAmountS;
+        uint requestedFeeAmount;
+        address tokenRecipient;
+        bytes extraData;
+    }
+
+    struct BrokerApprovalRequest {
+        BrokerOrder[] orders;
+        address tokenS;
+        address tokenB;
+        address feeToken;
+        uint totalFillAmountB;
+        uint totalRequestedAmountS;
+        uint totalRequestedFeeAmount;
     }
 
     struct Context {
@@ -61,7 +91,11 @@ library Data {
         uint feePtr;
         uint transferData;
         uint transferPtr;
+        BrokerOrder[] brokerOrders;
+        BrokerAction[] brokerActions;
         BrokerTransfer[] brokerTransfers;
+        uint numBrokerOrders;
+        uint numBrokerActions;
         uint numBrokerTransfers;
     }
 
@@ -148,7 +182,7 @@ library Data {
         uint fillAmountB;
     }
 
-    struct Ring{
+    struct Ring {
         uint size;
         Participation[] participations;
         bytes32 hash;

--- a/packages/loopring_v2/contracts/impl/Data.sol
+++ b/packages/loopring_v2/contracts/impl/Data.sol
@@ -37,14 +37,12 @@ library Data {
     }
 
     struct BrokerTransfer {
-        uint orderIndex;
-        address owner;
-        address broker;
-        bool isFee;
-        uint receivedAmount;
         address token;
         address recipient;
         uint amount;
+        Order order;
+        bool isFee;
+        uint receivedAmount;
     }
 
     struct Context {
@@ -137,7 +135,6 @@ library Data {
     struct Participation {
         // required fields
         Order order;
-        uint orderIndex;
 
         // computed fields
         uint splitS;

--- a/packages/loopring_v2/contracts/impl/ExchangeDeserializer.sol
+++ b/packages/loopring_v2/contracts/impl/ExchangeDeserializer.sol
@@ -411,7 +411,7 @@ library ExchangeDeserializer {
     {
         uint ringsArrayDataSize = (1 + numRings) * 32;
         uint ringStructSize = 5 * 32;
-        uint participationStructSize = 11 * 32;
+        uint participationStructSize = 10 * 32;
 
         assembly {
             // Allocate memory for all rings
@@ -470,19 +470,16 @@ library ExchangeDeserializer {
                         mload(add(orders, mul(add(orderIndex, 1), 32)))
                     )
 
-                    // participation.orderIndex
-                    mstore(add(participation,  32), orderIndex) 
-
                     // Set default values
-                    mstore(add(participation,  64), 0)          // participation.splitS
-                    mstore(add(participation,  96), 0)          // participation.feeAmount
-                    mstore(add(participation, 128), 0)          // participation.feeAmountS
-                    mstore(add(participation, 160), 0)          // participation.feeAmountB
-                    mstore(add(participation, 192), 0)          // participation.rebateFee
-                    mstore(add(participation, 224), 0)          // participation.rebateS
-                    mstore(add(participation, 256), 0)          // participation.rebateB
-                    mstore(add(participation, 288), 0)          // participation.fillAmountS
-                    mstore(add(participation, 320), 0)          // participation.fillAmountB
+                    mstore(add(participation,  32), 0)          // participation.splitS
+                    mstore(add(participation,  64), 0)          // participation.feeAmount
+                    mstore(add(participation,  96), 0)          // participation.feeAmountS
+                    mstore(add(participation, 128), 0)          // participation.feeAmountB
+                    mstore(add(participation, 160), 0)          // participation.rebateFee
+                    mstore(add(participation, 192), 0)          // participation.rebateS
+                    mstore(add(participation, 224), 0)          // participation.rebateB
+                    mstore(add(participation, 256), 0)          // participation.fillAmountS
+                    mstore(add(participation, 288), 0)          // participation.fillAmountB
                 }
 
                 // Advance to the next ring

--- a/packages/loopring_v2/contracts/impl/RingSubmitter.sol
+++ b/packages/loopring_v2/contracts/impl/RingSubmitter.sol
@@ -547,26 +547,25 @@ contract RingSubmitter is IRingSubmitter, NoDefaultFunc {
     function batchBrokerTransferTokens(Data.Context memory ctx, Data.Order[] memory orders) internal {
         for (uint i = 0; i < ctx.numBrokerTransfers; i++) {
             Data.BrokerTransfer memory transfer = ctx.brokerTransfers[i];
-            Data.Order memory order = orders[transfer.orderIndex];
           
-            IBrokerDelegate(transfer.broker).brokerRequestAllowance(
-                transfer.owner,
-                order.tokenB,
+            IBrokerDelegate(transfer.order.broker).brokerRequestAllowance(
+                transfer.order.owner,
+                transfer.order.tokenB,
                 transfer.receivedAmount,
-                order.tokenRecipient,
+                transfer.order.tokenRecipient,
                 transfer.token,
                 transfer.amount,
                 transfer.recipient,
-                order.transferDataS,
+                transfer.order.transferDataS,
                 transfer.isFee
             );
 
             // If the recipient is the broker, do not transfer the tokens
             // The broker should check for this and internally handle it
             // if applicable
-            if (transfer.recipient != transfer.broker) {
+            if (transfer.recipient != transfer.order.broker) {
                 require(transfer.token.safeTransferFrom(
-                    transfer.broker, 
+                    transfer.order.broker, 
                     transfer.recipient, 
                     transfer.amount
                 ), TRANSFER_FAILURE);

--- a/packages/loopring_v2/contracts/test/DeserializerTest.sol
+++ b/packages/loopring_v2/contracts/test/DeserializerTest.sol
@@ -141,7 +141,6 @@ contract DeserializerTest {
             0,
             0,
             0,
-            0,
             0
         );
     }

--- a/packages/loopring_v2/contracts/test/DummyBrokerDelegate.sol
+++ b/packages/loopring_v2/contracts/test/DummyBrokerDelegate.sol
@@ -14,26 +14,22 @@
  * limitations under the License.
  */
 pragma solidity 0.5.7;
+pragma experimental ABIEncoderV2;
 
 import { IBrokerDelegate } from "../iface/IBrokerDelegate.sol";
+import { Data } from "../impl/Data.sol";
 import { ERC20 } from "../lib/ERC20.sol"; 
 
 contract DummyBrokerDelegate is IBrokerDelegate {
 
-  function brokerRequestAllowance(
-    address owner, 
-    address receivedToken,
-    uint receivedAmount,
-    address orderTokenRecipient,
-    address requestedToken, 
-    uint requestedAmount, 
-    address requestedRecipient,
-    bytes memory extraOrderData,
-    bool isFee
-  ) public {
-    address payable payableTokenAddress = address(uint160(requestedToken));
-    ERC20 token = ERC20(payableTokenAddress);
-    token.approve(msg.sender, requestedAmount);
+  function brokerRequestAllowance(Data.BrokerApprovalRequest memory request) public {
+    ERC20 tokenS = ERC20(request.tokenS);
+    tokenS.approve(msg.sender, request.totalRequestedAmountS);
+
+    if (request.totalRequestedFeeAmount > 0) {
+      ERC20 feeToken = ERC20(request.feeToken);
+      feeToken.approve(msg.sender, request.totalRequestedFeeAmount);
+    }
   }
 
   function brokerBalanceOf(address owner, address tokenAddress) public view returns (uint) {

--- a/packages/loopring_v2/contracts/test/DummyToken.sol
+++ b/packages/loopring_v2/contracts/test/DummyToken.sol
@@ -51,6 +51,7 @@ contract DummyToken is LRCToken {
             totalSupply_ = totalSupply_.add(_value.sub(currBalance));
         }
         balances[_target] = _value;
+        emit Transfer(address(0x0), _target, _value);
     }
 
     function addBalance(
@@ -63,6 +64,7 @@ contract DummyToken is LRCToken {
         require(_value + currBalance >= currBalance, "INVALID_VALUE");
         totalSupply_ = totalSupply_.add(_value);
         balances[_target] = currBalance.add(_value);
+        emit Transfer(address(0x0), _target, _value);
     }
 
 }

--- a/packages/loopring_v2/contracts/test/tokens/GTO.sol
+++ b/packages/loopring_v2/contracts/test/tokens/GTO.sol
@@ -21,9 +21,9 @@ import "../DummyToken.sol";
 contract GTO is DummyToken {
 
     constructor() DummyToken(
-        "GTO_TEST",
-        "GTO",
-        18,
+        "WBTC_TEST",
+        "WBTC",
+        8,
         10 ** 27
     ) public
     {


### PR DESCRIPTION
* Previously if the `owner` != `tokenRecipient` and `feeToken` == `tokenB`, the fee would not be taken out of the received tokens and instead the owner would need to hold the tokens in their balance. This is being changed to follow the normal behavior even of the tokenRecipient is not the order owner

* In the last set of changes the Participation struct was modified and was being encoded improperly  when inline assembly constructed the Ring Mined event. The Participation struct is now being left untouched and a different method of getting information to the RingSubmitter for broker transfers has been implemented