### PR TITLE
[Lightcone_v2.js] Fix missing 'to' when using Transaction in create account method

### DIFF
--- a/packages/lightcone_v2.js/src/sign/exchange.ts
+++ b/packages/lightcone_v2.js/src/sign/exchange.ts
@@ -112,6 +112,7 @@ export class Exchange {
 
       const nonce = await ethereum.wallet.getNonce(this.getAddress());
       return new Transaction({
+        to: this.exchangeAddr,
         value: fm.toHex(this.dexConfigurations["deposit_fee_eth"]),
         data: data,
         chainId: config.getChainId(),


### PR DESCRIPTION
![Screen Shot 2019-09-02 at 8 36 39 PM](https://user-images.githubusercontent.com/18495858/64142628-ab6de900-cdc1-11e9-8b36-a69a90383323.png)
