### PR TITLE
[protocol3] Reduce gas cost by 20.000 gas

### DIFF
--- a/packages/loopring_v3/contracts/impl/UserStakingPool.sol
+++ b/packages/loopring_v3/contracts/impl/UserStakingPool.sol
@@ -34,10 +34,10 @@ contract UserStakingPool is Claimable, ReentrancyGuard, IUserStakingPool
     using MathUint          for uint;
 
     struct Staking {
-        uint    balance;        // Total amount of LRC staked or rewarded
-        uint    depositedAt;
-        uint    claimedAt;      // timestamp from which more points will be accumulated
-        uint    claimedReward;  // Total amount of LRC claimed as reward.
+        uint256    balance;        // Total amount of LRC staked or rewarded
+        uint64     depositedAt;
+        uint64     claimedAt;      // timestamp from which more points will be accumulated
+        uint256    claimedReward;  // Total amount of LRC claimed as reward.
     }
 
     Staking private total;

--- a/packages/loopring_v3/contracts/impl/UserStakingPool.sol
+++ b/packages/loopring_v3/contracts/impl/UserStakingPool.sol
@@ -34,10 +34,10 @@ contract UserStakingPool is Claimable, ReentrancyGuard, IUserStakingPool
     using MathUint          for uint;
 
     struct Staking {
-        uint256    balance;        // Total amount of LRC staked or rewarded
-        uint64     depositedAt;
-        uint64     claimedAt;      // timestamp from which more points will be accumulated
-        uint256    claimedReward;  // Total amount of LRC claimed as reward.
+        uint   balance;        // Total amount of LRC staked or rewarded
+        uint64 depositedAt;
+        uint64 claimedAt;      // timestamp from which more points will be accumulated
+        uint   claimedReward;  // Total amount of LRC claimed as reward.
     }
 
     Staking private total;


### PR DESCRIPTION
Unix timestamps can be no bigger than ~uint40, using uint64 for the timestamps reduces gas cost for every store of the Staking struct by 20.000 gas.