### PR TITLE
Save gas cost in universal registry

### DIFF
--- a/packages/loopring_v3/contracts/impl/UniversalRegistry.sol
+++ b/packages/loopring_v3/contracts/impl/UniversalRegistry.sol
@@ -34,10 +34,10 @@ contract UniversalRegistry is IUniversalRegistry {
     struct Protocol
     {
         address protocol;
-        address manager;
-        string  version;
         bool    registered;
         bool    enabled;
+        address manager;
+        string  version;
     }
 
     // IExchange addresses => IProtocol addresses


### PR DESCRIPTION
Address are 20 bytes, we can save the two bools within the protocol address and we can save 20.000 gas if the version string is less than 12 bytes long. I would also consider making the version a number (uint96)