### PR TITLE
[Protocol3] WIP:  Generic Extension for Request Validation (GERV)  to enable features such as Fast withdrawals

### DIFF
--- a/packages/loopring_v3/contracts/iface/ICookieJarContract.sol
+++ b/packages/loopring_v3/contracts/iface/ICookieJarContract.sol
@@ -1,0 +1,34 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+
+/// @title ICookieJarContract
+/// @author Brecht Devos - <brecht@loopring.org>
+contract ICookieJarContract
+{
+    /// @dev Transfers funds out of the contract to a specified address
+    /// @param to The recipient of the funds
+    /// @param token The token address (0x0 for ETH)
+    /// @param amount The number of tokens transferred to the recipient
+    function transfer(
+        address to,
+        address token,
+        uint    amount
+        )
+        external;
+}

--- a/packages/loopring_v3/contracts/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/impl/ExchangeV3.sol
@@ -604,6 +604,8 @@ contract ExchangeV3 is IExchangeV3
         key |= feeTokenID;
         key <<= 16;
         key |= fFee;
+        key <<= 8;
+        key |= 1;
         key <<= 32;
         key |= salt;
 

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -445,9 +445,9 @@ library ExchangeBlocks
         // Run over all conditional transfers
         uint numBytesPerTransfer = 13;
         for (uint i = 0; i < auxiliaryData.length; i += 6) {
-            // auxiliaryData contains:
+            // auxiliaryData contains for each conditional transfer:
             // - Transfer index: 2 bytes (the position of the conditional transfer inside data)
-            // - Salt: The salt of the transfer
+            // - Salt: 4 bytes (the salt of the transfer)
             uint index;
             uint salt;
             assembly {
@@ -459,6 +459,9 @@ library ExchangeBlocks
             assembly {
                 transferData := and(mload(add(data, offset)), 0xFFFFFFFFFFFFFFFFFFFFFFFFFF)
             }
+
+            // Check that this is a conditional transfer
+            require((transferData & 0xFF) == 1, "INVALID_AUXILIARYDATA");
 
             // The key of the transfer is the combination of the transfer DA data and the salt
             uint key = (transferData << 32) | salt;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeData.sol
@@ -119,6 +119,9 @@ library ExchangeData
         // The time the block was created.
         uint32 timestamp;
 
+        // The Ethereum block the block was created in.
+        uint32 ethereumBlockNumber;
+
         // The number of onchain deposit requests that have been processed
         // up to and including this block.
         uint32 numDepositRequestsCommitted;
@@ -163,6 +166,18 @@ library ExchangeData
         uint96 amount;
     }
 
+    // The state of a conditional transfer
+    struct ConditionalTransferState
+    {
+        // True if the conditional transfer can be included in a block
+        bool    approved;
+
+        // The blockIdx and the Ethereum block number when this conditional transfer was processed
+        // (the Ethereum block number is used to detect if the block was reverted)
+        uint32  blockIdx;
+        uint32  ethereumBlockNumber;
+    }
+
     function SNARK_SCALAR_FIELD() internal pure returns (uint) {
         // This is the prime number that is used for the alt_bn128 elliptic curve, see EIP-196.
         return 21888242871839275222246405745257275088548364400416034343698204186575808495617;
@@ -186,6 +201,7 @@ library ExchangeData
     function MIN_GAS_TO_DISTRIBUTE_WITHDRAWALS() internal pure returns (uint32) { return 60000; }
     function MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED() internal pure returns (uint32) { return 1 days; }
     function GAS_LIMIT_SEND_TOKENS() internal pure returns (uint32) { return 30000; }
+    function MAX_TOTAL_TOKEN_BALANCE() internal pure returns (uint) { return 2 ** 96 - 1; }
 
     // Represents the entire exchange state except the owner of the exchange.
     struct State
@@ -197,6 +213,7 @@ library ExchangeData
 
         ILoopringV3    loopring;
         IBlockVerifier blockVerifier;
+        address        relayer;
 
         address lrcAddress;
 
@@ -226,6 +243,9 @@ library ExchangeData
 
         // A map from token address to their accumulated balances
         mapping (address => uint) tokenBalances;
+
+        // A map from the conditional transfer key to the ConditionalTransferState
+        mapping (uint => ConditionalTransferState) conditionalTransfers;
 
         // A block's state will become FINALIZED when and only when this block is VERIFIED
         // and all previous blocks in the chain have become FINALIZED.

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
@@ -68,6 +68,7 @@ library ExchangeGenesis
             0,
             0,
             uint32(now),
+            uint32(block.number),
             1,
             1,
             true,

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeMode.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeMode.sol
@@ -30,6 +30,17 @@ library ExchangeMode
 {
     using MathUint  for uint;
 
+    function isAuthorized(
+        ExchangeData.State storage S,
+        address accountOwner
+        )
+        internal // inline call
+        view
+        returns (bool)
+    {
+        return msg.sender == accountOwner || msg.sender == S.relayer;
+    }
+
     function isInWithdrawalMode(
         ExchangeData.State storage S
         )

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeWithdrawals.sol
@@ -279,7 +279,7 @@ library ExchangeWithdrawals
         // Extract the withdrawal data
         uint16 tokenID = uint16((data >> 48) & 0xFF);
         uint24 accountID = uint24((data >> 28) & 0xFFFFF);
-        uint amount = (data & 0xFFFFFFF).decodeFloat();
+        uint amount = (data & 0xFFFFFFF).decodeFloat(28);
 
         // Transfer the tokens
         success = transferTokens(

--- a/packages/loopring_v3/contracts/impl/relayer/FastWithdrawal.sol
+++ b/packages/loopring_v3/contracts/impl/relayer/FastWithdrawal.sol
@@ -25,6 +25,8 @@ import "../../lib/MathUint.sol";
 import "../../thirdparty/ECDSA.sol";
 
 /// @title An Implementation of IRelayer.
+/// @dev FastWithdrawal needs to extend RelayerData to make sure the data layout matches
+///      with that layout in the Relayer contract.
 /// @author Brecht Devos - <brecht@loopring.org>
 contract FastWithdrawal is RelayerData
 {

--- a/packages/loopring_v3/contracts/impl/relayer/FastWithdrawal.sol
+++ b/packages/loopring_v3/contracts/impl/relayer/FastWithdrawal.sol
@@ -1,0 +1,92 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./RelayerData.sol";
+
+import "../../iface/IExchangeV3.sol";
+import "../../iface/ICookieJarContract.sol";
+
+import "../../lib/MathUint.sol";
+import "../../thirdparty/ECDSA.sol";
+
+/// @title An Implementation of IRelayer.
+/// @author Brecht Devos - <brecht@loopring.org>
+contract FastWithdrawal is RelayerData
+{
+    using ECDSA             for bytes32;
+    using MathUint          for uint;
+
+    function executeFastWithdrawal(
+        address cookieJarContractAddress,
+        address exchangeAddress,
+        address destinationAddress,
+        address from,
+        address to,
+        address token,
+        uint24  fAmount,
+        address feeToken,
+        uint16  fFee,
+        bool    onchainFeePayment,
+        uint32  salt,
+        bytes   calldata signature
+        )
+        external
+    {
+        // Check the signature
+        bytes32 hash = keccak256(
+            abi.encodePacked(
+                cookieJarContractAddress,
+                exchangeAddress,
+                destinationAddress,
+                from,
+                to,
+                token,
+                uint(fAmount).decodeFloat(24),
+                feeToken,
+                uint(fFee).decodeFloat(16),
+                onchainFeePayment,
+                salt
+            )
+        );
+        require(hash.toEthSignedMessageHash().recover(signature) == from, "UNAUTHORIZED");
+
+        // Transfer the tokens directly to the destination address
+        ICookieJarContract(cookieJarContractAddress).transfer(destinationAddress, token, uint(fAmount).decodeFloat(24));
+
+        // Do fee payment directly from the user's wallet if requested
+        if (onchainFeePayment) {
+            IExchangeV3(exchangeAddress).onchainTransferFrom(
+                from,
+                to,
+                feeToken,
+                uint(fFee).decodeFloat(16)
+            );
+        }
+
+        // Approve the conditional transfer
+        IExchangeV3(exchangeAddress).approveConditionalTransfer(
+            from,
+            to,
+            token,
+            fAmount,
+            feeToken,
+            onchainFeePayment ? 0 : fFee,
+            salt
+        );
+    }
+}

--- a/packages/loopring_v3/contracts/impl/relayer/Relayer.sol
+++ b/packages/loopring_v3/contracts/impl/relayer/Relayer.sol
@@ -1,0 +1,50 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./RelayerData.sol";
+
+import "../../lib/Claimable.sol";
+import "../../lib/ReentrancyGuard.sol";
+
+
+/// @title An Implementation of IRelayer.
+/// @author Brecht Devos - <brecht@loopring.org>
+contract Relayer is Claimable, ReentrancyGuard, RelayerData
+{
+    function executeTransaction(
+        address module,
+        bytes memory transaction
+        )
+        public
+        nonReentrant
+    {
+        require(modules[module], "UNAUTHORIZED_MODULE");
+        (bool success, ) = module.delegatecall(transaction);
+        require(success, "MODULE_DELEGATECALL_FAILED");
+    }
+
+    function setAuthorized(
+        address module,
+        bool authorized
+        )
+        external
+        onlyOwner
+    {
+        modules[module] = authorized;
+    }
+}

--- a/packages/loopring_v3/contracts/impl/relayer/RelayerData.sol
+++ b/packages/loopring_v3/contracts/impl/relayer/RelayerData.sol
@@ -1,0 +1,25 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+
+/// @title Relayer data shared accross modules.
+/// @author Brecht Devos - <brecht@loopring.org>
+contract RelayerData
+{
+    mapping (address => bool) public modules;
+}

--- a/packages/loopring_v3/contracts/lib/MathUint.sol
+++ b/packages/loopring_v3/contracts/lib/MathUint.sol
@@ -58,15 +58,17 @@ library MathUint
     }
 
     function decodeFloat(
-        uint f
+        uint f,
+        uint numBits
         )
         internal
         pure
         returns (uint value)
     {
-        uint numBitsMantissa = 23;
+        uint numBitsMantissa = numBits - 5;
         uint exponent = f >> numBitsMantissa;
         uint mantissa = f & ((1 << numBitsMantissa) - 1);
         value = mantissa * (10 ** exponent);
+        require(value < (2 ** 96), "FLOAT_VALUE_TOO_BIG");
     }
 }

--- a/packages/loopring_v3/contracts/test/CookieJarContract.sol
+++ b/packages/loopring_v3/contracts/test/CookieJarContract.sol
@@ -1,0 +1,70 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "../iface/ICookieJarContract.sol";
+
+import "./AccountContract.sol";
+
+import "../lib/AddressUtil.sol";
+import "../lib/Claimable.sol";
+import "../lib/ERC20SafeTransfer.sol";
+
+
+contract CookieJarContract is AccountContract, Claimable, ICookieJarContract {
+
+    using AddressUtil       for address;
+    using ERC20SafeTransfer for address;
+
+    // List of addresses which can transfer funds out of this contract as tx.origin
+    mapping (address => bool) authorizedAddresses;
+
+    function transfer(
+        address to,
+        address token,
+        uint    amount
+        )
+        external
+    {
+        // Only allow an authorized transaction origin to transfer tokens out
+        /* solium-disable-next-line */
+        require(authorizedAddresses[tx.origin], "UNAUTHORIZED");
+
+        // Transfer
+        bool success;
+        if (amount > 0) {
+            if (token == address(0)) {
+                // ETH
+                success = to.sendETH(amount, gasleft());
+            } else {
+                // ERC20 token
+                success = token.safeTransfer(to, amount);
+            }
+        }
+        require(success, "TRANSFER_FAILED");
+    }
+
+    function setAuthorized(
+        address _address,
+        bool authorized
+        )
+        external
+        onlyOwner
+    {
+        authorizedAddresses[_address] = authorized;
+    }
+}

--- a/packages/loopring_v3/contracts/test/Operator.sol
+++ b/packages/loopring_v3/contracts/test/Operator.sol
@@ -36,11 +36,12 @@ contract Operator {
         uint16 blockSize,
         uint8  blockVersion,
         bytes calldata data,
+        bytes calldata auxiliaryData,
         bytes calldata offchainData
         )
         external
     {
-        exchange.commitBlock(blockType, blockSize, blockVersion, data, offchainData);
+        exchange.commitBlock(blockType, blockSize, blockVersion, data, auxiliaryData, offchainData);
     }
 
     function verifyBlocks(

--- a/packages/loopring_v3/contracts/thirdparty/ECDSA.sol
+++ b/packages/loopring_v3/contracts/thirdparty/ECDSA.sol
@@ -1,0 +1,84 @@
+// This code is taken from https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol
+
+pragma solidity ^0.5.11;
+
+/**
+ * @dev Elliptic Curve Digital Signature Algorithm (ECDSA) operations.
+ *
+ * These functions can be used to verify that a message was signed by the holder
+ * of the private keys of a given address.
+ */
+library ECDSA {
+    /**
+     * @dev Returns the address that signed a hashed message (`hash`) with
+     * `signature`. This address can then be used for verification purposes.
+     *
+     * The `ecrecover` EVM opcode allows for malleable (non-unique) signatures:
+     * this function rejects them by requiring the `s` value to be in the lower
+     * half order, and the `v` value to be either 27 or 28.
+     *
+     * NOTE: This call _does not revert_ if the signature is invalid, or
+     * if the signer is otherwise unable to be retrieved. In those scenarios,
+     * the zero address is returned.
+     *
+     * IMPORTANT: `hash` _must_ be the result of a hash operation for the
+     * verification to be secure: it is possible to craft signatures that
+     * recover to arbitrary addresses for non-hashed data. A safe way to ensure
+     * this is by receiving a hash of the original message (which may otherwise
+     * be too long), and then calling {toEthSignedMessageHash} on it.
+     */
+    function recover(bytes32 hash, bytes memory signature) internal pure returns (address) {
+        // Check the signature length
+        if (signature.length != 65) {
+            return (address(0));
+        }
+
+        // Divide the signature in r, s and v variables
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // ecrecover takes the signature parameters, and the only way to get them
+        // currently is to use assembly.
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            r := mload(add(signature, 0x20))
+            s := mload(add(signature, 0x40))
+            v := byte(0, mload(add(signature, 0x60)))
+        }
+
+        // EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+        // unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+        // the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+        // signatures from current libraries generate a unique signature with an s-value in the lower half order.
+        //
+        // If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+        // with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+        // vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+        // these malleable signatures as well.
+        if (uint256(s) > 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0) {
+            return address(0);
+        }
+
+        if (v != 27 && v != 28) {
+            return address(0);
+        }
+
+        // If the signature is valid (and not malleable), return the signer address
+        return ecrecover(hash, v, r, s);
+    }
+
+    /**
+     * @dev Returns an Ethereum Signed Message, created from a `hash`. This
+     * replicates the behavior of the
+     * https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_sign[`eth_sign`]
+     * JSON-RPC method.
+     *
+     * See {recover}.
+     */
+    function toEthSignedMessageHash(bytes32 hash) internal pure returns (bytes32) {
+        // 32 is the length in bytes of hash,
+        // enforced by the type signature above
+        return keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+    }
+}


### PR DESCRIPTION
Continuation of #318 with quite some changes.

Untested with many mistakes no doubt. Only here to show the high-level design.

The current design:
- Uses the internal token transfer circuit with no significant changes and practically no additional constraint cost. There is an additional cost gas cost for every conditional transfer included in a block, but no additional overhead for normal internal transfers.
- Complete freedom for when/in what order the conditional transfers are included in a block. There is no queue.
- Allows tokens tokens to be transferred to an account, while a fee can be paid using on-chain balances (could be any Ethereum address) or off-chain balances (always the operator).
- All data to include a conditional transfer in a block is on-chain, it does not depend on any off-chain signed data. It does not depend in any way on the nonce of the account stored in the Merkle tree.

To keep the circuits costs the same we use the data already available on-chain for data availability, with 1 additional byte/transfer that stores the transfer `type`. We have 2 types of transfers:
- Type 0: The transfer has a valid EdDSA signature. If this is the case this is a normal internal transfer.
- Type 1:  The transfer has no valid EdDSA signature. This is a conditional transfer and a block with a transfer like this can only be included when the transfer was approved on-chain. This is checked using the data availability data of the transfer (i.e. the result of the transfer, which is all that matters) and the salt value (only necessary so that multiple conditional transfers can be approved on-chain with the same data-availability data. For example a user may transfer 1ETH 10 times to the same address. Without the salt all these conditional transfers would be exactly the same which the smart contracts disallow (to prevent replay attacks). The salt is used to make the transfer unique, a timestamp can be used for example).

The internal transfer circuit only needs some very small changes:
- Add a `type` byte in the data-availability of the transfer.
- Instead of requiring the signature to be valid, the signature can be invalid. In that case the `type` byte is set to 1, if the signature is valid `type` it is set to 0.
- If `type == 1` we don't increment the nonce (this change is not necessary for the design, but makes the most sense)

That's it. For the no data-availability version we still need to send the data-availabiltiy data on-chain, but the data of the normal transfers can be zeroed out so save gas (and all conditional transfers could be done at the start of the block, so the data will end with only zeros which can easily be compressed away).

A mechanism with an EdDSA request/signature for fast withdrawals is also possible, but this method is more limited (nonces, no immediate authorization on-chain so we are limited in what we can do, no on-chain fee payments for example, ...) and is more expensive in the circuits (additional data for the condition hashes would need to be hashed with sha256, and because hashes are big this would be quite expensive). It could save some gas on-chain, but I think it's not worth it because of the reduced flexibility. Supporting both methods would increase the complexity and increase costs for both.

I think this design has a nice balance between complexity, flexibility, and cost. But I change my mind almost everyday on how to do this so any feedback welcome!

