### PR TITLE
Update bitarray hash algorithm to avoid short private key.

### DIFF
--- a/packages/lightcone_v2.js/src/lib/sign/bitarray.ts
+++ b/packages/lightcone_v2.js/src/lib/sign/bitarray.ts
@@ -1,4 +1,5 @@
 import BN = require("bn.js");
+import hash = require("hash.js");
 
 export class BitArray {
   private data: number[];
@@ -28,8 +29,10 @@ export class BitArray {
   }
 
   public static hashCode(s) {
-    for (var i = 0, h = 0; i < s.length; i++)
-      h = (Math.imul(31, h) + s.charCodeAt(i)) | 0;
-    return Math.abs(h);
+    var hashValue = hash
+      .sha256()
+      .update(s)
+      .digest();
+    return new BN(hashValue);
   }
 }


### PR DESCRIPTION
Our old private key seems too short.
Before:
keyPair: {
publicKeyX:"15030727036724168751212480282500540869268142725392913493575803542173309367534",
publicKeyY:"21709653362655094841217318150615954140561437115749994376567240539798473592233",
secretKey: "1268930117" #too short for private key
}

After:
{ publicKeyX:'8813841639841077546078089488867097267085213881825607563506983828135503562052',
publicKeyY:'20955895273353568600806208646961956684700918435341245662365898050978330578659',
secretKey:'1696716368835402715786292139526618358846458481981228831374151359817119808723' 
}

Use sha256 here may not fully comply with the wiki page, but key length strength should be enough.