### PR TITLE
[Lightcone_v2.js] Fix npm build due to dependency updates

### DIFF
--- a/packages/lightcone_v2.js/globals.d.ts
+++ b/packages/lightcone_v2.js/globals.d.ts
@@ -1,9 +1,8 @@
-declare module 'bn.js';
-declare module 'ethereumjs-abi';
-declare module 'ethereumjs-util';
-declare module 'es6-promisify';
-declare module 'sha2';
-declare module 'snarkjs';
+declare module "bn.js";
+declare module "ethereumjs-abi";
+declare module "es6-promisify";
+declare module "sha2";
+declare module "snarkjs";
 
 declare var web3: any;
 declare var artifacts: any;

--- a/packages/lightcone_v2.js/package.json
+++ b/packages/lightcone_v2.js/package.json
@@ -32,7 +32,7 @@
     "bignumber.js": "^9.0.0",
     "bip39": "2.5.0",
     "blake-hash": "^1.1.0",
-    "bn.js": "^5.0.0",
+    "@types/bn.js": "4.11.5",
     "ethereumjs-abi": "0.6.8",
     "ethereumjs-tx": "2.1.1",
     "ethereumjs-util": "6.1.0",

--- a/packages/lightcone_v2.js/src/index.ts
+++ b/packages/lightcone_v2.js/src/index.ts
@@ -5,16 +5,6 @@ import EthRpcUtils from "./lib/wallet/ethereum/eth";
 import Utils from "./lib/wallet/common/utils";
 import config from "./lib/wallet/config";
 
-import { exchange } from "./sign/exchange";
 import { Account } from "./wallet/account";
 
-export {
-  common,
-  config,
-  ethereum,
-  exchange,
-  Account,
-  ContractUtils,
-  EthRpcUtils,
-  Utils
-};
+export { common, config, ethereum, Account, ContractUtils, EthRpcUtils, Utils };

--- a/packages/lightcone_v2.js/src/lib/wallet/config/config.json
+++ b/packages/lightcone_v2.js/src/lib/wallet/config/config.json
@@ -1,11 +1,12 @@
 {
   "defaultGasPrice": 21,
   "defaultGasLimit": "0x7a120",
-  "chainId": 1,
-  "exchangeId": 1,
+  "chainId": 4,
+  "exchangeId": 2,
   "walletAddressId": 0,
   "maxFeeBips": 20,
-  "exchangeAddress": "0x1D307532A97879b866A6fE33bf4A517bD28DE854",
+  "exchangeAddress": "0x5c6a4566a6cb3966fb9b713994d3ef747247ab88",
+  "maxAmount": "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
   "markets": [
     {
       "tokenx": "LRC",

--- a/packages/lightcone_v2.js/src/lib/wallet/config/index.ts
+++ b/packages/lightcone_v2.js/src/lib/wallet/config/index.ts
@@ -169,6 +169,10 @@ function getWallets() {
   return data.wallets;
 }
 
+function getMaxAmountInWEI() {
+  return config.maxAmount;
+}
+
 export default {
   getTokenBySymbol,
   getTokenByAddress,
@@ -188,6 +192,7 @@ export default {
   getMarkets,
   getWalletAddress,
   getExchangeAddress,
+  getMaxAmountInWEI,
   getWallets,
   fromWEI,
   toWEI

--- a/packages/lightcone_v2.js/src/lib/wallet/ethereum/metaMask.ts
+++ b/packages/lightcone_v2.js/src/lib/wallet/ethereum/metaMask.ts
@@ -2,8 +2,8 @@ import validator from "./validator";
 import Response from "../common/response";
 import code from "../common/code";
 import { addHexPrefix, toHex, toNumber } from "../common/formatter";
-import { hashPersonalMessage, sha3 } from "ethereumjs-util";
-import EthTransaction from "ethereumjs-tx";
+import { hashPersonalMessage, keccak256 } from "ethereumjs-util";
+import { Transaction as EthTransaction } from "ethereumjs-tx";
 
 /**
  * @description sign hash
@@ -44,7 +44,7 @@ export async function sign(web3, account, hash) {
  * @returns {Promise}
  */
 export function signMessage(web3, account, message) {
-  const hash = toHex(hashPersonalMessage(sha3(message)));
+  const hash = toHex(hashPersonalMessage(keccak256(message)));
   return sign(web3, account, hash);
 }
 
@@ -69,7 +69,7 @@ export async function signEthereumTx(web3, account, rawTx) {
     const response = await sign(web3, account, hash);
     if (!response["error"]) {
       const signature = response["result"];
-      signature.v += ethTx._chainId * 2 + 8;
+      signature.v += ethTx.getChainId() * 2 + 8;
       Object.assign(ethTx, signature);
       return { result: toHex(ethTx.serialize()) };
     } else {

--- a/packages/lightcone_v2.js/src/lib/wallet/ethereum/transaction.ts
+++ b/packages/lightcone_v2.js/src/lib/wallet/ethereum/transaction.ts
@@ -1,4 +1,4 @@
-import EthTransaction from "ethereumjs-tx";
+import { Transaction as EthTransaction } from "ethereumjs-tx";
 import validator from "./validator";
 import { addHexPrefix, toBuffer, toHex } from "../common/formatter";
 import { getGasPrice, getTransactionCount } from "./utils";

--- a/packages/lightcone_v2.js/src/lib/wallet/ethereum/utils.ts
+++ b/packages/lightcone_v2.js/src/lib/wallet/ethereum/utils.ts
@@ -1,7 +1,7 @@
 import validator from "../common/validator";
 import request from "../common/request";
 
-import { sha3 } from "ethereumjs-util";
+import { keccak256 } from "ethereumjs-util";
 
 var host = "http://localhost:8545";
 
@@ -132,5 +132,5 @@ export function isValidEthAddress(address) {
 }
 
 export function getHash(message) {
-  return sha3(message);
+  return keccak256(message);
 }

--- a/packages/lightcone_v2.js/src/lib/wallet/ethereum/walletAccount.ts
+++ b/packages/lightcone_v2.js/src/lib/wallet/ethereum/walletAccount.ts
@@ -16,13 +16,13 @@ import {
   privateToAddress,
   privateToPublic,
   publicToAddress,
-  sha3
+  keccak256
 } from "ethereumjs-util";
 import { mnemonictoPrivatekey } from "./mnemonic";
 import { generateMnemonic } from "bip39";
 import { trimAll } from "../common/utils";
 import HDKey from "hdkey";
-import EthTransaction from "ethereumjs-tx";
+import { Transaction as EthTransaction } from "ethereumjs-tx";
 import * as MetaMask from "./metaMask";
 import Wallet from "ethereumjs-wallet";
 
@@ -253,7 +253,7 @@ export class PrivateKeyAccount extends WalletAccount {
   }
 
   signMessage(message) {
-    const hash = sha3(message);
+    const hash = keccak256(message);
     const finalHash = hashPersonalMessage(hash);
     return this.sign(finalHash);
   }

--- a/packages/lightcone_v2.js/src/sign/exchange.ts
+++ b/packages/lightcone_v2.js/src/sign/exchange.ts
@@ -10,7 +10,7 @@ import { OrderInfo } from "../model/types";
 export class Exchange {
   private currentWalletAccount: WalletAccount;
 
-  public async createOrUpdateAccount(
+  public createOrUpdateAccount(
     wallet: WalletAccount,
     password: string,
     nonce: number,
@@ -19,7 +19,7 @@ export class Exchange {
     try {
       const keyPair = generateKeyPair(wallet.getAddress() + password);
       this.currentWalletAccount = wallet;
-      const transaction = await this.createAccountAndDeposit(
+      const transaction = this.createAccountAndDeposit(
         keyPair.publicKeyX,
         keyPair.publicKeyY,
         "",
@@ -37,7 +37,7 @@ export class Exchange {
     }
   }
 
-  private async createAccountAndDeposit(
+  private createAccountAndDeposit(
     publicX: string,
     publicY: string,
     symbol: string,
@@ -82,7 +82,7 @@ export class Exchange {
     }
   }
 
-  public async deposit(
+  public deposit(
     wallet: WalletAccount,
     symbol: string,
     amount: string,
@@ -135,7 +135,7 @@ export class Exchange {
     }
   }
 
-  public async withdraw(
+  public withdraw(
     wallet: WalletAccount,
     symbol: string,
     amount: string,
@@ -215,7 +215,7 @@ export class Exchange {
     return order;
   }
 
-  public async setupOrder(order: OrderInfo) {
+  public setupOrder(order: OrderInfo) {
     if (!order.tokenS.startsWith("0x")) {
       order.tokenS = config.getTokenBySymbol(order.tokenS).address;
     }
@@ -256,9 +256,9 @@ export class Exchange {
     return this.signOrder(order);
   }
 
-  public async submitOrder(wallet: WalletAccount, orderInfo: OrderInfo) {
+  public submitOrder(wallet: WalletAccount, orderInfo: OrderInfo) {
     this.currentWalletAccount = wallet;
-    return await this.setupOrder(orderInfo);
+    return this.setupOrder(orderInfo);
   }
 
   public async cancelOrder(orderInfo: OrderInfo) {

--- a/packages/lightcone_v2.js/test/testAccount.ts
+++ b/packages/lightcone_v2.js/test/testAccount.ts
@@ -4,15 +4,18 @@ import ethereum from "../src/lib/wallet/ethereum";
 import config from "../src/lib/wallet/config";
 import { Account } from "../src";
 
-describe("config test", function() {
+describe("account test", function() {
   this.timeout(10000);
 
-  before(async () => {});
+  let privateKeyAccount;
 
-  it("unlock wallet", function(done) {
-    let privateKeyAccount = ethereum.account.fromPrivateKey(
+  beforeEach(() => {
+    privateKeyAccount = ethereum.account.fromPrivateKey(
       "0x7c71142c72a019568cf848ac7b805d21f2e0fd8bc341e8314580de11c6a397bf"
     );
+  });
+
+  it("unlock wallet", function(done) {
     assert.strictEqual(
       privateKeyAccount.getAddress(),
       "0xE20cF871f1646d8651ee9dC95AAB1d93160b3467"
@@ -36,14 +39,47 @@ describe("config test", function() {
     done();
   });
 
-  it("account sign deposit", async function() {
-    let privateKeyAccount = ethereum.account.fromPrivateKey(
-      "0x7c71142c72a019568cf848ac7b805d21f2e0fd8bc341e8314580de11c6a397bf"
-    );
+  it("account sign create account", async function() {
     let wallet = new Account(privateKeyAccount);
-    let signed = await wallet.depositTo("LRC", "10", 10, 10);
+    let signed = await wallet.createOrUpdateAccount("Abc!12345", 10, 10);
+    const expected = {
+      signedTx:
+        "0xf8f10a8502540be400830f4240941d307532a97879b866a6fe33bf4a517bd28de8548727147114878000b884b4bf7618213b170bbd3cdecfb7885ebfb9cc4272f9ac40da01fea8698d78daddcee274ee2fff3a75d20db0719655fe1fe2f65dce28e5aae723d429c67dab896d7dd8cda90000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000026a0f8d13027c691b7d477d3daf3fdec9568333912b1a37de4de13d0913e2041b8f1a0346888c55245298785b098ad99315ddc563c1c955e6a8b6ef13f9c8387ebc324",
+      keyPair: {
+        publicKeyX:
+          "15030727036724168751212480282500540869268142725392913493575803542173309367534",
+        publicKeyY:
+          "21709653362655094841217318150615954140561437115749994376567240539798473592233",
+        secretKey: "1268930117"
+      }
+    };
+    assert.strictEqual(signed.signedTx, expected.signedTx);
+    assert.strictEqual(signed.keyPair.publicKeyX, expected.keyPair.publicKeyX);
+    assert.strictEqual(signed.keyPair.publicKeyY, expected.keyPair.publicKeyY);
+    assert.strictEqual(signed.keyPair.secretKey, expected.keyPair.secretKey);
+  });
+
+  it("account sign deposit", async function() {
+    let wallet = new Account(privateKeyAccount);
+    let signedTx = await wallet.depositTo("LRC", "10", 10, 10);
     const expected =
       "0xf8b10a8502540be400830f4240941d307532a97879b866a6fe33bf4a517bd28de854872386f26fc10000b8443ae50b730000000000000000000000009032dbf5669341c3d95bc02b4bde90e4e051db350000000000000000000000000000000000000000000000008ac7230489e8000025a0a89745dbfedb7160f7ed4702b0f88a6c4abfb4b7daa0e3b24a21177ea9816412a0025af9a36a9966a8a35fc3567125d6e5e58b3d8db24a0cd74c8659ac222c176f";
-    assert.strictEqual(signed, expected);
+    assert.strictEqual(signedTx, expected);
+  });
+
+  it("account sign approve", async function() {
+    let wallet = new Account(privateKeyAccount);
+    let signedTx = await wallet.approve("LRC", 10, 10);
+    const expected =
+      "0xf8aa0a8502540be400830186a0949032dbf5669341c3d95bc02b4bde90e4e051db3580b844095ea7b30000000000000000000000001d307532a97879b866a6fe33bf4a517bd28de854ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff25a071af95d2a3eb01bb11f84d9c66d09924d97a2b3ce38e0079a2d56dfb13035df0a07404b3a48c40cc3e7b9893d88512ef526a67bf3c274548ec09f94386e0062fc2";
+    assert.strictEqual(signedTx, expected);
+  });
+
+  it("account sign withdraw", async function() {
+    let wallet = new Account(privateKeyAccount);
+    let signedTx = await wallet.withdrawFrom("LRC", "10", 10, 10);
+    const expected =
+      "0xf8b10a8502540be400830f4240941d307532a97879b866a6fe33bf4a517bd28de854872386f26fc10000b8448c8c3c9d0000000000000000000000009032dbf5669341c3d95bc02b4bde90e4e051db350000000000000000000000000000000000000000000000008ac7230489e8000025a0bab16f326c770ad08c4e21c4c67a727c1babf2fe3de4870e30bdc77371048b1da03a47e25c78d5137dc3f57e1764a66e11032e1ae361d220b38b6c338a4525af61";
+    assert.strictEqual(signedTx, expected);
   });
 });

--- a/packages/lightcone_v2.js/test/testEddsa.ts
+++ b/packages/lightcone_v2.js/test/testEddsa.ts
@@ -1,5 +1,5 @@
 // Hack: Failed to import src files directly.
-import { exchange } from "../src";
+import { exchange } from "../src/sign/exchange";
 import * as eddsa from "../src/lib/sign/eddsa";
 import * as fm from "../src/lib/wallet/common/formatter";
 import { OrderInfo } from "../src/model/types";

--- a/packages/lightcone_v2.js/test/testExchange.ts
+++ b/packages/lightcone_v2.js/test/testExchange.ts
@@ -1,5 +1,5 @@
 // Hack: Failed to import src files directly.
-import { exchange } from "../src";
+import { exchange } from "../src/sign/exchange";
 import { fromPrivateKey } from "../src/lib/wallet/ethereum/walletAccount";
 import assert = require("assert");
 


### PR DESCRIPTION
```npm run test``` doesn't pass

```
####################################
[ 18461811482240861092127996284914078088723463759234691728583091886124032327996n,
  12408252482010503600595715827901878671968894948988357460202767969927793637775n ]
1687023508745541781822008154827904514028415203517821866372277605910974068776n
accP: 
12814186605633838161465901630320439100565827976101287594230038579582678591406
20581441827076388071492824916932778097249385119747029565502024772738923615041
    2) sign and verify
accP: 
4496886077546369029288375509585003717020710202480852367695556545173931953798
7963252827810179549682475526859097309220865080725729373845158239060043994495
    ✓ verify python gen sig (609ms)
    3) generate key pair

  eddsa sign test
    4) create account


  6 passing (3s)
  4 failing

  1) account test
       "before each" hook for "unlock wallet":
     Error: Invalid private key
      at new PrivateKeyAccount (src/lib/wallet/ethereum/walletAccount.ts:220:13)
      at Object.fromPrivateKey (src/lib/wallet/ethereum/walletAccount.ts:129:10)
      at Context.beforeEach (test/testAccount.ts:13:42)

  2) eddsa sign test
       sign and verify:
     Error: Timeout of 1000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/Users/ruby/Development/protocols/packages/lightcone_v2.js/test/testEddsa.ts)
      at Context.<anonymous> (test/testEddsa.ts:118:5)

  3) eddsa sign test
       generate key pair:

      AssertionError [ERR_ASSERTION]: Input A expected to strictly equal input B:
+ expected - actual

- '19207709823610792518758223127229703910829427979843647634361472587040376856542'
+ '15030727036724168751212480282500540869268142725392913493575803542173309367534'
      + expected - actual

      -19207709823610792518758223127229703910829427979843647634361472587040376856542
      +15030727036724168751212480282500540869268142725392913493575803542173309367534
      
      at Context.<anonymous> (test/testEddsa.ts:181:12)

  4) eddsa sign test
       create account:
     Error: Invalid private key
      at new PrivateKeyAccount (src/lib/wallet/ethereum/walletAccount.ts:220:13)
      at Object.fromPrivateKey (src/lib/wallet/ethereum/walletAccount.ts:129:10)
      at Context.<anonymous> (test/testExchange.ts:15:19)
      at Generator.next (<anonymous>)
      at /Users/ruby/Development/protocols/packages/lightcone_v2.js/test/testExchange.ts:8:71
      at new Promise (<anonymous>)
      at __awaiter (test/testExchange.ts:4:12)
      at Context.<anonymous> (test/testExchange.ts:22:16)


```