### PR TITLE
REVERT [Protocol3] emit BlockFinalized event only once (#614)

### DIFF
--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -170,14 +170,10 @@ library ExchangeBlocks
         uint idx = S.numBlocksFinalized;
         while (idx < S.blocks.length &&
             S.blocks[idx].state == ExchangeData.BlockState.VERIFIED) {
+            emit BlockFinalized(idx);
             idx++;
         }
-
-        // Only emit BlockFinalized event for the last verified block.
-        if (idx > S.numBlocksFinalized) {
-            emit BlockFinalized(idx - 1);
-            S.numBlocksFinalized = idx;
-        }
+        S.numBlocksFinalized = idx;
     }
 
     function revertBlock(

--- a/packages/loopring_v3/package-lock.json
+++ b/packages/loopring_v3/package-lock.json
@@ -332,9 +332,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.11.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.1.tgz",
-      "integrity": "sha512-TJtwsqZ39pqcljJpajeoofYRfeZ7/I/OMUQ5pR4q5wOKf2ocrUvBAZUMhWsOvKx3dVc/aaV5GluBivt0sWqA5A==",
+      "version": "12.11.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.11.2.tgz",
+      "integrity": "sha512-dsfE4BHJkLQW+reOS6b17xhZ/6FB1rB8eRRvO08nn5o+voxf3i74tuyFWNH6djdfgX7Sm5s6LD8t6mJug4dpDw==",
       "dev": true
     },
     "@types/normalize-package-data": {


### PR DESCRIPTION
Caused 63 test failures. I think we should revert this change for now.