### PR TITLE
add a precondition for withdrawal non-LRC tokens

### DIFF
--- a/packages/loopring_v3/contracts/iface/ILoopringV3.sol
+++ b/packages/loopring_v3/contracts/iface/ILoopringV3.sol
@@ -71,13 +71,14 @@ contract ILoopringV3 is ILoopring
     uint    public totalStake;
     address public blockVerifierAddress;
     address public downtimeCostCalculator;
-    uint    public maxWithdrawalFee;
     uint    public withdrawalFineLRC;
     uint    public tokenRegistrationFeeLRCBase;
     uint    public tokenRegistrationFeeLRCDelta;
     uint    public minExchangeStakeWithDataAvailability;
     uint    public minExchangeStakeWithoutDataAvailability;
     uint    public revertFineLRC;
+    uint    public maxWithdrawalFee;
+    uint    public minLRCBalanceForUserToWithdraw;
     uint8   public minProtocolTakerFeeBips;
     uint8   public maxProtocolTakerFeeBips;
     uint8   public minProtocolMakerFeeBips;
@@ -104,7 +105,8 @@ contract ILoopringV3 is ILoopring
         uint    _minExchangeStakeWithDataAvailability,
         uint    _minExchangeStakeWithoutDataAvailability,
         uint    _revertFineLRC,
-        uint    _withdrawalFineLRC
+        uint    _withdrawalFineLRC,
+        uint    _minLRCBalanceForUserToWithdraw
         )
         external;
 

--- a/packages/loopring_v3/contracts/impl/LoopringV3.sol
+++ b/packages/loopring_v3/contracts/impl/LoopringV3.sol
@@ -59,7 +59,7 @@ contract LoopringV3 is ILoopringV3
             _protocolFeeVault,
             _blockVerifierAddress,
             _downtimeCostCalculator,
-            0, 0, 0, 0, 0, 0, 0, 0
+            0, 0, 0, 0, 0, 0, 0, 0, 0
         );
     }
 
@@ -122,7 +122,8 @@ contract LoopringV3 is ILoopringV3
         uint    _minExchangeStakeWithDataAvailability,
         uint    _minExchangeStakeWithoutDataAvailability,
         uint    _revertFineLRC,
-        uint    _withdrawalFineLRC
+        uint    _withdrawalFineLRC,
+        uint    _minLRCBalanceForUserToWithdraw
         )
         external
         onlyOwner
@@ -138,7 +139,8 @@ contract LoopringV3 is ILoopringV3
             _minExchangeStakeWithDataAvailability,
             _minExchangeStakeWithoutDataAvailability,
             _revertFineLRC,
-            _withdrawalFineLRC
+            _withdrawalFineLRC,
+            _minLRCBalanceForUserToWithdraw
         );
     }
 
@@ -370,7 +372,8 @@ contract LoopringV3 is ILoopringV3
         uint    _minExchangeStakeWithDataAvailability,
         uint    _minExchangeStakeWithoutDataAvailability,
         uint    _revertFineLRC,
-        uint    _withdrawalFineLRC
+        uint    _withdrawalFineLRC,
+        uint    _minLRCBalanceForUserToWithdraw
         )
         private
     {
@@ -389,6 +392,7 @@ contract LoopringV3 is ILoopringV3
         minExchangeStakeWithoutDataAvailability = _minExchangeStakeWithoutDataAvailability;
         revertFineLRC = _revertFineLRC;
         withdrawalFineLRC = _withdrawalFineLRC;
+        minLRCBalanceForUserToWithdraw = _minLRCBalanceForUserToWithdraw;
 
         emit SettingsUpdated(now);
     }


### PR DESCRIPTION
We now require a user must hold ILoopring.minLRCBalanceForUserToWithdraw in order to send onchain withdrawal requests to withdraw non-LRC tokens.