### PR TITLE
Update exchange simulator according to new ring settle logic.

### DIFF
--- a/packages/loopring_v3/operator/state.py
+++ b/packages/loopring_v3/operator/state.py
@@ -621,10 +621,11 @@ class State(object):
 
         # Saved in ring for tests
         ring.fFillS_A = toFloat(fillA.S, Float24Encoding)
-        ring.fFillS_B = toFloat(fillB.S, Float24Encoding)
+        roundFillS_A = fromFloat(ring.fFillS_A, Float24Encoding)
+        ring.fFillS_B = toFloat(roundFillS_A * int(ring.orderB.amountS) // int(ring.orderB.amountB), Float24Encoding)
 
-        fillA.S = roundToFloatValue(fillA.S, Float24Encoding)
-        fillB.S = roundToFloatValue(fillB.S, Float24Encoding)
+        fillA.S = fromFloat(ring.fFillS_A, Float24Encoding)
+        fillB.S = fromFloat(ring.fFillS_B, Float24Encoding)
         fillA.B = fillB.S
         fillB.B = fillA.S
 

--- a/packages/loopring_v3/test/simulator.ts
+++ b/packages/loopring_v3/test/simulator.ts
@@ -420,7 +420,10 @@ export class Simulator {
     }
 
     fillA.S = roundToFloatValue(fillA.S, Constants.Float24Encoding);
-    fillB.S = roundToFloatValue(fillB.S, Constants.Float24Encoding);
+    fillB.S = roundToFloatValue(
+      fillA.S.mul(ring.orderB.amountS).div(ring.orderB.amountB),
+      Constants.Float24Encoding
+    );
 
     // Validate
     this.validateOrder(


### PR DESCRIPTION
Co-work with circuit PR#25 (/protocol3-circuits/pull/25).
Now, we use encoded fillS_A/B to calculate the real trade amount.

Signed-off-by: yue.wang <yue.wang@loopring>