### PR TITLE
[Protocol3] Fixed dummy rings

### DIFF
--- a/packages/loopring_v3/test/testExchangeBlockPermutations.ts
+++ b/packages/loopring_v3/test/testExchangeBlockPermutations.ts
@@ -147,6 +147,25 @@ contract("Exchange", (accounts: string[]) => {
       }
     });
 
+    it("Ring Settlement (dummy rings)", async () => {
+      const bDataAvailabilities = [true];
+      for (const bDataAvailability of bDataAvailabilities) {
+        await createExchange(bDataAvailability);
+        await exchangeTestUtil.commitDeposits(exchangeId);
+        const blockSizes = exchangeTestUtil.ringSettlementBlockSizes;
+        for (const blockSize of blockSizes) {
+          for (let i = 0; i < blockSize; i++) {
+            await exchangeTestUtil.sendRing(
+              exchangeId,
+              exchangeTestUtil.dummyRing
+            );
+          }
+          await exchangeTestUtil.commitRings(exchangeId);
+        }
+        await verify();
+      }
+    });
+
     it("Deposit", async () => {
       await createExchange(false);
       const blockSizes = exchangeTestUtil.depositBlockSizes;

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -300,7 +300,7 @@ export class ExchangeTestUtil {
         validSince: 0,
         validUntil: 2 ** 32 - 1,
         maxFeeBips: 0,
-        buy: true,
+        buy: false,
         label: 1,
 
         feeBips: 0,
@@ -319,7 +319,7 @@ export class ExchangeTestUtil {
         validSince: 0,
         validUntil: 2 ** 32 - 1,
         maxFeeBips: 0,
-        buy: true,
+        buy: false,
         label: 2,
 
         feeBips: 0,

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -137,6 +137,7 @@ export class ExchangeTestUtil {
 
   public dummyAccountId: number;
   public dummyAccountKeyPair: any;
+  public dummyRing: RingInfo;
 
   public tokenAddressToIDMap = new Map<string, number>();
   public tokenIDToAddressMap = new Map<number, string>();
@@ -272,7 +273,7 @@ export class ExchangeTestUtil {
     const keyPair = this.getKeyPairEDDSA();
     const depositInfo = await this.deposit(
       exchangeID,
-      this.testContext.deployer,
+      this.testContext.ringMatchers[0],
       keyPair.secretKey,
       keyPair.publicKeyX,
       keyPair.publicKeyY,
@@ -285,6 +286,60 @@ export class ExchangeTestUtil {
     this.operators[exchangeID] = await this.createOperator(
       exchangeID,
       this.testContext.operators[0]
+    );
+
+    // Create a ring that can be reused 2**96 times if filled wit 1 wei/1 wei
+    this.dummyRing = {
+      orderA: {
+        exchangeID,
+        orderID: 0,
+        accountID: this.dummyAccountId,
+        tokenIdS: this.getTokenIdFromNameOrAddress("ETH"),
+        tokenIdB: this.getTokenIdFromNameOrAddress("LRC"),
+        allOrNone: false,
+        validSince: 0,
+        validUntil: 2 ** 32 - 1,
+        maxFeeBips: 0,
+        buy: true,
+        label: 1,
+
+        feeBips: 0,
+        rebateBips: 0,
+
+        amountS: Constants.MAX_AMOUNT,
+        amountB: Constants.MAX_AMOUNT
+      },
+      orderB: {
+        exchangeID,
+        orderID: 0,
+        accountID: this.dummyAccountId,
+        tokenIdS: this.getTokenIdFromNameOrAddress("LRC"),
+        tokenIdB: this.getTokenIdFromNameOrAddress("ETH"),
+        allOrNone: false,
+        validSince: 0,
+        validUntil: 2 ** 32 - 1,
+        maxFeeBips: 0,
+        buy: true,
+        label: 2,
+
+        feeBips: 0,
+        rebateBips: 0,
+
+        amountS: Constants.MAX_AMOUNT,
+        amountB: Constants.MAX_AMOUNT
+      },
+      tokenID: 0,
+      fee: new BN(0)
+    };
+    this.signOrder(this.dummyRing.orderA);
+    this.signOrder(this.dummyRing.orderB);
+
+    // Deposit 1 wei ETH and 1 wei LRC to the dummy account so the ring can be filled with 1 wei
+    await this.depositTo(this.dummyAccountId, Constants.zeroAddress, new BN(1));
+    await this.depositTo(
+      this.dummyAccountId,
+      this.getTokenAddress("LRC"),
+      new BN(1)
     );
   }
 
@@ -2346,51 +2401,7 @@ export class ExchangeTestUtil {
         if (b < pendingRings.length) {
           rings.push(pendingRings[b]);
         } else {
-          const dummyRing: RingInfo = {
-            orderA: {
-              exchangeID,
-              orderID: 0,
-              accountID: this.dummyAccountId,
-              tokenIdS: 0,
-              tokenIdB: 1,
-              allOrNone: false,
-              validSince: 0,
-              validUntil: 0,
-              maxFeeBips: 0,
-              buy: true,
-              label: 1,
-
-              feeBips: 0,
-              rebateBips: 0,
-
-              amountS: new BN(1),
-              amountB: new BN(1)
-            },
-            orderB: {
-              exchangeID,
-              orderID: 0,
-              accountID: this.dummyAccountId,
-              tokenIdS: 1,
-              tokenIdB: 0,
-              allOrNone: false,
-              validSince: 0,
-              validUntil: 0,
-              maxFeeBips: 0,
-              buy: true,
-              label: 2,
-
-              feeBips: 0,
-              rebateBips: 0,
-
-              amountS: new BN(1),
-              amountB: new BN(1)
-            },
-            tokenID: 0,
-            fee: new BN(0)
-          };
-          this.signOrder(dummyRing.orderA);
-          this.signOrder(dummyRing.orderB);
-          rings.push(dummyRing);
+          rings.push(this.dummyRing);
         }
       }
       assert(rings.length === blockSize);


### PR DESCRIPTION
This works around the limitation in the new circuits that the fills cannot be 0. I forgot that this is actually a case where that would be useful.

Luckily  the workaround isn't very difficult. We can can just create orders for the dummy account that for example self-trades 1 wei LRC for 1 wei ETH. So the only difference for the relayer should be that the dummy orders have some different properties and that the dummy account needs e.g. 1 wei LRC and 1 wei ETH in its account (this only needs to be deposited once). The dummy ring can then be used, as is, `2**96` times, so there will be no need to ever create another dummy ring or another dummy account.

A minor downside is that the dummy ring now cost 24 gas more/dummy trade (but the compression could help with this), but this is pretty insignificant.
