### PR TITLE
[Protocol3] Add owner contracts with mandatory delays

### DIFF
--- a/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
+++ b/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
@@ -16,10 +16,12 @@
 */
 pragma solidity ^0.5.11;
 
+import "../lib/Claimable.sol";
+
 
 /// @title IBlockVerifier
 /// @author Brecht Devos - <brecht@loopring.org>
-contract IBlockVerifier
+contract IBlockVerifier is Claimable
 {
     // -- Events --
 

--- a/packages/loopring_v3/contracts/iface/IDelayedOwner.sol
+++ b/packages/loopring_v3/contracts/iface/IDelayedOwner.sol
@@ -1,0 +1,114 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "../lib/Claimable.sol";
+
+
+/// @title IDelayedOwner
+/// @author Brecht Devos - <brecht@loopring.org>
+/// @dev Base class for an Owner contract where certain functions have
+///      a mandatory delay for security purposes.
+contract IDelayedOwner is Claimable
+{
+    event TransactionDelayed(
+        uint    id,
+        uint    timestamp,
+        uint    value,
+        bytes   data,
+        uint    delay
+    );
+
+    event TransactionCancelled(
+        uint    id,
+        uint    timestamp,
+        uint    value,
+        bytes   data
+    );
+
+    event TransactionExecuted(
+        uint    timestamp,
+        uint    value,
+        bytes   data
+    );
+
+    event PendingTransactionExecuted(
+        uint    id,
+        uint    timestamp,
+        uint    value,
+        bytes   data
+    );
+
+    struct Transaction
+    {
+        uint    id;
+        uint    timestamp;
+        uint    value;
+        bytes   data;
+    }
+
+    struct DelayedFunction
+    {
+        bytes4  functionSelector;
+        uint    delay;
+    }
+
+    // The contract all function calls will be done on.
+    address public ownedContract;
+
+    // The maximum amount of time (in seconds) a pending transaction can be executed
+    // (so the amount of time than can pass after the mandatory function specific delay).
+    // If the transaction hasn't been executed before then it can be cancelled so it is removed
+    // from the pending transaction list.
+    uint public timeToLive;
+
+    // Active list of delayed functions (delay > 0)
+    DelayedFunction[] public delayedFunctions;
+
+    // Active list of pending transactions
+    Transaction[] public pendingTransactions;
+
+    function executeTransaction(
+        uint transactionId
+        )
+        external;
+
+    function cancelTransaction(
+        uint transactionId
+        )
+        external;
+
+    function cancelAllTransactions()
+        external;
+
+    function getFunctionDelay(
+        bytes4 functionSelector
+        )
+        public
+        view
+        returns (uint);
+
+    function getNumPendingTransactions()
+        external
+        view
+        returns (uint);
+
+    function getNumDelayedFunctions()
+        external
+        view
+        returns (uint);
+}

--- a/packages/loopring_v3/contracts/iface/IDelayedOwner.sol
+++ b/packages/loopring_v3/contracts/iface/IDelayedOwner.sol
@@ -21,8 +21,6 @@ import "../lib/Claimable.sol";
 
 /// @title IDelayedOwner
 /// @author Brecht Devos - <brecht@loopring.org>
-/// @dev Base class for an Owner contract where certain functions have
-///      a mandatory delay for security purposes.
 contract IDelayedOwner is Claimable
 {
     event TransactionDelayed(
@@ -82,19 +80,27 @@ contract IDelayedOwner is Claimable
     // Active list of pending transactions
     Transaction[] public pendingTransactions;
 
+    /// @dev Executes a pending transaction.
+    /// @param transactionId The id of the pending transaction.
     function executeTransaction(
         uint transactionId
         )
         external;
 
+    /// @dev Cancels a pending transaction.
+    /// @param transactionId The id of the pending transaction.
     function cancelTransaction(
         uint transactionId
         )
         external;
 
+    /// @dev Cancels all pending transactions.
     function cancelAllTransactions()
         external;
 
+    /// @dev Gets the delay for the given function
+    /// @param functionSelector The function selector.
+    /// @return The delay of the function.
     function getFunctionDelay(
         bytes4 functionSelector
         )
@@ -102,11 +108,15 @@ contract IDelayedOwner is Claimable
         view
         returns (uint);
 
+    /// @dev Gets the number of pending transactions.
+    /// @return The number of pending transactions.
     function getNumPendingTransactions()
         external
         view
         returns (uint);
 
+    /// @dev Gets the number of functions that have a delay.
+    /// @return The number of delayed functions.
     function getNumDelayedFunctions()
         external
         view

--- a/packages/loopring_v3/contracts/impl/BlockVerifier.sol
+++ b/packages/loopring_v3/contracts/impl/BlockVerifier.sol
@@ -19,7 +19,6 @@ pragma solidity ^0.5.11;
 import "../thirdparty/Verifier.sol";
 import "../thirdparty/BatchVerifier.sol";
 
-import "../lib/Claimable.sol";
 import "../lib/ReentrancyGuard.sol";
 
 import "../iface/IBlockVerifier.sol";
@@ -29,7 +28,7 @@ import "../impl/libexchange/ExchangeData.sol";
 
 /// @title An Implementation of IBlockVerifier.
 /// @author Brecht Devos - <brecht@loopring.org>
-contract BlockVerifier is Claimable, ReentrancyGuard, IBlockVerifier
+contract BlockVerifier is ReentrancyGuard, IBlockVerifier
 {
     struct Circuit
     {

--- a/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
@@ -27,7 +27,7 @@ contract BlockVerifierOwner is DelayedOwner
     constructor(
         IBlockVerifier blockVerifier
         )
-        DelayedOwner(address(blockVerifier))
+        DelayedOwner(address(blockVerifier), 3 days)
         public
     {
         setFunctionDelay(blockVerifier.transferOwnership.selector, 7 days);

--- a/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
@@ -25,12 +25,11 @@ import "../../iface/IBlockVerifier.sol";
 contract BlockVerifierOwner is DelayedOwner
 {
     constructor(
-        address blockVerifierAddress
+        IBlockVerifier blockVerifier
         )
-        DelayedOwner(blockVerifierAddress)
+        DelayedOwner(address(blockVerifier))
         public
     {
-        IBlockVerifier blockVerifier = IBlockVerifier(blockVerifierAddress);
         setFunctionDelay(blockVerifier.transferOwnership.selector, 7 days);
         setFunctionDelay(blockVerifier.registerCircuit.selector, 7 days);
         setFunctionDelay(blockVerifier.disableCircuit.selector, 1 days);

--- a/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/BlockVerifierOwner.sol
@@ -1,0 +1,38 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./DelayedOwner.sol";
+import "../../iface/IBlockVerifier.sol";
+
+
+/// @title  BlockVerifierOwner
+/// @author Brecht Devos - <brecht@loopring.org>
+contract BlockVerifierOwner is DelayedOwner
+{
+    constructor(
+        address blockVerifierAddress
+        )
+        DelayedOwner(blockVerifierAddress)
+        public
+    {
+        IBlockVerifier blockVerifier = IBlockVerifier(blockVerifierAddress);
+        setFunctionDelay(blockVerifier.transferOwnership.selector, 7 days);
+        setFunctionDelay(blockVerifier.registerCircuit.selector, 7 days);
+        setFunctionDelay(blockVerifier.disableCircuit.selector, 1 days);
+    }
+}

--- a/packages/loopring_v3/contracts/impl/owners/DelayedOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/DelayedOwner.sol
@@ -1,0 +1,212 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "../../lib/AddressUtil.sol";
+import "../../lib/BytesUtil.sol";
+import "../../lib/Claimable.sol";
+import "../../lib/MathUint.sol";
+import "../../lib/ReentrancyGuard.sol";
+
+
+/// @title DelayedOwner
+/// @author Brecht Devos - <brecht@loopring.org>
+/// @dev Base class for an Owner contract where certain functions have
+///      a mandatory delay for security purposes.
+contract DelayedOwner is Claimable, ReentrancyGuard
+{
+    using AddressUtil for address payable;
+    using BytesUtil   for bytes;
+    using MathUint    for uint;
+
+    struct Transaction
+    {
+        uint timestamp;
+        uint value;
+        bytes data;
+    }
+
+    event TransactionDelayed(
+        uint    delayedTransactionIdx,
+        uint    timestamp,
+        uint    value,
+        bytes   data,
+        uint    delay
+    );
+
+    event TransactionExecuted(
+        uint    timestamp,
+        uint    value,
+        bytes   data
+    );
+
+    event DelayedTransactionExecuted(
+        uint    delayedTransactionIdx,
+        uint    timestamp,
+        uint    value,
+        bytes   data
+    );
+
+    address public contractAddress;
+    mapping (bytes4 => uint) public functionDelays;
+
+    Transaction[] public delayedTransactions;
+
+    constructor(
+        address _contractAddress
+        )
+        public
+    {
+        require(_contractAddress != address(0), "ZERO_ADDRESS");
+        contractAddress = _contractAddress;
+    }
+
+    function executeDelayedTransaction(
+        uint delayedTransactionIdx
+        )
+        external
+        nonReentrant
+        onlyOwner
+    {
+        require(delayedTransactionIdx < delayedTransactions.length, "INVALID_INDEX");
+        Transaction storage transaction = delayedTransactions[delayedTransactionIdx];
+
+        // Check if this transaction can still be executed
+        require(transaction.timestamp > 0, "TRANSACTION_CONSUMED");
+
+        // Make sure the delay is respected
+        bytes4 functionSelector = transaction.data.bytesToBytes4(0);
+        uint delay = functionDelays[functionSelector];
+        require(now >= transaction.timestamp.add(delay), "TOO_EARLY");
+
+        // Exectute the transaction
+        (bool success, bytes memory returnData) = exectuteTransaction(transaction);
+
+        emit DelayedTransactionExecuted(
+            delayedTransactionIdx,
+            transaction.timestamp,
+            transaction.value,
+            transaction.data
+        );
+
+        // Make the transaction unusable
+        disableTransaction(transaction);
+
+        // Return the same data the original transaction would
+        // (this will return the data even though this function doesn't have a return vallue in solidity)
+        assembly {
+            switch success
+            case 0 { revert(returnData, mload(returnData)) }
+            default { return(returnData, mload(returnData)) }
+        }
+    }
+
+    function cancelDelayedTransaction(
+        uint delayedTransactionIdx
+        )
+        external
+        nonReentrant
+        onlyOwner
+    {
+        require(delayedTransactionIdx < delayedTransactions.length, "INVALID_INDEX");
+        Transaction storage transaction = delayedTransactions[delayedTransactionIdx];
+
+        require(transaction.timestamp > 0, "TRANSACTION_CONSUMED");
+
+        // Make the transaction unusable
+        disableTransaction(transaction);
+
+        // Return the transaction value (if there is any)
+        uint value = transaction.value;
+        if (value > 0) {
+            msg.sender.sendETHAndVerify(value, gasleft());
+        }
+    }
+
+    // If the function that was called has no delay the function is called immediately,
+    // otherwise the function call is stored on-chain and can be executed later using
+    // `executeDelayedTransaction` when the necessary time has passed.
+    function()
+        external
+        payable
+    {
+        // Don't do anything if msg.sender isn't the owner (e.g. when receiving ETH)
+        if (msg.sender != owner) {
+            return;
+        }
+
+        Transaction memory transaction = Transaction(
+            now,
+            msg.value,
+            msg.data
+        );
+
+        uint delay = functionDelays[msg.sig];
+        if (delay == 0) {
+            (bool success, bytes memory returnData) = exectuteTransaction(transaction);
+            emit TransactionExecuted(
+                transaction.timestamp,
+                transaction.value,
+                transaction.data
+            );
+            // Return the same data the original transaction would
+            // (this will return the data even though this function doesn't have a return vallue in solidity)
+            assembly {
+                switch success
+                case 0 { revert(returnData, mload(returnData)) }
+                default { return(returnData, mload(returnData)) }
+            }
+        } else {
+            delayedTransactions.push(transaction);
+            emit TransactionDelayed(
+                delayedTransactions.length - 1,
+                transaction.timestamp,
+                transaction.value,
+                transaction.data,
+                delay
+            );
+        }
+    }
+
+    // == Internal Functions ==
+
+    function setFunctionDelay(
+        bytes4 functionSelector,
+        uint   delay
+        )
+        internal
+    {
+        functionDelays[functionSelector] = delay;
+    }
+
+    function exectuteTransaction(
+        Transaction memory transaction
+        )
+        internal
+        returns (bool success, bytes memory returnData)
+    {
+        (success, returnData) = contractAddress.call.value(transaction.value)(transaction.data);
+    }
+
+    function disableTransaction(
+        Transaction storage transaction
+        )
+        internal
+    {
+        transaction.timestamp = 0;
+    }
+}

--- a/packages/loopring_v3/contracts/impl/owners/DelayedOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/DelayedOwner.sol
@@ -136,11 +136,11 @@ contract DelayedOwner is Claimable, ReentrancyGuard
         );
 
         // Return the same data the original transaction would
-        // (this will return the data even though this function doesn't have a return vallue in solidity)
+        // (this will return the data even though this function doesn't have a return value in solidity)
         assembly {
             switch success
-            case 0 { revert(returnData, mload(returnData)) }
-            default { return(returnData, mload(returnData)) }
+            case 0 { revert(add(returnData, 32), mload(returnData)) }
+            default { return(add(returnData, 32), mload(returnData)) }
         }
     }
 
@@ -198,11 +198,11 @@ contract DelayedOwner is Claimable, ReentrancyGuard
                 transaction.data
             );
             // Return the same data the original transaction would
-            // (this will return the data even though this function doesn't have a return vallue in solidity)
+            // (this will return the data even though this function doesn't have a return value in solidity)
             assembly {
                 switch success
-                case 0 { revert(returnData, mload(returnData)) }
-                default { return(returnData, mload(returnData)) }
+                case 0 { revert(add(returnData, 32), mload(returnData)) }
+                default { return(add(returnData, 32), mload(returnData)) }
             }
         } else {
             pendingTransactions.push(transaction);

--- a/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
@@ -27,7 +27,7 @@ contract ImplementationManagerOwner is DelayedOwner
     constructor(
         IImplementationManager implementationManager
         )
-        DelayedOwner(address(implementationManager))
+        DelayedOwner(address(implementationManager), 3 days)
         public
     {
         setFunctionDelay(implementationManager.transferOwnership.selector, 7 days);

--- a/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
@@ -25,12 +25,11 @@ import "../../iface/IImplementationManager.sol";
 contract ImplementationManagerOwner is DelayedOwner
 {
     constructor(
-        address implementationManagerAddress
+        IImplementationManager implementationManager
         )
-        DelayedOwner(implementationManagerAddress)
+        DelayedOwner(address(implementationManager))
         public
     {
-        IImplementationManager implementationManager = IImplementationManager(implementationManagerAddress);
         setFunctionDelay(implementationManager.transferOwnership.selector, 7 days);
         setFunctionDelay(implementationManager.register.selector, 1 days);
         setFunctionDelay(implementationManager.setDefault.selector, 7 days);

--- a/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/ImplementationManagerOwner.sol
@@ -1,0 +1,40 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./DelayedOwner.sol";
+import "../../iface/IImplementationManager.sol";
+
+
+/// @title ImplementationManagerOwner
+/// @author Brecht Devos - <brecht@loopring.org>
+contract ImplementationManagerOwner is DelayedOwner
+{
+    constructor(
+        address implementationManagerAddress
+        )
+        DelayedOwner(implementationManagerAddress)
+        public
+    {
+        IImplementationManager implementationManager = IImplementationManager(implementationManagerAddress);
+        setFunctionDelay(implementationManager.transferOwnership.selector, 7 days);
+        setFunctionDelay(implementationManager.register.selector, 1 days);
+        setFunctionDelay(implementationManager.setDefault.selector, 7 days);
+        setFunctionDelay(implementationManager.enable.selector, 7 days);
+        setFunctionDelay(implementationManager.disable.selector, 1 days);
+    }
+}

--- a/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
@@ -1,0 +1,38 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./DelayedOwner.sol";
+import "../../iface/ILoopringV3.sol";
+
+
+/// @title LoopringV3Owner
+/// @author Brecht Devos - <brecht@loopring.org>
+contract LoopringV3Owner is DelayedOwner
+{
+    constructor(
+        address loopringV3address
+        )
+        DelayedOwner(loopringV3address)
+        public
+    {
+        ILoopringV3 loopringV3 = ILoopringV3(loopringV3address);
+        setFunctionDelay(loopringV3.transferOwnership.selector, 7 days);
+        setFunctionDelay(loopringV3.updateSettings.selector, 7 days);
+        setFunctionDelay(loopringV3.updateProtocolFeeSettings.selector, 7 days);
+    }
+}

--- a/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
@@ -27,7 +27,7 @@ contract LoopringV3Owner is DelayedOwner
     constructor(
         ILoopringV3 loopringV3
         )
-        DelayedOwner(address(loopringV3))
+        DelayedOwner(address(loopringV3), 3 days)
         public
     {
         setFunctionDelay(loopringV3.transferOwnership.selector, 7 days);

--- a/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
+++ b/packages/loopring_v3/contracts/impl/owners/LoopringV3Owner.sol
@@ -25,12 +25,11 @@ import "../../iface/ILoopringV3.sol";
 contract LoopringV3Owner is DelayedOwner
 {
     constructor(
-        address loopringV3address
+        ILoopringV3 loopringV3
         )
-        DelayedOwner(loopringV3address)
+        DelayedOwner(address(loopringV3))
         public
     {
-        ILoopringV3 loopringV3 = ILoopringV3(loopringV3address);
         setFunctionDelay(loopringV3.transferOwnership.selector, 7 days);
         setFunctionDelay(loopringV3.updateSettings.selector, 7 days);
         setFunctionDelay(loopringV3.updateProtocolFeeSettings.selector, 7 days);

--- a/packages/loopring_v3/contracts/lib/BytesUtil.sol
+++ b/packages/loopring_v3/contracts/lib/BytesUtil.sol
@@ -73,7 +73,19 @@ library BytesUtil
         pure
         returns (bytes4 data)
     {
-        require(b.length >= offset + 4, "INVALID_SIZE");
+        return bytes4(bytesToBytesX(b, offset, 4));
+    }
+
+    function bytesToBytesX(
+        bytes memory b,
+        uint  offset,
+        uint  numBytes
+        )
+        private
+        pure
+        returns (bytes32 data)
+    {
+        require(b.length >= offset + numBytes, "INVALID_SIZE");
         assembly {
             data := mload(add(b, add(32, offset)))
         }

--- a/packages/loopring_v3/contracts/lib/BytesUtil.sol
+++ b/packages/loopring_v3/contracts/lib/BytesUtil.sol
@@ -65,6 +65,20 @@ library BytesUtil
         return uint16(bytesToUintX(b, offset, 2) & 0xFFFF);
     }
 
+    function bytesToBytes4(
+        bytes memory b,
+        uint  offset
+        )
+        internal
+        pure
+        returns (bytes4 data)
+    {
+        require(b.length >= offset + 4, "INVALID_SIZE");
+        assembly {
+            data := mload(add(b, add(32, offset)))
+        }
+    }
+
     function bytesToUintX(
         bytes memory b,
         uint  offset,

--- a/packages/loopring_v3/contracts/lib/BytesUtil.sol
+++ b/packages/loopring_v3/contracts/lib/BytesUtil.sol
@@ -73,7 +73,7 @@ library BytesUtil
         pure
         returns (bytes4 data)
     {
-        return bytes4(bytesToBytesX(b, offset, 4));
+        return bytes4(bytesToBytesX(b, offset, 4) & 0xFFFFFFFF00000000000000000000000000000000000000000000000000000000);
     }
 
     function bytesToBytesX(

--- a/packages/loopring_v3/contracts/test/DelayedOwnerContract.sol
+++ b/packages/loopring_v3/contracts/test/DelayedOwnerContract.sol
@@ -1,0 +1,49 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "../impl/owners/DelayedOwner.sol";
+import "./DelayedTargetContract.sol";
+
+
+/// @title DelayedOwnerContract
+/// @author Brecht Devos - <brecht@loopring.org>
+contract DelayedOwnerContract is DelayedOwner
+{
+    constructor(
+        address delayedTargetAddress,
+        bool setDefaultFunctionDelays
+        )
+        DelayedOwner(delayedTargetAddress, 3 days)
+        public
+    {
+        if (setDefaultFunctionDelays) {
+            DelayedTargetContract delayedTarget = DelayedTargetContract(delayedTargetAddress);
+            setFunctionDelay(delayedTarget.delayedFunctionPayable.selector, 1 days);
+            setFunctionDelay(delayedTarget.delayedFunctionRevert.selector, 2 days);
+        }
+    }
+
+    function setFunctionDelayExternal(
+        bytes4 functionSelector,
+        uint   delay
+        )
+        external
+    {
+        setFunctionDelay(functionSelector, delay);
+    }
+}

--- a/packages/loopring_v3/contracts/test/DelayedTargetContract.sol
+++ b/packages/loopring_v3/contracts/test/DelayedTargetContract.sol
@@ -1,0 +1,73 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+
+/// @title DelayedTargetContract
+/// @author Brecht Devos - <brecht@loopring.org>
+contract DelayedTargetContract
+{
+    uint public constant MAGIC_VALUE = 0xFEDCBA987654321;
+    uint public value = 7;
+
+    function delayedFunctionPayable(
+        uint _value
+        )
+        external
+        payable
+        returns (uint)
+    {
+        value = _value;
+        return _value;
+    }
+
+    function delayedFunctionRevert(
+        uint _value
+        )
+        external
+    {
+        require(false, "DELAYED_REVERT");
+        value = _value;
+    }
+
+    function immediateFunctionPayable(
+        uint _value
+        )
+        external
+        payable
+    {
+        value = _value;
+    }
+
+    function immediateFunctionView()
+        external
+        pure
+        returns (uint)
+    {
+        return MAGIC_VALUE;
+    }
+
+    function immediateFunctionRevert(
+        uint _value
+        )
+        external
+        payable
+    {
+        require(false, "IMMEDIATE_REVERT");
+        value = _value;
+    }
+}

--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -11,11 +11,11 @@ contract("DelayedOwner", (accounts: string[]) => {
 
   let exchangeTestUtil: ExchangeTestUtil;
 
-  let oldValue: BN;
-  const newValue = new BN(123);
-
   let TTL: number;
   let MAGIC_VALUE: BN;
+
+  let oldValue: BN;
+  const newValue = new BN(123);
 
   const getFunctionSelector = (functionCall: any) => {
     return functionCall.encodeABI().slice(0, 10);

--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -402,7 +402,7 @@ contract("DelayedOwner", (accounts: string[]) => {
     }
   });
 
-  it("transaction expired by TTL", async () => {
+  it("Transaction expired by TTL", async () => {
     const ethToTransfer = new BN(web3.utils.toWei("2.34", "ether"));
 
     const functionSelectorA = getFunctionSelector(

--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -1,0 +1,489 @@
+import BN = require("bn.js");
+import { Artifacts } from "../util/Artifacts";
+import { ExchangeTestUtil } from "./testExchangeUtil";
+import { expectThrow } from "./expectThrow";
+
+contract("DelayedOwner", (accounts: string[]) => {
+  const contracts = new Artifacts(artifacts);
+  let targetContract: any;
+  let delayedContract: any;
+  let targetInterface: any;
+
+  let exchangeTestUtil: ExchangeTestUtil;
+
+  let oldValue: BN;
+  const newValue = new BN(123);
+
+  let TTL: number;
+  let MAGIC_VALUE: BN;
+
+  const getFunctionSelector = (functionCall: any) => {
+    return functionCall.encodeABI().slice(0, 10);
+  };
+
+  const getFunctionDelay = async (functionSelector: string) => {
+    return (await delayedContract.getFunctionDelay(
+      functionSelector
+    )).toNumber();
+  };
+
+  const checkFunctionDelay = async (
+    functionSelector: string,
+    delay: number
+  ) => {
+    const functionDelay = await getFunctionDelay(functionSelector);
+    assert.equal(functionDelay, delay, "invalid function delay");
+  };
+
+  const setFunctionDelayChecked = async (
+    functionSelector: string,
+    delay: number
+  ) => {
+    await delayedContract.setFunctionDelayExternal(
+      functionSelector,
+      new BN(delay)
+    );
+    await checkFunctionDelay(functionSelector, delay);
+  };
+
+  const cancelTransactionChecked = async (id: BN) => {
+    await delayedContract.cancelTransaction(id);
+    await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionCancelled",
+      (event: any) => {
+        return event.id.eq(id);
+      }
+    );
+  };
+
+  const checkNumDelayedFunctions = async (numExpected: number) => {
+    const numDelayedFunctions = (await delayedContract.getNumDelayedFunctions()).toNumber();
+    assert.equal(
+      numDelayedFunctions,
+      numExpected,
+      "unexpected number of delayed functions"
+    );
+  };
+
+  const checkNumPendingTransactions = async (numExpected: number) => {
+    const numPendingTransactions = (await delayedContract.getNumPendingTransactions()).toNumber();
+    assert.equal(
+      numPendingTransactions,
+      numExpected,
+      "unexpected number of pending transactions"
+    );
+  };
+
+  before(async () => {
+    exchangeTestUtil = new ExchangeTestUtil();
+  });
+
+  beforeEach(async () => {
+    targetContract = await contracts.DelayedTargetContract.new();
+    delayedContract = await contracts.DelayedOwnerContract.new(
+      targetContract.address,
+      true
+    );
+    targetInterface = await contracts.DelayedTargetContract.at(
+      delayedContract.address
+    );
+
+    TTL = (await delayedContract.timeToLive()).toNumber();
+    MAGIC_VALUE = await targetContract.MAGIC_VALUE();
+
+    oldValue = await targetContract.value();
+    assert(!oldValue.eq(newValue), "invalid test value");
+  });
+
+  it("Set function delay", async () => {
+    // Create a new delayed contract without any function delays set
+    delayedContract = await contracts.DelayedOwnerContract.new(
+      targetContract.address,
+      false
+    );
+
+    // Set some function delays
+    await setFunctionDelayChecked("0x00000001", 1);
+    await setFunctionDelayChecked("0x00000002", 2);
+    await setFunctionDelayChecked("0x00000003", 3);
+    await checkNumDelayedFunctions(3);
+
+    // Remove the delay of 2
+    await setFunctionDelayChecked("0x00000002", 0);
+    await checkNumDelayedFunctions(2);
+    // Check if the function delays of the remaining functions are still correct
+    checkFunctionDelay("0x00000001", 1);
+    checkFunctionDelay("0x00000003", 3);
+
+    // Remove the delay of 1
+    await setFunctionDelayChecked("0x00000001", 0);
+    await checkNumDelayedFunctions(1);
+    // Check if the function delays of the remaining functions are still correct
+    checkFunctionDelay("0x00000003", 3);
+
+    // Remove the delay of 3
+    await setFunctionDelayChecked("0x00000003", 0);
+    await checkNumDelayedFunctions(0);
+  });
+
+  it("Immediate function (payable)", async () => {
+    const ethToTransfer = new BN(web3.utils.toWei("1.23", "ether"));
+
+    // Check function delay
+    await checkFunctionDelay(
+      getFunctionSelector(
+        targetContract.contract.methods.immediateFunctionPayable(0)
+      ),
+      0
+    );
+
+    // Store the amount of ETH in the contract before the call
+    const balanceBefore = new BN(
+      await web3.eth.getBalance(targetContract.address)
+    );
+
+    await targetInterface.immediateFunctionPayable(newValue, {
+      value: ethToTransfer
+    });
+    assert(
+      (await targetContract.value()).eq(newValue),
+      "Test value unexpected"
+    );
+    await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionExecuted"
+    );
+    await checkNumPendingTransactions(0);
+
+    // Check the amount of ETH in the contract after the call
+    const balanceAfter = new BN(
+      await web3.eth.getBalance(targetContract.address)
+    );
+    assert(
+      balanceAfter.eq(balanceBefore.add(ethToTransfer)),
+      "ETH balance target contract incorrect"
+    );
+  });
+
+  it("Immediate function (view)", async () => {
+    // Check function delay
+    await checkFunctionDelay(
+      getFunctionSelector(
+        targetContract.contract.methods.immediateFunctionView()
+      ),
+      0
+    );
+
+    const returnValue = await targetInterface.immediateFunctionView();
+    assert(returnValue.eq(MAGIC_VALUE), "return value incorrect");
+  });
+
+  it("Immediate function (revert)", async () => {
+    // Check function delay
+    await checkFunctionDelay(
+      getFunctionSelector(
+        targetContract.contract.methods.immediateFunctionRevert(0)
+      ),
+      0
+    );
+
+    // Make sure the expected revert message is thrown
+    await expectThrow(
+      targetInterface.immediateFunctionRevert(0),
+      "IMMEDIATE_REVERT"
+    );
+  });
+
+  it("Delayed function (payable)", async () => {
+    const ethToTransfer = new BN(web3.utils.toWei("2.34", "ether"));
+
+    const functionSelector = getFunctionSelector(
+      targetContract.contract.methods.delayedFunctionPayable(0)
+    );
+    const functionDelay = await getFunctionDelay(functionSelector);
+    assert(functionDelay > 0, "invalid function delay");
+
+    // Store the amount of ETH in the contract before the call
+    const balanceBefore = new BN(
+      await web3.eth.getBalance(targetContract.address)
+    );
+
+    // Call the delayed function
+    await targetInterface.delayedFunctionPayable(newValue, {
+      value: ethToTransfer
+    });
+    assert(
+      (await targetContract.value()).eq(oldValue),
+      "Test value unexpected"
+    );
+    const event = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await checkNumPendingTransactions(1);
+
+    // Try to execute the transaction too early
+    await expectThrow(
+      delayedContract.executeTransaction(event.id),
+      "TOO_EARLY"
+    );
+    assert((await targetContract.value()).eq(oldValue));
+
+    // Wait
+    await exchangeTestUtil.advanceBlockTimestamp(functionDelay - 100);
+
+    // Try to execute the transaction too early
+    await expectThrow(
+      delayedContract.executeTransaction(event.id),
+      "TOO_EARLY"
+    );
+    assert((await targetContract.value()).eq(oldValue));
+
+    // Wait
+    await exchangeTestUtil.advanceBlockTimestamp(200);
+
+    // Balance of the target contract should still be the same
+    assert(
+      new BN(await web3.eth.getBalance(targetContract.address)).eq(
+        balanceBefore
+      ),
+      "ETH balance target contract incorrect"
+    );
+
+    // Now execute it after the necessary delay
+    delayedContract.executeTransaction(event.id);
+    assert(
+      (await targetContract.value()).eq(newValue),
+      "Test value unexpected"
+    );
+    await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "PendingTransactionExecuted"
+    );
+    await checkNumPendingTransactions(0);
+
+    // Try to execute the same delayed transaction again
+    await expectThrow(
+      delayedContract.executeTransaction(event.id),
+      "TRANSACTION_NOT_FOUND"
+    );
+
+    // Check the amount of ETH in the contract after the call
+    const balanceAfter = new BN(
+      await web3.eth.getBalance(targetContract.address)
+    );
+    assert(
+      balanceAfter.eq(balanceBefore.add(ethToTransfer)),
+      "ETH balance target contract incorrect"
+    );
+  });
+
+  it("Delayed function (revert)", async () => {
+    // Call the delayed function
+    await targetInterface.delayedFunctionRevert(0);
+    assert(
+      (await targetContract.value()).eq(oldValue),
+      "Test value unexpected"
+    );
+    const event = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+
+    // Wait
+    await exchangeTestUtil.advanceBlockTimestamp(event.delay.toNumber() + 100);
+
+    // Make sure the expected revert message is thrown
+    await expectThrow(
+      delayedContract.executeTransaction(event.id),
+      "DELAYED_REVERT"
+    );
+  });
+
+  it("Cancel pending transactions", async () => {
+    // Execture a few transactions that will be delayed
+    await targetInterface.delayedFunctionPayable(0);
+    const eventA = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(1);
+    const eventB = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(2);
+    const eventC = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(3);
+    const eventD = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await checkNumPendingTransactions(4);
+
+    // Now cancel a couple of transactions
+    await cancelTransactionChecked(eventC.id);
+    await cancelTransactionChecked(eventD.id);
+    await cancelTransactionChecked(eventA.id);
+    await checkNumPendingTransactions(1);
+
+    // Try to cancel the a transaction twice
+    await expectThrow(
+      delayedContract.executeTransaction(eventD.id),
+      "TRANSACTION_NOT_FOUND"
+    );
+
+    // Execute the last non-cancelled transaction
+    await exchangeTestUtil.advanceBlockTimestamp(eventB.delay.toNumber() + 100);
+    await delayedContract.executeTransaction(eventB.id);
+    assert(
+      (await targetContract.value()).eq(new BN(1)),
+      "Test value unexpected"
+    );
+    await checkNumPendingTransactions(0);
+
+    // Try to cancel the transaction after it has been executed
+    await expectThrow(
+      delayedContract.executeTransaction(eventB.id),
+      "TRANSACTION_NOT_FOUND"
+    );
+  });
+
+  it("Cancel all pending transactions", async () => {
+    // Execture a few transactions that will be delayed
+    await targetInterface.delayedFunctionPayable(0);
+    const eventA = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(1);
+    const eventB = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(2);
+    const eventC = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await targetInterface.delayedFunctionPayable(3);
+    const eventD = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+    await checkNumPendingTransactions(4);
+
+    // Put all pending transactions in a list
+    const transactionIds = [eventA.id, eventB.id, eventC.id, eventD.id];
+
+    // Cancel all transactions
+    await delayedContract.cancelAllTransactions();
+    await exchangeTestUtil.assertEventsEmitted(
+      delayedContract,
+      "TransactionCancelled",
+      transactionIds.length
+    );
+    await checkNumPendingTransactions(0);
+
+    // Try to execture or cancel the transactions again
+    for (const transactionId of transactionIds) {
+      await expectThrow(
+        delayedContract.executeTransaction(transactionId),
+        "TRANSACTION_NOT_FOUND"
+      );
+      await expectThrow(
+        delayedContract.cancelTransaction(transactionId),
+        "TRANSACTION_NOT_FOUND"
+      );
+    }
+  });
+
+  it("transaction expired by TTL", async () => {
+    const ethToTransfer = new BN(web3.utils.toWei("2.34", "ether"));
+
+    const functionSelectorA = getFunctionSelector(
+      targetContract.contract.methods.delayedFunctionPayable(0)
+    );
+    const functionDelayA = await getFunctionDelay(functionSelectorA);
+    assert(functionDelayA > 0, "invalid function delay");
+
+    // Store the amount of ETH in the contract before the call
+    const balanceBefore = new BN(
+      await web3.eth.getBalance(delayedContract.address)
+    );
+
+    // Call the delayed function
+    await targetInterface.delayedFunctionPayable(newValue, {
+      value: ethToTransfer
+    });
+    assert(
+      (await targetContract.value()).eq(oldValue),
+      "Test value unexpected"
+    );
+    const eventA = await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionDelayed"
+    );
+
+    // Balance of the target contract should still be the same
+    assert(
+      new BN(await web3.eth.getBalance(delayedContract.address)).eq(
+        balanceBefore.add(ethToTransfer)
+      ),
+      "ETH balance target contract incorrect"
+    );
+
+    // Wait
+    await exchangeTestUtil.advanceBlockTimestamp(functionDelayA + TTL + 100);
+
+    // Try to execute the transaction too late
+    await expectThrow(
+      delayedContract.executeTransaction(eventA.id),
+      "TOO_LATE"
+    );
+    assert((await targetContract.value()).eq(oldValue));
+
+    // Balance of the target contract should still be the same
+    assert(
+      new BN(await web3.eth.getBalance(delayedContract.address)).eq(
+        balanceBefore.add(ethToTransfer)
+      ),
+      "ETH balance target contract incorrect"
+    );
+
+    // Now cancel the transaction
+    await delayedContract.cancelTransaction(eventA.id);
+    assert(
+      (await targetContract.value()).eq(oldValue),
+      "Test value unexpected"
+    );
+    await exchangeTestUtil.assertEventEmitted(
+      delayedContract,
+      "TransactionCancelled"
+    );
+
+    // Try to execute the same transaction again
+    await expectThrow(
+      delayedContract.executeTransaction(eventA.id),
+      "TRANSACTION_NOT_FOUND"
+    );
+    // Try to cancel the same transaction again
+    await expectThrow(
+      delayedContract.cancelTransaction(eventA.id),
+      "TRANSACTION_NOT_FOUND"
+    );
+
+    // Check the amount of ETH in the contract after the call
+    const balanceAfter = new BN(
+      await web3.eth.getBalance(delayedContract.address)
+    );
+    assert(
+      balanceAfter.eq(balanceBefore),
+      "ETH balance target contract incorrect"
+    );
+  });
+});

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -396,7 +396,7 @@ export class ExchangeTestUtil {
     assert.equal(
       items.length,
       numExpected,
-      "Expected a single {} event",
+      "Unexpected number of events",
       event
     );
     return items;

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -380,7 +380,7 @@ export class ExchangeTestUtil {
     contract: any,
     event: string,
     numExpected: number,
-    filter: any = undefined
+    filter?: any
   ) {
     const eventArr: any = await this.getEventsFromContract(
       contract,
@@ -402,11 +402,7 @@ export class ExchangeTestUtil {
     return items;
   }
 
-  public async assertEventEmitted(
-    contract: any,
-    event: string,
-    filter: any = undefined
-  ) {
+  public async assertEventEmitted(contract: any, event: string, filter?: any) {
     return (await this.assertEventsEmitted(contract, event, 1, filter))[0];
   }
 

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -373,26 +373,45 @@ export class ExchangeTestUtil {
       });
   }
 
-  public async getTransferEvents(tokens: any[], fromBlock: number) {
-    let transferItems: Array<[string, string, string, BN]> = [];
-    for (const tokenContractInstance of tokens) {
-      const eventArr: any = await this.getEventsFromContract(
-        tokenContractInstance,
-        "Transfer",
-        fromBlock
-      );
-      const items = eventArr.map((eventObj: any) => {
-        return [
-          tokenContractInstance.address,
-          eventObj.args.from,
-          eventObj.args.to,
-          eventObj.args.value
-        ];
-      });
-      transferItems = transferItems.concat(items);
-    }
+  // This works differently from truffleAssert.eventEmitted in that it also is able to
+  // get events emmitted in `deep contracts` (i.e. events not emmitted in the contract
+  // the function got called in).
+  public async assertEventsEmitted(
+    contract: any,
+    event: string,
+    numExpected: number,
+    filter: any = undefined
+  ) {
+    const eventArr: any = await this.getEventsFromContract(
+      contract,
+      event,
+      web3.eth.blockNumber
+    );
+    const items = eventArr.map((eventObj: any) => {
+      if (filter !== undefined) {
+        assert(filter(eventObj.args), "Event values unexpected: " + eventObj);
+      }
+      return eventObj.args;
+    });
+    assert.equal(
+      items.length,
+      numExpected,
+      "Expected a single {} event",
+      event
+    );
+    return items;
+  }
 
-    return transferItems;
+  public async assertEventEmitted(
+    contract: any,
+    event: string,
+    filter: any = undefined
+  ) {
+    return (await this.assertEventsEmitted(contract, event, 1, filter))[0];
+  }
+
+  public async assertNoEventEmitted(contract: any, event: string) {
+    this.assertEventsEmitted(contract, event, 0, undefined);
   }
 
   public async setupRing(

--- a/packages/loopring_v3/util/Artifacts.ts
+++ b/packages/loopring_v3/util/Artifacts.ts
@@ -24,6 +24,8 @@ export class Artifacts {
   public ProtocolFeeVault: any;
   public UniswapTokenSeller: any;
   public AddressWhitelist: any;
+  public DelayedOwnerContract: any;
+  public DelayedTargetContract: any;
 
   constructor(artifacts: any) {
     this.MockContract = artifacts.require("thirdparty/MockContract.sol");
@@ -54,6 +56,9 @@ export class Artifacts {
       "./impl/SignatureBasedAddressWhitelist.sol"
     );
     this.ProtocolFeeVault = artifacts.require("impl/ProtocolFeeVault");
-    this.UniswapTokenSeller = artifacts.require("impl/UniswapTokenSeller");
+    this.DelayedOwnerContract = artifacts.require("test/DelayedOwnerContract");
+    this.DelayedTargetContract = artifacts.require(
+      "test/DelayedTargetContract"
+    );
   }
 }


### PR DESCRIPTION
On our current smart contracts there are some critical values that the owner of the contract could immediately change (like changing the verification keys so proofs can be constructed using any rules) which is a big security issues for users.

This PR has a simple base contract that enforces a mandatory delay on specified function calls. This means that if the owner of a contract is malicious, users can observe the malicious intent and act before the function call actually can be executed.

In the future this can be done with more advanced mechanisms like a DAO, but this seems to be a good compromise between security/simplicity in the short/medium term.