### PR TITLE
[tokenbank] Some re-entrancy changes

### DIFF
--- a/packages/tokenbank_v1/contracts/base/BaseModule.sol
+++ b/packages/tokenbank_v1/contracts/base/BaseModule.sol
@@ -107,7 +107,6 @@ contract BaseModule is Module, ReentrancyGuard
     /// @dev This method will cause an re-entry to the same module contract.
     function activate(address wallet)
         external
-        nonReentrantExceptFrom(wallet)
         onlyFromWallet(wallet)
     {
         bindStaticMethods(wallet);
@@ -117,7 +116,6 @@ contract BaseModule is Module, ReentrancyGuard
     /// @dev This method will cause an re-entry to the same module contract.
     function deactivate(address wallet)
         external
-        nonReentrantExceptFrom(wallet)
         onlyFromWallet(wallet)
     {
         unbindStaticMethods(wallet);

--- a/packages/tokenbank_v1/contracts/base/BaseWallet.sol
+++ b/packages/tokenbank_v1/contracts/base/BaseWallet.sol
@@ -86,9 +86,8 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         return _owner;
     }
 
-    function setOwenr(address newOwner)
+    function setOwner(address newOwner)
         external
-        nonReentrant
         onlyModule
     {
         require(newOwner != address(0), "ZERO_ADDRESS");
@@ -119,7 +118,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
 
     function addModule(address _module)
         external
-        nonReentrant
         onlyModule
     {
         addModuleInternal(_module);
@@ -128,7 +126,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
     function removeModule(address _module)
         external
         onlyModule
-        nonReentrant
     {
         require(numAddressesInSet(MODULE) > 1, "PROHIBITED");
         Module(_module).deactivate(address(this));
@@ -154,7 +151,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
 
     function bindStaticMethod(bytes4 _method, address _module)
         external
-        nonReentrant
         onlyModule
     {
         require(_method != bytes4(0) && !isLocalStaticMethod(_method), "BAD_METHOD");
@@ -199,7 +195,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         address token
         )
         external
-        nonReentrant
         onlyModule
         returns (bool success)
     {
@@ -228,7 +223,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         bytes   calldata data
         )
         external
-        nonReentrant
         onlyModule
         returns (bytes memory result)
     {
@@ -254,6 +248,8 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         internal
         returns (bytes memory result)
     {
+        require(!bankRegistry.isModuleRegistered(to), "CANNOT_TRANSACT_WITH_MODULE");
+
         bool success;
         // solium-disable-next-line security/no-call-value
         (success, result) = to.call.value(value)(data);

--- a/packages/tokenbank_v1/contracts/base/BaseWallet.sol
+++ b/packages/tokenbank_v1/contracts/base/BaseWallet.sol
@@ -248,8 +248,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         internal
         returns (bytes memory result)
     {
-        require(!bankRegistry.isModuleRegistered(to), "CANNOT_TRANSACT_WITH_MODULE");
-
         bool success;
         // solium-disable-next-line security/no-call-value
         (success, result) = to.call.value(value)(data);

--- a/packages/tokenbank_v1/contracts/lib/ReentrancyGuard.sol
+++ b/packages/tokenbank_v1/contracts/lib/ReentrancyGuard.sol
@@ -35,28 +35,4 @@ contract ReentrancyGuard
         _;
         _guardValue = 0;
     }
-
-    modifier nonReentrantExceptFrom(address addr)
-    {
-        if (msg.sender != addr) {
-            require(_guardValue == 0, "REENTRANCY");
-            _guardValue = 1;
-        }
-        _;
-        if (msg.sender != addr) {
-            _guardValue = 0;
-        }
-    }
-
-    modifier nonReentrantExceptFromThis()
-    {
-        if (msg.sender != address(this)) {
-            require(_guardValue == 0, "REENTRANCY");
-            _guardValue = 1;
-        }
-        _;
-        if (msg.sender != address(this)) {
-            _guardValue = 0;
-        }
-    }
 }

--- a/packages/tokenbank_v1/contracts/modules/loopring/ExchangeModule.sol
+++ b/packages/tokenbank_v1/contracts/modules/loopring/ExchangeModule.sol
@@ -31,7 +31,7 @@ contract ExchangeModule is SecurityModule
         IExchangeV3        exchange
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {

--- a/packages/tokenbank_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/tokenbank_v1/contracts/modules/security/GuardianModule.sol
@@ -59,7 +59,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
         notWalletGuardian(wallet, guardian)
@@ -84,7 +84,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {
@@ -101,7 +101,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {
@@ -116,7 +116,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
         onlyWalletGuardian(wallet, guardian)
@@ -132,7 +132,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {
@@ -149,7 +149,7 @@ contract GuardianModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {

--- a/packages/tokenbank_v1/contracts/modules/security/LockModule.sol
+++ b/packages/tokenbank_v1/contracts/modules/security/LockModule.sol
@@ -70,7 +70,7 @@ contract LockModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOr(guardian)
         onlyWalletGuardian(wallet, guardian)
         onlyWhenWalletUnlocked(wallet)
@@ -85,7 +85,7 @@ contract LockModule is SecurityModule
         address guardian
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTxOr(guardian)
         onlyWalletGuardian(wallet, guardian)
         onlyWhenWalletLocked(wallet)

--- a/packages/tokenbank_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/tokenbank_v1/contracts/modules/security/RecoveryModule.sol
@@ -69,7 +69,7 @@ contract RecoveryModule is SecurityModule
         address            newOwner
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
         notWalletOwner(wallet, newOwner)
     {
@@ -100,7 +100,7 @@ contract RecoveryModule is SecurityModule
         address[] calldata signers // enforece data-layout, see extractMetaTxSigners.
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
     {
         WalletRecovery storage recovery = wallets[wallet];
@@ -124,7 +124,7 @@ contract RecoveryModule is SecurityModule
         address[] calldata signers
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
     {
         require(signers.length == 0, "NO_SIGNER_NEEDED");
 

--- a/packages/tokenbank_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/tokenbank_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -39,7 +39,7 @@ contract ApprovedTransfers is TransferModule
         bytes     calldata data
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
     {
@@ -58,7 +58,7 @@ contract ApprovedTransfers is TransferModule
         uint               amount
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
         notWalletOrItsModule(wallet, to)
@@ -78,7 +78,7 @@ contract ApprovedTransfers is TransferModule
         bytes     calldata data
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
         notWalletOrItsModule(wallet, to)
@@ -99,7 +99,7 @@ contract ApprovedTransfers is TransferModule
         bytes     calldata data
         )
         external
-        nonReentrantExceptFromThis
+        nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
         notWalletOrItsModule(wallet, to)

--- a/packages/tokenbank_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/tokenbank_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -29,7 +29,6 @@ contract UpgraderModule is BaseModule {
 
     function activate(address wallet)
         external
-        nonReentrantExceptFrom(wallet)
         onlyFromWallet(wallet)
     {
         Wallet w = Wallet(wallet);
@@ -51,7 +50,6 @@ contract UpgraderModule is BaseModule {
 
     function deactivate(address wallet)
         external
-        nonReentrantExceptFrom(wallet)
         onlyFromWallet(wallet)
     {
         emit Deactivated(wallet);


### PR DESCRIPTION
Some changes so that re-entrancy is easier (hopefully). It should also fix some interactions between the wallet and module that wouldn't work with the current code:
```
addModule (wallet, nonReentrant)
 activate (module)
  bindStaticMethod (wallet, nonReentrant - fails because re-entrancy is detected)
```

I think the cleanest solution to this is that all communications wallet <-> modules are inherently safe because all code is written/approved by us. So if a wallet function is `onlyModule` it's safe, if a module function is `onlyFromWallet` it is also safe (`transact` is also only callable by a module, and only with a select number of functions known beforehand. If this would not be the case we would have to make sure `transact` can't call a function on a module directly, otherwise it would be possible to call e.g. `activate` on a module without going through a module). This also seems to make sense logically because wallet + modules kind of act as a single entity so they are basically internal methods if you would write everything in a single contract.

In all other cases `nonReentrant` can be used as usual, with `executeMetaTx` being the exception in that it needs to follow the 'Checks Effects Interactions' pattern, which is very easy and was already the case.