### PR TITLE
[hebao] Changes to module activation/deactivation

### DIFF
--- a/packages/hebao_v1/contracts/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/base/BaseModule.sol
@@ -115,7 +115,7 @@ contract BaseModule is Module, ReentrancyGuard
         external
         onlyFromWalletModule(wallet)
     {
-        bindStaticMethods(wallet);
+        bindMethods(wallet);
         emit Activated(wallet);
     }
 
@@ -124,16 +124,16 @@ contract BaseModule is Module, ReentrancyGuard
         external
         onlyFromWalletModule(wallet)
     {
-        unbindStaticMethods(wallet);
+        unbindMethods(wallet);
         emit Deactivated(wallet);
     }
 
-    ///.@dev Gets the list of static methods for binding to wallets.
-    ///      Sub-contracts should override this method to provide readonly methods for
+    ///.@dev Gets the list of methods for binding to wallets.
+    ///      Sub-contracts should override this method to provide methods for
     ///      wallet binding.
-    /// @return methods A list of static method selectors for binding to the wallet
+    /// @return methods A list of method selectors for binding to the wallet
     ///         when this module is activated for the wallet.
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)
@@ -142,25 +142,25 @@ contract BaseModule is Module, ReentrancyGuard
 
     // ===== internal & private methods =====
 
-    /// @dev Binds all static methods to the given wallet.
-    function bindStaticMethods(address wallet)
+    /// @dev Binds all methods to the given wallet.
+    function bindMethods(address wallet)
         internal
     {
         Wallet w = Wallet(wallet);
-        bytes4[] memory methods = staticMethods();
+        bytes4[] memory methods = boundMethods();
         for (uint i = 0; i < methods.length; i++) {
-            w.bindStaticMethod(methods[i], address(this));
+            w.bindMethod(methods[i], address(this));
         }
     }
 
-    /// @dev Unbinds all static methods from the given wallet.
-    function unbindStaticMethods(address wallet)
+    /// @dev Unbinds all methods from the given wallet.
+    function unbindMethods(address wallet)
         internal
     {
         Wallet w = Wallet(wallet);
-        bytes4[] memory methods = staticMethods();
+        bytes4[] memory methods = boundMethods();
         for (uint i = 0; i < methods.length; i++) {
-            w.bindStaticMethod(methods[i], address(0));
+            w.bindMethod(methods[i], address(0));
         }
     }
 

--- a/packages/hebao_v1/contracts/base/BaseWallet.sol
+++ b/packages/hebao_v1/contracts/base/BaseWallet.sol
@@ -45,7 +45,7 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
     event OwnerChanged          (address indexed newOwner);
     event ModuleAdded           (address indexed module);
     event ModuleRemoved         (address indexed module);
-    event StaticMethodBound     (bytes4  indexed method, address indexed module);
+    event MethodBound           (bytes4  indexed method, address indexed module);
 
     event WalletSetup(address indexed owner);
 
@@ -145,7 +145,7 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         return isAddressInSet(MODULE, _module);
     }
 
-    function bindStaticMethod(bytes4 _method, address _module)
+    function bindMethod(bytes4 _method, address _module)
         external
         onlyModule
     {
@@ -154,10 +154,10 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         require(bankRegistry.isModuleRegistered(_module), "UNREGISTERED_MODULE");
 
         methodToModule[_method] = _module;
-        emit StaticMethodBound(_method, _module);
+        emit MethodBound(_method, _module);
     }
 
-    function staticMethodModule(bytes4 _method)
+    function boundMethodModule(bytes4 _method)
         public
         view
         returns (address)
@@ -217,8 +217,8 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         emit Transacted(msg.sender, to, value, data);
     }
 
-    /// @dev This default function can receive Ether or perform queris to modules
-    ///      using staticly bound methods.
+    /// @dev This default function can receive Ether or perform queries to modules
+    ///      using bound methods.
     function()
         external
         payable
@@ -248,7 +248,7 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         }
     }
 
-    function isLocalStaticMethod(bytes4 _method)
+    function isLocalMethod(bytes4 _method)
         private
         pure
         returns (bool)
@@ -256,6 +256,6 @@ contract BaseWallet is Wallet, AddressSet, ReentrancyGuard
         return _method == this.owner.selector ||
             _method == this.modules.selector ||
             _method == this.hasModule.selector ||
-            _method == this.staticMethodModule.selector;
+            _method == this.boundMethodModule.selector;
     }
 }

--- a/packages/hebao_v1/contracts/base/ERC1271Module.sol
+++ b/packages/hebao_v1/contracts/base/ERC1271Module.sol
@@ -32,7 +32,7 @@ contract ERC1271Module is BaseModule, ERC1271
 {
     using SignatureUtil for bytes32;
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)
@@ -41,7 +41,7 @@ contract ERC1271Module is BaseModule, ERC1271
         methods[0] = this.isValidSignature.selector;
     }
 
-    /// @dev This is a static method bound to wallet.
+    /// @dev This is a method bound to wallet.
     ///      It checks if the current wallet owner is the data signer.
     function isValidSignature(
         bytes memory _data,

--- a/packages/hebao_v1/contracts/iface/Wallet.sol
+++ b/packages/hebao_v1/contracts/iface/Wallet.sol
@@ -68,20 +68,20 @@ contract Wallet
     /// @return True if the module exists; False otherwise.
     function hasModule(address _module) public view returns (bool);
 
-    /// @dev Binds a static (readonly) method from the given module to this
+    /// @dev Binds a method from the given module to this
     ///      wallet so the method can be invoked using this wallet's default
     ///      function.
     ///      Note that this method must throw when the given module has
     ///      not been added to this wallet.
     /// @param _method The method's 4-byte selector.
     /// @param _module The module's address. Use address(0) to unbind the method.
-    function bindStaticMethod(bytes4 _method, address _module) external;
+    function bindMethod(bytes4 _method, address _module) external;
 
     /// @dev Returns the module the given method has been bound to.
     /// @param _method The method's 4-byte selector.
     /// @return _module The address of the bound module. If no binding exists,
     ///                 returns address(0) instead.
-    function staticMethodModule(bytes4 _method) public view returns (address _module);
+    function boundMethodModule(bytes4 _method) public view returns (address _module);
 
     /// @dev Performs generic transactions. Any module that has been added to this
     ///      wallet can use this method to transact on any third-party contract with

--- a/packages/hebao_v1/contracts/modules/dapps/UniswapModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/UniswapModule.sol
@@ -37,7 +37,7 @@ contract UniswapModule is SecurityModule
     {
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
+++ b/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
@@ -64,7 +64,7 @@ contract LoopringModule is SecurityModule
         reimbursementStore = _reimbursementStore;
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -50,7 +50,7 @@ contract InheritanceModule is SecurityModule
         waitingPeriod = _waitingPeriod;
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/security/LockModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/LockModule.sol
@@ -56,7 +56,7 @@ contract LockModule is SecurityModule
         lockPeriod = _lockPeriod;
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
@@ -66,7 +66,7 @@ contract QuotaModule is SecurityModule
         available = quotaStore.availableQuota(wallet);
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -82,7 +82,7 @@ contract WhitelistModule is SecurityModule
         return whitelistStore.isWhitelisted(wallet, addr);
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
@@ -65,7 +65,7 @@ contract QuotaTransfers is Claimable, TransferModule
         pendingExpiry = _pendingExpiry;
     }
 
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/transfers/TokenBalances.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TokenBalances.sol
@@ -24,7 +24,7 @@ import "../../base/BaseModule.sol";
 /// @title TokenBalances
 contract TokenBalances is BaseModule
 {
-    function staticMethods()
+    function boundMethods()
         public
         pure
         returns (bytes4[] memory methods)

--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -29,28 +29,32 @@ contract UpgraderModule is BaseModule {
 
     function activate(address wallet)
         external
-        onlyFromWallet(wallet)
+        onlyFromWalletModule(wallet)
     {
         Wallet w = Wallet(wallet);
         for(uint i = 0; i < modulesToAdd.length; i++) {
             if (!w.hasModule(modulesToAdd[i])) {
                 w.addModule(modulesToAdd[i]);
+                Module(modulesToAdd[i]).activate(wallet);
             }
         }
         for(uint i = 0; i < modulesToRemove.length; i++) {
             if (w.hasModule(modulesToRemove[i])) {
+                Module(modulesToRemove[i]).deactivate(wallet);
                 w.removeModule(modulesToRemove[i]);
             }
         }
 
         emit Activated(wallet);
 
+        deactivate(wallet);
         w.removeModule(address(this));
     }
 
+
     function deactivate(address wallet)
-        external
-        onlyFromWallet(wallet)
+        public
+        onlyFromWalletModule(wallet)
     {
         emit Deactivated(wallet);
     }


### PR DESCRIPTION
I'm still not completely happy with this PR (adding/removing modules is less clean than before), but I do think the positives far outweigh the negatives.

With the current code the module can call into the module for activation/deactivation, which kind of complicates things a bit. In the best case, which makes things easier, everything is callable using `transact` or the fallback function without any limitations or caveats. The current exceptions are `activation` and `deactivation` which should not be callable by the wallet except when adding/removing modules. 

To solve this in this PR the wallet doesn't call `activate` and `deactivate` any more, those can now be called by the module adding/removing the module. This also means that the wallet itself has zero dependencies on modules. A module is now just an address for the wallet. The interface of a module is now just for other modules to add/remove the wallet, which could in theory change.

This also allows us to safely forward any call in the fallback function (not just staticcalls). If a module wants to catch a call that has passed through the wallet it can simply bind the method and check that `msg.sender` is the wallet address. This is different from before where we had to be careful not to call the wrong function from the wallet address. Using this PR any call to any contract can be made from the wallet.

This can be helpful for certain token standards (see [EIP-1155](`https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1155.md) which calls `onERC1155Received` on the smart contract). By having a `call` instead of a `staticcall` we can now more than before when catching these (like logging an event, which is not possible with `staticcall`). We could even append the original `msg.sender` so the module can check the origin of the call into the fallback function.

