### PR TITLE
[hebao] Better meta transaction authorization checks

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -68,7 +68,8 @@ contract InheritanceModule is SecurityModule
     }
 
     function inherit(
-        address wallet
+        address wallet,
+        address[] calldata /*signers*/
         )
         external
         nonReentrant
@@ -106,7 +107,7 @@ contract InheritanceModule is SecurityModule
     function extractMetaTxSigners(
         bytes4  method,
         address wallet,
-        bytes   memory /*data*/
+        bytes   memory data
         )
         internal
         view
@@ -116,8 +117,7 @@ contract InheritanceModule is SecurityModule
             signers = new address[](1);
             signers[0] = Wallet(wallet).owner();
         } else if (method == this.inherit.selector) {
-            signers = new address[](1);
-            (signers[0],) = controller.securityStore().inheritor(wallet);
+            return extractAddressesFromCallData(data, 1);
         } else {
             revert("INVALID_METHOD");
         }

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -87,7 +87,6 @@ contract RecoveryModule is SecurityModule
         }
 
         require(signers.length >= requiredCount, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         recovery.newOwner = newOwner;
         recovery.completeAfter = now + recoveryPeriod;
@@ -115,7 +114,6 @@ contract RecoveryModule is SecurityModule
 
         uint guardianCount = wallets[wallet].guardianCount;
         require(signers.length >= (guardianCount + 1) / 2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         delete wallets[wallet];
         controller.securityStore().setLock(wallet, 0);
@@ -128,13 +126,11 @@ contract RecoveryModule is SecurityModule
     /// @param wallet The wallet for which the recovery shall complete.
     function completeRecovery(
         address            wallet,
-        address[] calldata signers
+        address[] calldata /*signers*/
         )
         external
         nonReentrant
     {
-        require(signers.length == 0, "NO_SIGNER_NEEDED");
-
         WalletRecovery storage recovery = wallets[wallet];
         require(recovery.completeAfter > 0, "NOT_STARTED");
         require(recovery.completeAfter < now, "TWO_EARLY");

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -92,30 +92,6 @@ contract SecurityModule is MetaTxModule
         _;
     }
 
-    function isWalletOwnerOrGuardian(address wallet, address addr)
-        internal
-        view
-        returns (bool)
-    {
-        return Wallet(wallet).owner() == addr ||
-            controller.securityStore().isGuardian(wallet, addr);
-    }
-
-    function isWalletOwnerOrGuardian(address wallet, address[] memory addrs)
-        internal
-        view
-        returns (bool)
-    {
-        if (addrs.length == 0) return false;
-
-        for (uint i = 0; i < addrs.length; i++) {
-            if (!isWalletOwnerOrGuardian(wallet, addrs[i])) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     function quotaManager() internal view returns (address)
     {
         return address(controller.quotaManager());

--- a/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -46,7 +46,6 @@ contract ApprovedTransfers is TransferModule
     {
         uint guardianCount = controller.securityStore().numGuardians(wallet);
         require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         transferInternal(wallet, token, to, amount, logdata);
     }
@@ -65,7 +64,6 @@ contract ApprovedTransfers is TransferModule
     {
         uint guardianCount = controller.securityStore().numGuardians(wallet);
         require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         for (uint i = 0; i < tokens.length; i++) {
             address token = tokens[i];
@@ -89,7 +87,6 @@ contract ApprovedTransfers is TransferModule
     {
         uint guardianCount = controller.securityStore().numGuardians(wallet);
         require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         approveInternal(wallet, token, to, amount);
     }
@@ -108,7 +105,6 @@ contract ApprovedTransfers is TransferModule
     {
         uint guardianCount = controller.securityStore().numGuardians(wallet);
         require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         callContractInternal(wallet, to, amount, data);
     }
@@ -128,7 +124,6 @@ contract ApprovedTransfers is TransferModule
     {
         uint guardianCount = controller.securityStore().numGuardians(wallet);
         require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-        require(isWalletOwnerOrGuardian(wallet, signers), "UNAUTHORIZED");
 
         approveInternal(wallet, token, to, amount);
         callContractInternal(wallet, to, 0, data);


### PR DESCRIPTION
A meta transaction needs to be signed by a trusted signer, otherwise anyone can create a meta tx for a wallet and spend funds on gas reimbursement. This signers need to be checked before the meta-tx `call` is executed because the `call` is allowed to fail.

Not really sure if this is the best solution.