### PR TITLE
[hebao] Guardian grouping

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -65,7 +65,7 @@ library GuardianUtils
         bool walletOwnerSigned = false;
         SecurityStore.Guardian[] memory signingGuardians = new SecurityStore.Guardian[](signers.length);
         uint numGuardians = 0;
-        for (uint i = 0; i < 0; i++) {
+        for (uint i = 0; i < signers.length; i++) {
             if (signers[i] == walletOwner) {
                 walletOwnerSigned = true;
             } else {
@@ -89,6 +89,7 @@ library GuardianUtils
         if (numFriends + numFamily + numSocialOther == 0) {
             /* Self authentication */
             uint numSelfControlledSignersRequired = 2;
+
             // If the owner is allowed to sign:
             // - increase the total number of self controlled guardians
             // - increase the number of required self controlled guardians

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -1,0 +1,164 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+import "./SecurityModule.sol";
+
+
+/// @title GuardianType
+/// @author Brecht Devos - <brecht@loopring.org>
+library GuardianType
+{
+    function None()            internal pure returns (uint) { return      0; }
+    function EOA()             internal pure returns (uint) { return 1 << 0; }
+    function SelfControlled()  internal pure returns (uint) { return 1 << 1; }
+    function Hardware()        internal pure returns (uint) { return 1 << 2; }
+    function Device()          internal pure returns (uint) { return 1 << 3; }
+    function Service()         internal pure returns (uint) { return 1 << 4; }
+    function Family()          internal pure returns (uint) { return 1 << 5; }
+    function Friend()          internal pure returns (uint) { return 1 << 6; }
+}
+
+library GuardianUtils
+{
+    enum SigRequirement
+    {
+        OwnerNotAllowed,
+        OwnerAllowed,
+        OwnerRequired
+    }
+
+    function requireSufficientSigners(
+        SecurityStore   securityStore,
+        address         wallet,
+        address[]       memory signers,
+        SigRequirement  requirement
+        )
+        internal
+        view
+    {
+        // Calculate total group sizes
+        SecurityStore.Guardian[] memory allGuardians = securityStore.guardians(wallet);
+        (
+            uint totalNumSelfControlled,
+            uint totalNumFriends,
+            uint totalNumFamily,
+            uint totalNumSocialOther
+        ) = countGuardians(allGuardians);
+
+        // Calculate how many signers are in each group
+        address walletOwner = Wallet(wallet).owner();
+        bool walletOwnerSigned = false;
+        SecurityStore.Guardian[] memory signingGuardians = new SecurityStore.Guardian[](signers.length);
+        uint numGuardians = 0;
+        for (uint i = 0; i < 0; i++) {
+            if (signers[i] == walletOwner) {
+                walletOwnerSigned = true;
+            } else {
+                signingGuardians[numGuardians++] = securityStore.getGuardian(wallet, signers[i]);
+            }
+        }
+        // Update the signingGuardians array with the actual number of guardians that have signed
+        // (could be 1 less than the length if the owner signed as well)
+        assembly { mstore(signingGuardians, numGuardians) }
+        (
+            uint numSelfControlled,
+            uint numFriends,
+            uint numFamily,
+            uint numSocialOther
+        ) = countGuardians(signingGuardians);
+
+        if (requirement == SigRequirement.OwnerRequired) {
+            require(walletOwnerSigned, "WALLET_OWNER_SIGNATURE_REQUIRED");
+        }
+
+        if (numSelfControlled > 0) {
+            /* Self authentication */
+            uint numSelfControlledSignersRequired = 2;
+            // If the owner is allowed to sign:
+            // - increase the total number of self controlled guardians
+            // - increase the number of required self controlled guardians
+            if (requirement != SigRequirement.OwnerNotAllowed) {
+                totalNumSelfControlled += 1;
+                numSelfControlledSignersRequired += 1;
+            }
+            // Count the wallet owner as a self controlled guardian
+            if (walletOwnerSigned) {
+                numSelfControlled += 1;
+            }
+            if (totalNumSelfControlled >= numSelfControlledSignersRequired) {
+                require(numSelfControlled >= numSelfControlledSignersRequired, "NOT_ENOUGH_SIGNERS");
+            } else {
+                require(numSelfControlled == totalNumSelfControlled, "NOT_ENOUGH_SIGNERS");
+            }
+        } else {
+            /* Social authentication */
+            uint numGroupsActive = 0;
+            uint numGroupsSatisfied = 0;
+
+            if (totalNumFriends > 0) {
+                numGroupsActive++;
+                numGroupsSatisfied += isGroupCriteriaValid(numFriends, totalNumFriends) ? 1 : 0;
+            }
+            if (totalNumFamily > 0) {
+                numGroupsActive++;
+                numGroupsSatisfied += isGroupCriteriaValid(numFamily, totalNumFamily) ? 1 : 0;
+            }
+            if (totalNumSocialOther > 0) {
+                numGroupsActive++;
+                numGroupsSatisfied += isGroupCriteriaValid(numSocialOther, totalNumSocialOther) ? 1 : 0;
+            }
+
+            require(numGroupsActive > 0, "SOCIAL_RECOVERY_IMPOSSIBLE");
+            require(numGroupsSatisfied >= (numGroupsActive*2 + 2) / 3, "NOT_ENOUGH_SIGNERS");
+        }
+    }
+
+    function isGroupCriteriaValid(
+        uint numSigners,
+        uint numTotal
+        )
+        internal
+        pure
+        returns (bool)
+    {
+        return (numSigners >= (numTotal + 1) / 2);
+    }
+
+    function countGuardians(
+        SecurityStore.Guardian[] memory guardians
+        )
+        internal
+        pure
+        returns (uint numSelfControlled, uint numFriends, uint numFamily, uint numSocialOther)
+    {
+        for (uint i = 0; i < guardians.length; i++) {
+            if(guardians[i].info & GuardianType.SelfControlled() != 0) {
+                numSelfControlled++;
+            } else {
+                if(guardians[i].info & GuardianType.Friend() != 0) {
+                    numFriends++;
+                } else if(guardians[i].info & GuardianType.Family() != 0) {
+                    numFamily++;
+                } else {
+                    numSocialOther++;
+                }
+            }
+        }
+    }
+}
+

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -86,7 +86,7 @@ library GuardianUtils
             require(walletOwnerSigned, "WALLET_OWNER_SIGNATURE_REQUIRED");
         }
 
-        if (numSelfControlled > 0) {
+        if (numFriends + numFamily + numSocialOther == 0) {
             /* Self authentication */
             uint numSelfControlledSignersRequired = 2;
             // If the owner is allowed to sign:
@@ -100,6 +100,7 @@ library GuardianUtils
             if (walletOwnerSigned) {
                 numSelfControlled += 1;
             }
+            require(totalNumSelfControlled > 0, "SELF_AUTHENTICATION_IMPOSSIBLE");
             if (totalNumSelfControlled >= numSelfControlledSignersRequired) {
                 require(numSelfControlled >= numSelfControlledSignersRequired, "NOT_ENOUGH_SIGNERS");
             } else {
@@ -123,7 +124,7 @@ library GuardianUtils
                 numGroupsSatisfied += isGroupCriteriaValid(numSocialOther, totalNumSocialOther) ? 1 : 0;
             }
 
-            require(numGroupsActive > 0, "SOCIAL_RECOVERY_IMPOSSIBLE");
+            require(numGroupsActive > 0, "SOCIAL_AUTHENTICATION_IMPOSSIBLE");
             require(numGroupsSatisfied >= (numGroupsActive*2 + 2) / 3, "NOT_ENOUGH_SIGNERS");
         }
     }

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -46,7 +46,12 @@ contract RecoveryModule is SecurityModule
     uint public recoveryPeriod;
     uint public lockPeriod;
 
-    modifier onlySufficientSigners(address wallet, address[] memory signers, GuardianUtils.SigRequirement requirement) {
+    modifier onlySufficientSigners(
+        address wallet,
+        address[] memory signers,
+        GuardianUtils.SigRequirement requirement
+        )
+    {
         GuardianUtils.requireSufficientSigners(
             securityStore,
             wallet,

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -26,6 +26,7 @@ import "../../thirdparty/ERC1271.sol";
 import "../../iface/Wallet.sol";
 
 import "./SecurityModule.sol";
+import "./GuardianUtils.sol";
 
 
 /// @title RecoveryModule
@@ -44,6 +45,16 @@ contract RecoveryModule is SecurityModule
     mapping (address => WalletRecovery) public wallets;
     uint public recoveryPeriod;
     uint public lockPeriod;
+
+    modifier onlySufficientSigners(address wallet, address[] memory signers, GuardianUtils.SigRequirement requirement) {
+        GuardianUtils.requireSufficientSigners(
+            securityStore,
+            wallet,
+            signers,
+            requirement
+        );
+        _;
+    }
 
     constructor(
         Controller _controller,
@@ -72,25 +83,16 @@ contract RecoveryModule is SecurityModule
         nonReentrant
         onlyFromMetaTx
         notWalletOwner(wallet, newOwner)
+        onlySufficientSigners(wallet, signers, GuardianUtils.SigRequirement.OwnerNotAllowed)
     {
         require(newOwner != address(0), "ZERO_ADDRESS");
 
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(guardianCount > 0, "NO_GUARDIAN");
-
         WalletRecovery storage recovery = wallets[wallet];
-        require(recovery.completeAfter == 0, "ALREAY_STARTED");
-
-        uint requiredCount = guardianCount / 2;
-        if (guardianCount % 2 == 1) {
-            requiredCount += 1;
-        }
-
-        require(signers.length >= requiredCount, "NOT_ENOUGH_SIGNER");
+        require(recovery.completeAfter == 0, "ALREADY_STARTED");
 
         recovery.newOwner = newOwner;
         recovery.completeAfter = now + recoveryPeriod;
-        recovery.guardianCount = guardianCount;
+        recovery.guardianCount = securityStore.numGuardians(wallet);
 
         controller.securityStore().setLock(wallet, now + lockPeriod);
 
@@ -108,12 +110,10 @@ contract RecoveryModule is SecurityModule
         external
         nonReentrant
         onlyFromMetaTx
+        onlySufficientSigners(wallet, signers, GuardianUtils.SigRequirement.OwnerAllowed)
     {
         WalletRecovery storage recovery = wallets[wallet];
         require(recovery.completeAfter > 0, "NOT_STARTED");
-
-        uint guardianCount = wallets[wallet].guardianCount;
-        require(signers.length >= (guardianCount + 1) / 2, "NOT_ENOUGH_SIGNER");
 
         delete wallets[wallet];
         controller.securityStore().setLock(wallet, 0);

--- a/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -21,10 +21,22 @@ import "../../lib/ERC20.sol";
 
 import "./TransferModule.sol";
 
+import "../security/GuardianUtils.sol";
+
 
 /// @title ApprovedTransfers
 contract ApprovedTransfers is TransferModule
 {
+    modifier onlySufficientSigners(address wallet, address[] memory signers) {
+        GuardianUtils.requireSufficientSigners(
+            securityStore,
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        );
+        _;
+    }
+
     constructor(Controller _controller)
         public
         TransferModule(_controller)
@@ -43,10 +55,8 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
+        onlySufficientSigners(wallet, signers)
     {
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-
         transferInternal(wallet, token, to, amount, logdata);
     }
 
@@ -61,10 +71,8 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
+        onlySufficientSigners(wallet, signers)
     {
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-
         for (uint i = 0; i < tokens.length; i++) {
             address token = tokens[i];
             uint amount = (token == address(0)) ?
@@ -84,10 +92,8 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
+        onlySufficientSigners(wallet, signers)
     {
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-
         approveInternal(wallet, token, to, amount);
     }
 
@@ -102,10 +108,8 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
+        onlySufficientSigners(wallet, signers)
     {
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-
         callContractInternal(wallet, to, amount, data);
     }
 
@@ -121,10 +125,8 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
+        onlySufficientSigners(wallet, signers)
     {
-        uint guardianCount = controller.securityStore().numGuardians(wallet);
-        require(signers.length >= (guardianCount + 1)/2, "NOT_ENOUGH_SIGNER");
-
         approveInternal(wallet, token, to, amount);
         callContractInternal(wallet, to, 0, data);
     }

--- a/packages/hebao_v1/contracts/stores/SecurityStore.sol
+++ b/packages/hebao_v1/contracts/stores/SecurityStore.sol
@@ -62,9 +62,8 @@ contract SecurityStore is DataStore
         returns (Guardian memory guardian)
     {
         uint index = wallets[wallet].guardianIdx[_guardian];
-        if (index > 0) {
-            guardian = wallets[wallet].guardians[index-1];
-        }
+        require(index > 0, "NOT_A_GUARDIAN");
+        guardian = wallets[wallet].guardians[index-1];
     }
 
     function guardians(address wallet)

--- a/packages/hebao_v1/contracts/stores/SecurityStore.sol
+++ b/packages/hebao_v1/contracts/stores/SecurityStore.sol
@@ -31,7 +31,7 @@ contract SecurityStore is DataStore
     struct Guardian
     {
         address addr;
-        uint    info;
+        uint    types;
     }
 
     struct Wallet
@@ -82,21 +82,26 @@ contract SecurityStore is DataStore
         return wallets[wallet].guardians.length;
     }
 
-    function addGuardian(address wallet, address guardian, uint info)
+    function addOrUpdateGuardian(address wallet, address guardian, uint types)
         public
         onlyManager
     {
         require(guardian != address(0), "ZERO_ADDRESS");
         Wallet storage w = wallets[wallet];
-        require(w.guardianIdx[guardian] == 0, "GUARDIAN_EXISTS");
 
-        Guardian memory g = Guardian(
-            guardian,
-            info
-        );
-
-        w.guardians.push(g);
-        w.guardianIdx[guardian] = w.guardians.length;
+        uint pos = w.guardianIdx[guardian];
+        if (pos == 0) {
+            // Add the new guardian
+            Guardian memory g = Guardian(
+                guardian,
+                types
+            );
+            w.guardians.push(g);
+            w.guardianIdx[guardian] = w.guardians.length;
+        } else {
+            // Update the guardian
+            w.guardians[pos-1].types = types;
+        }
     }
 
     function removeGuardian(address wallet, address guardian)


### PR DESCRIPTION
The basic idea is to store data about the guardian and let modules use that data for more complex logic. This way we do not limit ourselves to a single system which we're than stuck with. So storing the guardians and adding/removing guardians remains just as easy as before, there's just a single extra `uint` value stored for each guardian. The modules could store any data in it, but currently it's used as a bitmask to store some extra data about the guardian.

This means there's a bit more work to 'prepare' the guardians, but that's insignificant with checking the actual signatures of the guardians. It allows a lot of flexibility in the modules (like allow a self controlled hardware guardian to do transfers with the same quota as the wallet owner or something like that).

I also changed some requirements in respect to when the owner needs or is allowed to sign.