### PR TITLE
[hebao] enable ERC712 for BaseVault and MetaTxModule

### DIFF
--- a/packages/hebao_v1/contracts/Migrations.sol
+++ b/packages/hebao_v1/contracts/Migrations.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 contract Migrations
 {

--- a/packages/hebao_v1/contracts/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/base/BaseModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/ReentrancyGuard.sol";
 

--- a/packages/hebao_v1/contracts/base/BaseSubAccount.sol
+++ b/packages/hebao_v1/contracts/base/BaseSubAccount.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../lib/ERC20.sol";

--- a/packages/hebao_v1/contracts/base/BaseVault.sol
+++ b/packages/hebao_v1/contracts/base/BaseVault.sol
@@ -112,7 +112,7 @@ contract BaseVault is AddressSet, ERC712, Vault
     {
         require(signers.length >= _requirement, "NEED_MORE_SIGNATURES");
 
-        bytes32 signHash = keccak256(
+        bytes32 erc712SignHash = keccak256(
             abi.encodePacked(
                 "\x19\x01",
                 _domain_seperator,
@@ -120,7 +120,7 @@ contract BaseVault is AddressSet, ERC712, Vault
             )
         );
 
-        signHash.verifySignatures(signers, signatures);
+        erc712SignHash.verifySignatures(signers, signatures);
 
         // solium-disable-next-line security/no-call-value
         (bool success, ) = target.call.value(value)(data);

--- a/packages/hebao_v1/contracts/base/BaseVault.sol
+++ b/packages/hebao_v1/contracts/base/BaseVault.sol
@@ -91,12 +91,14 @@ contract BaseVault is AddressSet, ERC712, Vault
         pure
         returns (bytes32)
     {
-        return keccak256(abi.encode(
-            VAULTTRANSACTION_TYPEHASH,
-            _tx.target,
-            _tx.value,
-            keccak256(_tx.data)
-        ));
+        return keccak256(
+            abi.encode(
+                VAULTTRANSACTION_TYPEHASH,
+                _tx.target,
+                _tx.value,
+                keccak256(_tx.data)
+            )
+        );
     }
 
     function execute(
@@ -110,11 +112,13 @@ contract BaseVault is AddressSet, ERC712, Vault
     {
         require(signers.length >= _requirement, "NEED_MORE_SIGNATURES");
 
-        bytes32 signHash = keccak256(abi.encodePacked(
-            "\x19\x01",
-            _domain_seperator,
-            hash(VaultTransaction(target, value, data))
-        ));
+        bytes32 signHash = keccak256(
+            abi.encodePacked(
+                "\x19\x01",
+                _domain_seperator,
+                hash(VaultTransaction(target, value, data))
+            )
+        );
 
         signHash.verifySignatures(signers, signatures);
 

--- a/packages/hebao_v1/contracts/base/BaseVault.sol
+++ b/packages/hebao_v1/contracts/base/BaseVault.sol
@@ -68,10 +68,10 @@ contract BaseVault is AddressSet, Vault
         )
         public
     {
-        DOMAIN_SEPARATOR = EIP712.hash(EIP712.Domain("BaseVault", "1.0"));
-
         require(owners.length > 0, "NULL_OWNERS");
         require(owners.length <= MAX_OWNERS, "TOO_MANY_OWNERS");
+
+        DOMAIN_SEPARATOR = EIP712.hash(EIP712.Domain("BaseVault", "1.0"));
 
         for (uint i = 0; i < owners.length; i++) {
             address owner = owners[i];
@@ -92,7 +92,7 @@ contract BaseVault is AddressSet, Vault
         returns (bytes32)
     {
         return keccak256(
-            abi.encodePacked(
+            abi.encode(
                 VAULTTRANSACTION_TYPEHASH,
                 _tx.target,
                 _tx.value,
@@ -112,7 +112,7 @@ contract BaseVault is AddressSet, Vault
     {
         require(signers.length >= _requirement, "NEED_MORE_SIGNATURES");
 
-        bytes32 metaTxHash = EIP712.hash(
+        bytes32 metaTxHash = EIP712.hashPacked(
             DOMAIN_SEPARATOR,
             hash(VaultTransaction(target, value, data))
         );

--- a/packages/hebao_v1/contracts/base/BaseWallet.sol
+++ b/packages/hebao_v1/contracts/base/BaseWallet.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/ERC20.sol";
 import "../lib/AddressSet.sol";

--- a/packages/hebao_v1/contracts/base/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/base/ControllerImpl.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/Claimable.sol";
 

--- a/packages/hebao_v1/contracts/base/DataStore.sol
+++ b/packages/hebao_v1/contracts/base/DataStore.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/OwnerManagable.sol";
 

--- a/packages/hebao_v1/contracts/base/ERC1271Module.sol
+++ b/packages/hebao_v1/contracts/base/ERC1271Module.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../thirdparty/ERC1271.sol";
 

--- a/packages/hebao_v1/contracts/base/ImplementationRegistryImpl.sol
+++ b/packages/hebao_v1/contracts/base/ImplementationRegistryImpl.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/AddressSet.sol";
 import "../lib/Claimable.sol";

--- a/packages/hebao_v1/contracts/base/MetaTxModule.sol
+++ b/packages/hebao_v1/contracts/base/MetaTxModule.sol
@@ -81,9 +81,9 @@ contract MetaTxModule is BaseModule
         "MetaTransaction(address from,address to,uint256 value,bytes data,uint256 nonce,address gasToken,uint256 gasPrice,uint256 gasLimit,uint256 gasOverhead)"
     );
 
-    bytes32 public DOMAIN_SEPARATOR;
-
+    bytes32    public DOMAIN_SEPARATOR;
     Controller public controller;
+
     mapping (address => WalletState) public wallets;
 
     event ExecutedMetaTx(
@@ -104,8 +104,8 @@ contract MetaTxModule is BaseModule
         public
         BaseModule()
     {
-        controller = _controller;
         DOMAIN_SEPARATOR = EIP712.hash(EIP712.Domain("MetaTxModule", "1.0"));
+        controller = _controller;
     }
 
     function quotaManager() internal view returns (address)
@@ -176,7 +176,7 @@ contract MetaTxModule is BaseModule
         require(startGas >= gasSettings.limit, "OUT_OF_GAS");
 
         address wallet = extractWalletAddress(data);
-        bytes32 metaTxHash = EIP712.hash(
+        bytes32 metaTxHash = EIP712.hashPacked(
             DOMAIN_SEPARATOR,
             hash(
                 MetaTransaction(

--- a/packages/hebao_v1/contracts/base/ModuleRegistryImpl.sol
+++ b/packages/hebao_v1/contracts/base/ModuleRegistryImpl.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/AddressSet.sol";
 import "../lib/Claimable.sol";

--- a/packages/hebao_v1/contracts/base/VaultFactory.sol
+++ b/packages/hebao_v1/contracts/base/VaultFactory.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./BaseVault.sol";
 

--- a/packages/hebao_v1/contracts/base/WalletENSManager.sol
+++ b/packages/hebao_v1/contracts/base/WalletENSManager.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../thirdparty/ens/BaseENSManager.sol";
 

--- a/packages/hebao_v1/contracts/base/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/base/WalletFactory.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/OwnerManagable.sol";
 import "../lib/ReentrancyGuard.sol";

--- a/packages/hebao_v1/contracts/base/WalletRegistryImpl.sol
+++ b/packages/hebao_v1/contracts/base/WalletRegistryImpl.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/AddressSet.sol";
 import "../lib/Claimable.sol";

--- a/packages/hebao_v1/contracts/iface/Controller.sol
+++ b/packages/hebao_v1/contracts/iface/Controller.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./ModuleRegistry.sol";
 import "./WalletRegistry.sol";

--- a/packages/hebao_v1/contracts/iface/ImplementationRegistry.sol
+++ b/packages/hebao_v1/contracts/iface/ImplementationRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title ImplementationRegistry

--- a/packages/hebao_v1/contracts/iface/Module.sol
+++ b/packages/hebao_v1/contracts/iface/Module.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/Ownable.sol";
 

--- a/packages/hebao_v1/contracts/iface/ModuleRegistry.sol
+++ b/packages/hebao_v1/contracts/iface/ModuleRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title ModuleRegistry

--- a/packages/hebao_v1/contracts/iface/PriceOracle.sol
+++ b/packages/hebao_v1/contracts/iface/PriceOracle.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title PriceOracle

--- a/packages/hebao_v1/contracts/iface/QuotaManager.sol
+++ b/packages/hebao_v1/contracts/iface/QuotaManager.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 

--- a/packages/hebao_v1/contracts/iface/SubAccount.sol
+++ b/packages/hebao_v1/contracts/iface/SubAccount.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 

--- a/packages/hebao_v1/contracts/iface/Vault.sol
+++ b/packages/hebao_v1/contracts/iface/Vault.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 

--- a/packages/hebao_v1/contracts/iface/Wallet.sol
+++ b/packages/hebao_v1/contracts/iface/Wallet.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Wallet

--- a/packages/hebao_v1/contracts/iface/WalletRegistry.sol
+++ b/packages/hebao_v1/contracts/iface/WalletRegistry.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title WalletRegistry

--- a/packages/hebao_v1/contracts/lib/AddressSet.sol
+++ b/packages/hebao_v1/contracts/lib/AddressSet.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title AddressSet

--- a/packages/hebao_v1/contracts/lib/AddressUtil.sol
+++ b/packages/hebao_v1/contracts/lib/AddressUtil.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Utility Functions for addresses

--- a/packages/hebao_v1/contracts/lib/Authorizable.sol
+++ b/packages/hebao_v1/contracts/lib/Authorizable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/Claimable.sol";
 

--- a/packages/hebao_v1/contracts/lib/BurnableERC20.sol
+++ b/packages/hebao_v1/contracts/lib/BurnableERC20.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./ERC20.sol";
 

--- a/packages/hebao_v1/contracts/lib/Claimable.sol
+++ b/packages/hebao_v1/contracts/lib/Claimable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./Ownable.sol";
 

--- a/packages/hebao_v1/contracts/lib/EIP712.sol
+++ b/packages/hebao_v1/contracts/lib/EIP712.sol
@@ -40,7 +40,7 @@ library EIP712
         assembly { _chainid := chainid() }
 
         return keccak256(
-            abi.encodePacked(
+            abi.encode(
                 EIP712_DOMAIN_TYPEHASH,
                 keccak256(bytes(domain.name)),
                 keccak256(bytes(domain.version)),
@@ -49,7 +49,7 @@ library EIP712
         );
     }
 
-    function hash(
+    function hashPacked(
         bytes32 domainHash,
         bytes32 dataHash
         )

--- a/packages/hebao_v1/contracts/lib/ERC20.sol
+++ b/packages/hebao_v1/contracts/lib/ERC20.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title ERC20 Token Interface

--- a/packages/hebao_v1/contracts/lib/ERC20SafeTransfer.sol
+++ b/packages/hebao_v1/contracts/lib/ERC20SafeTransfer.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title ERC20 safe transfer

--- a/packages/hebao_v1/contracts/lib/ERC20Token.sol
+++ b/packages/hebao_v1/contracts/lib/ERC20Token.sol
@@ -14,7 +14,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./ERC20.sol";
 import "./MathUint.sol";

--- a/packages/hebao_v1/contracts/lib/ERC712.sol
+++ b/packages/hebao_v1/contracts/lib/ERC712.sol
@@ -38,12 +38,13 @@ contract ERC712
 
         // TODO(daniel): uncomment the following line and enable `--evm-version istanbul`
         // assembly { _chainid := chainid() }
-
-        return keccak256(abi.encode(
-            EIP712_DOMAIN_TYPEHASH,
-            keccak256(bytes(domain.name)),
-            keccak256(bytes(domain.version)),
-            _chainid
-        ));
+        return keccak256(
+            abi.encode(
+                EIP712_DOMAIN_TYPEHASH,
+                keccak256(bytes(domain.name)),
+                keccak256(bytes(domain.version)),
+                _chainid
+            )
+        );
     }
 }

--- a/packages/hebao_v1/contracts/lib/ERC712.sol
+++ b/packages/hebao_v1/contracts/lib/ERC712.sol
@@ -1,0 +1,58 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless _requirement by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+pragma experimental ABIEncoderV2;
+
+import "../lib/AddressSet.sol";
+import "../lib/SignatureUtil.sol";
+
+import "../iface/Vault.sol";
+
+
+contract ERC712
+{
+    struct Domain {
+        string  name;
+        string  version;
+        address verifyingContract;
+        uint    salt;
+    }
+
+    bytes32 constant internal EIP712DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,uint256 salt)"
+    );
+
+    function hash(Domain memory domain)
+        internal
+        pure
+        returns (bytes32)
+    {
+        uint _chainid;
+
+        // TODO(daniel): uncomment the following line and enable `--evm-version istanbul`
+        // assembly { _chainid := chainid() }
+
+        return keccak256(abi.encode(
+            EIP712DOMAIN_TYPEHASH,
+            keccak256(bytes(domain.name)),
+            keccak256(bytes(domain.version)),
+            _chainid,
+            domain.verifyingContract,
+            domain.salt
+        ));
+    }
+}

--- a/packages/hebao_v1/contracts/lib/ERC712.sol
+++ b/packages/hebao_v1/contracts/lib/ERC712.sol
@@ -17,26 +17,19 @@
 pragma solidity ^0.5.11;
 pragma experimental ABIEncoderV2;
 
-import "../lib/AddressSet.sol";
-import "../lib/SignatureUtil.sol";
-
-import "../iface/Vault.sol";
-
 
 contract ERC712
 {
-    struct Domain {
+    struct EIP712Domain {
         string  name;
         string  version;
-        address verifyingContract;
-        uint    salt;
     }
 
-    bytes32 constant internal EIP712DOMAIN_TYPEHASH = keccak256(
-        "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract,uint256 salt)"
+    bytes32 constant public EIP712_DOMAIN_TYPEHASH = keccak256(
+        "EIP712Domain(string name,string version,uint256 chainId)"
     );
 
-    function hash(Domain memory domain)
+    function hash(EIP712Domain memory domain)
         internal
         pure
         returns (bytes32)
@@ -47,12 +40,10 @@ contract ERC712
         // assembly { _chainid := chainid() }
 
         return keccak256(abi.encode(
-            EIP712DOMAIN_TYPEHASH,
+            EIP712_DOMAIN_TYPEHASH,
             keccak256(bytes(domain.name)),
             keccak256(bytes(domain.version)),
-            _chainid,
-            domain.verifyingContract,
-            domain.salt
+            _chainid
         ));
     }
 }

--- a/packages/hebao_v1/contracts/lib/Killable.sol
+++ b/packages/hebao_v1/contracts/lib/Killable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/Claimable.sol";
 

--- a/packages/hebao_v1/contracts/lib/Managable.sol
+++ b/packages/hebao_v1/contracts/lib/Managable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./AddressSet.sol";
 

--- a/packages/hebao_v1/contracts/lib/MathInt.sol
+++ b/packages/hebao_v1/contracts/lib/MathInt.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Utility Functions for int

--- a/packages/hebao_v1/contracts/lib/MathUint.sol
+++ b/packages/hebao_v1/contracts/lib/MathUint.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Utility Functions for uint

--- a/packages/hebao_v1/contracts/lib/Ownable.sol
+++ b/packages/hebao_v1/contracts/lib/Ownable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Ownable

--- a/packages/hebao_v1/contracts/lib/OwnerManagable.sol
+++ b/packages/hebao_v1/contracts/lib/OwnerManagable.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./Claimable.sol";
 import "./AddressSet.sol";

--- a/packages/hebao_v1/contracts/lib/Poseidon.sol
+++ b/packages/hebao_v1/contracts/lib/Poseidon.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title Poseidon hash function

--- a/packages/hebao_v1/contracts/lib/ReentrancyGuard.sol
+++ b/packages/hebao_v1/contracts/lib/ReentrancyGuard.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title ReentrancyGuard

--- a/packages/hebao_v1/contracts/lib/SignatureUtil.sol
+++ b/packages/hebao_v1/contracts/lib/SignatureUtil.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../thirdparty/ERC1271.sol";

--- a/packages/hebao_v1/contracts/lib/SimpleProxy.sol
+++ b/packages/hebao_v1/contracts/lib/SimpleProxy.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../thirdparty/Proxy.sol";
 

--- a/packages/hebao_v1/contracts/modules/core/WalletFactoryModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactoryModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../../iface/Controller.sol";
 import "../../iface/Module.sol";

--- a/packages/hebao_v1/contracts/modules/core/WalletUpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletUpgraderModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/modules/dapps/CompoundModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/CompoundModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../base/BaseSubAccount.sol";

--- a/packages/hebao_v1/contracts/modules/dapps/DyDxModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/DyDxModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/modules/dapps/LRCStakingModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/LRCStakingModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/modules/dapps/MakerModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/MakerModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/modules/dapps/PoolTogetherModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/PoolTogetherModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/modules/exchanges/IExchangeV3.sol
+++ b/packages/hebao_v1/contracts/modules/exchanges/IExchangeV3.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /// @title IExchangeV3

--- a/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
+++ b/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/MathUint.sol";

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/MathUint.sol";

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./SecurityModule.sol";
 

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/MathUint.sol";

--- a/packages/hebao_v1/contracts/modules/security/LockModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/LockModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/MathUint.sol";

--- a/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../iface/Wallet.sol";

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/AddressUtil.sol";

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../base/MetaTxModule.sol";

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/MathUint.sol";

--- a/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/ERC20.sol";

--- a/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/Claimable.sol";

--- a/packages/hebao_v1/contracts/modules/transfers/TokenBalances.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TokenBalances.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/ERC20.sol";

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../security/SecurityModule.sol";

--- a/packages/hebao_v1/contracts/price/AggregationalPriceOracle.sol
+++ b/packages/hebao_v1/contracts/price/AggregationalPriceOracle.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/MathUint.sol";
 

--- a/packages/hebao_v1/contracts/price/KyberNetworkPriceOracle.sol
+++ b/packages/hebao_v1/contracts/price/KyberNetworkPriceOracle.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/ERC20.sol";
 

--- a/packages/hebao_v1/contracts/price/UniswapPriceOracle.sol
+++ b/packages/hebao_v1/contracts/price/UniswapPriceOracle.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../thirdparty/uniswap/UniswapExchangeInterface.sol";
 import "../thirdparty/uniswap/UniswapFactoryInterface.sol";

--- a/packages/hebao_v1/contracts/stores/PriceCacheStore.sol
+++ b/packages/hebao_v1/contracts/stores/PriceCacheStore.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "..//lib/MathUint.sol";
 

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/MathUint.sol";
 

--- a/packages/hebao_v1/contracts/stores/SecurityStore.sol
+++ b/packages/hebao_v1/contracts/stores/SecurityStore.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../base/DataStore.sol";

--- a/packages/hebao_v1/contracts/stores/WhitelistStore.sol
+++ b/packages/hebao_v1/contracts/stores/WhitelistStore.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../lib/AddressSet.sol";
 

--- a/packages/hebao_v1/contracts/test/DummyToken.sol
+++ b/packages/hebao_v1/contracts/test/DummyToken.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./LRCToken.sol";
 

--- a/packages/hebao_v1/contracts/test/LRCToken.sol
+++ b/packages/hebao_v1/contracts/test/LRCToken.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 

--- a/packages/hebao_v1/contracts/test/tokens/GTO.sol
+++ b/packages/hebao_v1/contracts/test/tokens/GTO.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/INDA.sol
+++ b/packages/hebao_v1/contracts/test/tokens/INDA.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/INDB.sol
+++ b/packages/hebao_v1/contracts/test/tokens/INDB.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/LRC.sol
+++ b/packages/hebao_v1/contracts/test/tokens/LRC.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/RDN.sol
+++ b/packages/hebao_v1/contracts/test/tokens/RDN.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/REP.sol
+++ b/packages/hebao_v1/contracts/test/tokens/REP.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/test/tokens/WETH.sol
+++ b/packages/hebao_v1/contracts/test/tokens/WETH.sol
@@ -14,7 +14,7 @@
   See the License for the specific language governing permissions and
   limitations under the License.
 */
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "../DummyToken.sol";
 

--- a/packages/hebao_v1/contracts/thirdparty/BytesUtil.sol
+++ b/packages/hebao_v1/contracts/thirdparty/BytesUtil.sol
@@ -1,5 +1,5 @@
 //Mainly taken from https://github.com/GNSPS/solidity-bytes-utils/blob/master/contracts/BytesLib.sol
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 library BytesUtil {
     function concat(

--- a/packages/hebao_v1/contracts/thirdparty/Cloneable.sol
+++ b/packages/hebao_v1/contracts/thirdparty/Cloneable.sol
@@ -1,7 +1,7 @@
 
 // This code is taken from https://gist.github.com/holiman/069de8d056a531575d2b786df3345665
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 library Cloneable {

--- a/packages/hebao_v1/contracts/thirdparty/ERC1271.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ERC1271.sol
@@ -1,6 +1,6 @@
 // Copied from https://eips.ethereum.org/EIPS/eip-1271.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 contract ERC1271 {
 

--- a/packages/hebao_v1/contracts/thirdparty/ERC165.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ERC165.sol
@@ -1,6 +1,6 @@
 // Copied from https://github.com/ethereum/EIPs/blob/master/EIPS/eip-165.md.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 interface ERC165 {
     /// @notice Query if a contract implements an interface

--- a/packages/hebao_v1/contracts/thirdparty/MockContract.sol
+++ b/packages/hebao_v1/contracts/thirdparty/MockContract.sol
@@ -1,6 +1,6 @@
 /// Borrowed from https://github.com/gnosis/mock-contract
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 interface MockInterface {
 	/**

--- a/packages/hebao_v1/contracts/thirdparty/OwnedUpgradabilityProxy.sol
+++ b/packages/hebao_v1/contracts/thirdparty/OwnedUpgradabilityProxy.sol
@@ -1,7 +1,7 @@
 // This code is taken from https://github.com/OpenZeppelin/openzeppelin-labs
 // with minor modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import './UpgradabilityProxy.sol';
 

--- a/packages/hebao_v1/contracts/thirdparty/Proxy.sol
+++ b/packages/hebao_v1/contracts/thirdparty/Proxy.sol
@@ -1,7 +1,7 @@
 // This code is taken from https://github.com/OpenZeppelin/openzeppelin-labs
 // with minor modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 
 /**

--- a/packages/hebao_v1/contracts/thirdparty/UpgradabilityProxy.sol
+++ b/packages/hebao_v1/contracts/thirdparty/UpgradabilityProxy.sol
@@ -1,7 +1,7 @@
 // This code is taken from https://github.com/OpenZeppelin/openzeppelin-labs
 // with minor modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import './Proxy.sol';
 

--- a/packages/hebao_v1/contracts/thirdparty/compound/CErc20.sol
+++ b/packages/hebao_v1/contracts/thirdparty/compound/CErc20.sol
@@ -1,6 +1,6 @@
 // From Compound code base - https://github.com/compound-finance/compound-protocol/blob/master/contracts/CErc20.sol
 // with minor modificaiton.
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./CToken.sol";
 

--- a/packages/hebao_v1/contracts/thirdparty/compound/CEther.sol
+++ b/packages/hebao_v1/contracts/thirdparty/compound/CEther.sol
@@ -1,6 +1,6 @@
 // From Compound code base - https://github.com/compound-finance/compound-protocol/blob/master/contracts/CEther.sol
 // with minor modificaiton.
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 import "./CToken.sol";
 

--- a/packages/hebao_v1/contracts/thirdparty/compound/CToken.sol
+++ b/packages/hebao_v1/contracts/thirdparty/compound/CToken.sol
@@ -1,6 +1,6 @@
 // From Compound code base - https://github.com/compound-finance/compound-protocol/blob/master/contracts/CToken.sol
 // with minor modificaiton.
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 interface CToken {

--- a/packages/hebao_v1/contracts/thirdparty/compound/CompoundRegistery.sol
+++ b/packages/hebao_v1/contracts/thirdparty/compound/CompoundRegistery.sol
@@ -1,6 +1,6 @@
 // From Argent code base - https://github.com/argentlabs/argent-contracts/blob/develop/contracts/defi/utils/CompoundRegistry.sol
 // with minor modificaiton.
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 pragma experimental ABIEncoderV2;
 
 import "../../lib/Claimable.sol";

--- a/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
@@ -1,7 +1,7 @@
 // Taken from Argent's code base - https://github.com/argentlabs/argent-contracts/blob/develop/contracts/ens/ArgentENSManager.sol
 // with few modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 import "../strings.sol";
 import "./ENS.sol";
 import "./ENSConsumer.sol";

--- a/packages/hebao_v1/contracts/thirdparty/ens/BaseENSResolver.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/BaseENSResolver.sol
@@ -1,7 +1,7 @@
 // Taken from Argent's code base - https://github.com/argentlabs/argent-contracts/blob/develop/contracts/ens/ArgentENSResolver.sol
 // with few modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 import "../../lib/OwnerManagable.sol";
 import "./ENS.sol";
 

--- a/packages/hebao_v1/contracts/thirdparty/ens/ENS.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/ENS.sol
@@ -1,7 +1,7 @@
 // Taken from Argent's code base - https://github.com/argentlabs/argent-contracts/blob/develop/contracts/ens/ENS.sol
 // with few modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 /**
  * ENS Registry interface.

--- a/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
@@ -2,7 +2,7 @@
 // Taken from Argent's code base - https://github.com/argentlabs/argent-contracts/blob/develop/contracts/ens/ENSConsumer.sol
 // with few modifications.
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 import "./ENS.sol";
 import "../strings.sol";
 

--- a/packages/hebao_v1/contracts/thirdparty/strings.sol
+++ b/packages/hebao_v1/contracts/thirdparty/strings.sol
@@ -34,7 +34,7 @@
  *      corresponding to the left and right parts of the string.
  */
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 /* solium-disable */
 library strings {

--- a/packages/hebao_v1/contracts/thirdparty/uniswap/UniswapExchangeInterface.sol
+++ b/packages/hebao_v1/contracts/thirdparty/uniswap/UniswapExchangeInterface.sol
@@ -1,5 +1,5 @@
 // Solidity Interface
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 contract UniswapExchangeInterface {
     // Address of ERC20 token sold on this exchange

--- a/packages/hebao_v1/contracts/thirdparty/uniswap/UniswapFactoryInterface.sol
+++ b/packages/hebao_v1/contracts/thirdparty/uniswap/UniswapFactoryInterface.sol
@@ -1,6 +1,6 @@
 // Solidity Interface
 
-pragma solidity ^0.5.11;
+pragma solidity ^0.5.13;
 
 contract UniswapFactoryInterface {
     // Public Variables

--- a/packages/hebao_v1/package-lock.json
+++ b/packages/hebao_v1/package-lock.json
@@ -34029,37 +34029,26 @@
       }
     },
     "solc": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.12.tgz",
-      "integrity": "sha512-OX/AGZT04tuUsagoVXSZBiBZYJReA02hdwZOfRkB03/eeYP9Dl3pr+M+au+1MhssgiuWBlFPN7sRXFiqwkAW2g==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.13.tgz",
+      "integrity": "sha512-osybDVPGjAqcmSKLU3vh5iHuxbhGlJjQI5ZvI7nRDR0fgblQqYte4MGvNjbew8DPvCrmoH0ZBiz/KBBLlPxfMg==",
       "dev": true,
       "requires": {
         "command-exists": "^1.2.8",
+        "commander": "3.0.2",
         "fs-extra": "^0.30.0",
         "js-sha3": "0.8.0",
         "memorystream": "^0.3.1",
         "require-from-string": "^2.0.0",
         "semver": "^5.5.0",
-        "tmp": "0.0.33",
-        "yargs": "^13.2.0"
+        "tmp": "0.0.33"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+        "commander": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
+          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
           "dev": true
-        },
-        "cliui": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
-          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-          "dev": true,
-          "requires": {
-            "string-width": "^3.1.0",
-            "strip-ansi": "^5.2.0",
-            "wrap-ansi": "^5.1.0"
-          }
         },
         "fs-extra": {
           "version": "0.30.0",
@@ -34074,12 +34063,6 @@
             "rimraf": "^2.2.8"
           }
         },
-        "get-caller-file": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-          "dev": true
-        },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -34089,76 +34072,11 @@
             "graceful-fs": "^4.1.6"
           }
         },
-        "require-main-filename": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
           "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^4.1.0"
-          }
-        },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
-          }
-        },
-        "yargs": {
-          "version": "13.3.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
-          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
-          "dev": true,
-          "requires": {
-            "cliui": "^5.0.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^3.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^13.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "13.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
-          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
         }
       }
     },

--- a/packages/hebao_v1/package.json
+++ b/packages/hebao_v1/package.json
@@ -73,7 +73,7 @@
     "npm-watch": "^0.6.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0",
-    "solc": "^0.5.11",
+    "solc": "^0.5.13",
     "solidity-coverage": "^0.7.0-beta.2",
     "solium": "^1.2.5",
     "truffle": "^5.0.38",

--- a/packages/hebao_v1/truffle.js
+++ b/packages/hebao_v1/truffle.js
@@ -48,9 +48,10 @@ module.exports = {
         optimizer: {
           enabled: true,
           runs: 200
-        }
+        },
+        evmVersion: "istanbul"
       },
-      version: "0.5.11"
+      version: "0.5.13"
     }
   },
   ens: {


### PR DESCRIPTION
the `execute` function of both `BaseVault` and `MetaTxModule` includes a `data` field which represents a function call. It seems the ERC712 cannot make it easier for users to see what the data really is (I would assume it is not possible given that our meta-transactions can call arbitrary external contracts from the wallet).