### PR TITLE
[heabo] Allow the wallet to be created trustlessly (with meta tx or not)

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/LockModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/LockModule.sol
@@ -122,11 +122,7 @@ contract LockModule is SecurityModule
             method == this.lock.selector || method == this.unlock.selector,
             "INVALID_METHOD"
         );
-        // data layout: {length:32}{sig:4}{_wallet:32}{_guardian:32}
-        require(data.length == 68, "INVALID_DATA");
-        address guardian;
-        assembly { guardian := mload(add(data, 68)) }
         signers = new address[](1);
-        signers[0] = guardian;
+        signers[0] = extractAddressFromCallData(data, 1);
     }
 }

--- a/packages/hebao_v1/contracts/thirdparty/Create2.sol
+++ b/packages/hebao_v1/contracts/thirdparty/Create2.sol
@@ -1,0 +1,51 @@
+// Taken from: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/970f687f04d20e01138a3e8ccf9278b1d4b3997b/contracts/utils/Create2.sol
+
+pragma solidity ^0.5.13;
+
+/**
+ * @dev Helper to make usage of the `CREATE2` EVM opcode easier and safer.
+ * `CREATE2` can be used to compute in advance the address where a smart
+ * contract will be deployed, which allows for interesting new mechanisms known
+ * as 'counterfactual interactions'.
+ *
+ * See the https://eips.ethereum.org/EIPS/eip-1014#motivation[EIP] for more
+ * information.
+ */
+library Create2 {
+    /**
+     * @dev Deploys a contract using `CREATE2`. The address where the contract
+     * will be deployed can be known in advance via {computeAddress}. Note that
+     * a contract cannot be deployed twice using the same salt.
+     */
+    function deploy(bytes32 salt, bytes memory bytecode) internal returns (address payable) {
+        address payable addr;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            addr := create2(0, add(bytecode, 0x20), mload(bytecode), salt)
+            if iszero(addr) {
+                revert(0, 0)
+            }
+        }
+        return addr;
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy}. Any change in the `bytecode`
+     * or `salt` will result in a new destination address.
+     */
+    function computeAddress(bytes32 salt, bytes memory bytecode) internal view returns (address) {
+        return computeAddress(salt, bytecode, address(this));
+    }
+
+    /**
+     * @dev Returns the address where a contract will be stored if deployed via {deploy} from a contract located at
+     * `deployer`. If `deployer` is this contract's address, returns the same value as {computeAddress}.
+     */
+    function computeAddress(bytes32 salt, bytes memory bytecodeHash, address deployer) internal pure returns (address) {
+        bytes32 bytecodeHashHash = keccak256(bytecodeHash);
+        bytes32 _data = keccak256(
+            abi.encodePacked(bytes1(0xff), deployer, salt, bytecodeHashHash)
+        );
+        return address(bytes20(_data << 96));
+    }
+}


### PR DESCRIPTION
The current method doesn't allow the wallet owner to create the wallet himself (which can be a security risk if he already deposited funds to the address) or easily allow the wallet owner to pay for the wallet deployment cost.

This PR allows the future wallet owner to remain in control of his wallet at any time. He can either deploy the wallet himself (by calling the create function directly) or pay a relayer to do it for him using a meta transaction.

So the normal process would be something like this:
- The user downloads the wallet UI and the wallet UI creates a new owner keypair.
- The wallet UI computes the wallet address and shows the address in the UI.
- The user can now deposit ETH/any token to the wallet address anytime he wants.
- The wallet UI monitors the deposits. If the user deposited some funds to the address the wallet UI can ask for the user to sign a meta tx so the wallet can be deployed on Ethereum. The cost for this deployment is paid using the funds in the wallet as usual.

Note that at any point the wallet can be created by anyone by calling the wallet create function. The wallet contract only needs to be deployed when it's actually used by the user.