### PR TITLE
[hebao] Small changes GenericDAppModule - one module multiple dapps

### DIFF
--- a/packages/hebao_v1/contracts/base/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/base/ControllerImpl.sol
@@ -36,15 +36,17 @@ contract ControllerImpl is Claimable, Controller
     );
 
     function init(
-        ModuleRegistry    _moduleRegistry,
-        WalletRegistry    _walletRegistry,
-        PriceCacheStore   _priceCacheStore,
-        QuotaStore        _quotaStore,
-        SecurityStore     _securityStore,
-        WhitelistStore    _whitelistStore,
-        PriceOracle       _priceOracle,
-        WalletENSManager  _ensManager,
-        QuotaManager      _quotaManager
+        ModuleRegistry          _moduleRegistry,
+        WalletRegistry          _walletRegistry,
+        ImplementationRegistry  _implementationRegistry,
+        DAppRegistry            _dappRegistry,
+        PriceCacheStore         _priceCacheStore,
+        QuotaStore              _quotaStore,
+        SecurityStore           _securityStore,
+        WhitelistStore          _whitelistStore,
+        PriceOracle             _priceOracle,
+        WalletENSManager        _ensManager,
+        QuotaManager            _quotaManager
         )
         external
         onlyOwner
@@ -54,6 +56,8 @@ contract ControllerImpl is Claimable, Controller
 
         moduleRegistry = _moduleRegistry;
         walletRegistry = _walletRegistry;
+        implementationRegistry = _implementationRegistry;
+        dappRegistry = _dappRegistry;
 
         priceCacheStore = _priceCacheStore;
         quotaStore = _quotaStore;

--- a/packages/hebao_v1/contracts/base/DAppRegistryImpl.sol
+++ b/packages/hebao_v1/contracts/base/DAppRegistryImpl.sol
@@ -1,0 +1,85 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.13;
+
+import "../lib/AddressSet.sol";
+import "../lib/Claimable.sol";
+
+import "../iface/DAppRegistry.sol";
+
+
+/// @title DAppRegistryImpl
+contract DAppRegistryImpl is Claimable, AddressSet, DAppRegistry
+{
+    bytes32 internal constant DAPPS = keccak256("__DAPP__");
+
+    event DAppEnabled(address indexed dapp, bool enabled);
+
+    constructor()
+        public
+        Claimable()
+    {
+    }
+
+    function enableDApp(address dapp)
+        external
+        onlyOwner
+    {
+        addAddressToSet(DAPPS, dapp, true);
+        emit DAppEnabled(dapp, true);
+    }
+
+    function disableDApp(address dapp)
+        external
+        onlyOwner
+    {
+        removeAddressFromSet(DAPPS, dapp);
+        emit DAppEnabled(dapp, false);
+    }
+
+    function isDAppEnabled(address dapp)
+        public
+        view
+        returns (bool)
+    {
+        return isAddressInSet(DAPPS, dapp);
+    }
+
+    function enabledDApps()
+        public
+        view
+        returns (address[] memory)
+    {
+        return addressesInSet(DAPPS);
+    }
+
+    function dapps()
+        public
+        view
+        returns (address[] memory)
+    {
+        return addressesInSet(DAPPS);
+    }
+
+    function numOfDApps()
+        public
+        view
+        returns (uint)
+    {
+        return numAddressesInSet(DAPPS);
+    }
+}

--- a/packages/hebao_v1/contracts/iface/Controller.sol
+++ b/packages/hebao_v1/contracts/iface/Controller.sol
@@ -19,6 +19,7 @@ pragma solidity ^0.5.13;
 import "./ModuleRegistry.sol";
 import "./WalletRegistry.sol";
 import "./ImplementationRegistry.sol";
+import "./DAppRegistry.sol";
 
 import "../stores/PriceCacheStore.sol";
 import "../stores/QuotaStore.sol";
@@ -38,6 +39,7 @@ contract Controller
     ModuleRegistry          public moduleRegistry;
     WalletRegistry          public walletRegistry;
     ImplementationRegistry  public implementationRegistry;
+    DAppRegistry            public dappRegistry;
 
     PriceCacheStore  public priceCacheStore;
     QuotaStore       public quotaStore;

--- a/packages/hebao_v1/contracts/iface/DAppRegistry.sol
+++ b/packages/hebao_v1/contracts/iface/DAppRegistry.sol
@@ -1,0 +1,31 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.13;
+
+
+/// @title DAppRegistry
+/// @dev A registry for DApps.
+///
+/// @author Daniel Wang - <daniel@loopring.org>
+contract DAppRegistry
+{
+    function enableDApp(address dapp) external;
+    function disableDApp(address dapp) external;
+    function isDAppEnabled(address dapp) public view returns (bool);
+    function dapps() public view returns (address[] memory _dapps);
+    function numOfDApps() public view returns (uint);
+}

--- a/packages/hebao_v1/contracts/modules/dapps/base/GenericDAppModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/base/GenericDAppModule.sol
@@ -151,6 +151,36 @@ contract GenericDAppModule is SecurityModule
         onlyWhenWalletUnlocked(wallet)
         onlyApprovedDapp(wallet, dapp)
     {
+        approveERC20Internal(wallet, dapp, token, amount);
+    }
+
+    function approveAndCallDApp(
+        address          wallet,
+        address          dapp,
+        address          token,
+        uint             approvedAmount,
+        uint             value,
+        bytes   calldata data
+        )
+        external
+        nonReentrant
+        onlyFromMetaTxOrWalletOwner(wallet)
+        onlyWhenWalletUnlocked(wallet)
+        onlyApprovedDapp(wallet, dapp)
+    {
+        approveERC20Internal(wallet, dapp, token, approvedAmount);
+        transactCall(wallet, dapp, value, data);
+    }
+
+    function approveERC20Internal(
+        address wallet,
+        address dapp,
+        address token,
+        uint    amount
+        )
+        internal
+        nonReentrant
+    {
         bytes memory txData = abi.encodeWithSelector(
             ERC20(token).approve.selector,
             dapp,


### PR DESCRIPTION
- Instead of using the fallback function I added `callDApp` because creating the correct data for the fallback function I think isn't easier because of the non-default data needed in the call. Also, by using `msg.value` it doesn't really play nice with our meta transactions.
- Added an `approveERC20` which is needed to approve ERC20 tokens for the dapp. This could also be done with `delegateCall` on the wallet but that would be more difficult to do.
- Added an optional extra security mode before the wallet owner can start using the dapp