### PR TITLE
[hebao] Some small quota implementation changes

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
@@ -49,17 +49,6 @@ contract QuotaModule is SecurityModule, QuotaManager
         delayPeriod = _delayPeriod;
     }
 
-    function checkAndAddToSpent(
-        address wallet,
-        address token,
-        uint    amount
-        )
-        external
-    {
-        uint value = controller.priceOracle().tokenPrice(token, amount);
-        controller.quotaStore().checkAndAddToSpent(wallet, value);
-    }
-
     function changeDailyQuota(
         address wallet,
         uint    newQuota


### PR DESCRIPTION
- Changed to a rolling daily limit instead of a hard day limit. The daily rolling limit is time zone independent and has some better worst case properties (with a hard day limit the daily limit be spent twice very shortly when done at 23.59 and 00.00, this is never possible with the rolling limit as the amount that can be spent gradually increases). The worst case (when hacked) is the same for both methods in that in 24 hours the daily limit can be spent twice.
- Allow the time it takes to change the daily quota to be set by the module. This allows for more flexible modules, which is used here to change the daily limit immediately with a majority.