### PR TITLE
[hebao] Guardian refactoring

### DIFF
--- a/packages/hebao_v1/contracts/iface/Data.sol
+++ b/packages/hebao_v1/contracts/iface/Data.sol
@@ -1,0 +1,28 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.13;
+
+
+library Data
+{
+    struct Guardian
+    {
+        address  addr;
+        uint     group;
+    }
+}
+

--- a/packages/hebao_v1/contracts/modules/core/WalletUpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletUpgraderModule.sol
@@ -41,8 +41,8 @@ contract WalletUpgraderModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(
             controller.implementationRegistry().isImplementationRegistered(implementation),

--- a/packages/hebao_v1/contracts/modules/dapps/LRCStakingModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/LRCStakingModule.sol
@@ -58,8 +58,8 @@ contract LRCStakingModule is SubAccountDAppModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(token == lrcTokenAddress, "LRC_ONLY");
         require(
@@ -93,8 +93,8 @@ contract LRCStakingModule is SubAccountDAppModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(token == lrcTokenAddress, "LRC_ONLY");
 
@@ -125,8 +125,8 @@ contract LRCStakingModule is SubAccountDAppModule
     function claimReward(address wallet)
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         (, uint rewardWaitTime, , uint pendingReward) = stakingPool.getUserStaking(wallet);
 

--- a/packages/hebao_v1/contracts/modules/dapps/base/GenericDAppModule.sol
+++ b/packages/hebao_v1/contracts/modules/dapps/base/GenericDAppModule.sol
@@ -54,8 +54,8 @@ contract GenericDAppModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         transactCall(wallet, dapp, value, data);
     }
@@ -67,8 +67,8 @@ contract GenericDAppModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         approveDAppInternal(wallet, token, amount);
     }
@@ -82,8 +82,8 @@ contract GenericDAppModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         approveDAppInternal(wallet, token, approvedAmount);
         transactCall(wallet, dapp, value, data);

--- a/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
+++ b/packages/hebao_v1/contracts/modules/exchanges/LoopringModule.sol
@@ -125,8 +125,8 @@ contract LoopringModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         (uint fee, bool newAccount) = getAccountCreationOrUpdateFee(wallet, exchange);
 
@@ -149,8 +149,8 @@ contract LoopringModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(amount > 0, "ZERO_VALUE");
         (, , uint fee, ) = exchange.getFees();
@@ -173,8 +173,8 @@ contract LoopringModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(amount > 0, "ZERO_VALUE");
         (, , , uint fee) = exchange.getFees();

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -63,10 +63,10 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
         notWalletGuardian(wallet, guardian)
         notWalletOwner(wallet, guardian)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(guardian != address(0), "ZERO_ADDRESS");
         require(group < GuardianUtils.MAX_NUM_GROUPS(), "INVALID_GROUP");
@@ -92,8 +92,8 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         uint confirmStart = pendingAdditions[wallet][guardian][group];
         require(confirmStart != 0, "NOT_PENDING");
@@ -110,8 +110,8 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         uint confirmStart = pendingAdditions[wallet][guardian][group];
         require(confirmStart > 0, "INVALID_GUARDIAN");
@@ -125,9 +125,9 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
         onlyWalletGuardian(wallet, guardian)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         uint confirmStart = pendingRemovals[wallet][guardian];
         require(confirmStart == 0 || now > confirmStart + confirmPeriod, "ALREADY_PENDING");
@@ -141,8 +141,8 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         uint confirmStart = pendingRemovals[wallet][guardian];
         require(confirmStart != 0, "NOT_PENDING");
@@ -158,8 +158,8 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         uint confirmStart = pendingRemovals[wallet][guardian];
         require(confirmStart > 0, "INVALID_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -36,8 +36,8 @@ contract GuardianModule is SecurityModule
     mapping (address => mapping(address => mapping(uint => uint))) public pendingAdditions;
     mapping (address => mapping(address => uint)) public pendingRemovals;
 
-    event GuardianAdditionPending   (address indexed wallet, address indexed guardian, uint types, uint confirmAfter);
-    event GuardianAdded             (address indexed wallet, address indexed guardian, uint types);
+    event GuardianAdditionPending   (address indexed wallet, address indexed guardian, uint group, uint confirmAfter);
+    event GuardianAdded             (address indexed wallet, address indexed guardian, uint group);
     event GuardianAdditionCancelled (address indexed wallet, address indexed guardian);
 
     event GuardianRemovalPending    (address indexed wallet, address indexed guardian, uint confirmAfter);
@@ -59,7 +59,7 @@ contract GuardianModule is SecurityModule
     function addGuardian(
         address wallet,
         address guardian,
-        uint    types
+        uint    group
         )
         external
         nonReentrant
@@ -69,52 +69,53 @@ contract GuardianModule is SecurityModule
         notWalletOwner(wallet, guardian)
     {
         require(guardian != address(0), "ZERO_ADDRESS");
+        require(group < GuardianUtils.MAX_NUM_GROUPS(), "INVALID_GROUP");
 
         uint count = controller.securityStore().numGuardians(wallet);
         require(count < MAX_GUARDIANS, "TOO_MANY_GUARDIANS");
 
         if (controller.securityStore().numGuardians(wallet) == 0) {
-            controller.securityStore().addOrUpdateGuardian(wallet, guardian, types);
-            emit GuardianAdded(wallet, guardian, types);
+            controller.securityStore().addOrUpdateGuardian(wallet, guardian, group);
+            emit GuardianAdded(wallet, guardian, group);
         } else {
-            uint confirmStart = pendingAdditions[wallet][guardian][types];
+            uint confirmStart = pendingAdditions[wallet][guardian][group];
             require(confirmStart == 0 || now > confirmStart + confirmPeriod, "ALREADY_PENDING");
-            pendingAdditions[wallet][guardian][types] = now + pendingPeriod;
-            emit GuardianAdditionPending(wallet, guardian, types, now + pendingPeriod);
+            pendingAdditions[wallet][guardian][group] = now + pendingPeriod;
+            emit GuardianAdditionPending(wallet, guardian, group, now + pendingPeriod);
         }
     }
 
     function confirmGuardianAddition(
         address wallet,
         address guardian,
-        uint    types
+        uint    group
         )
         external
         nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {
-        uint confirmStart = pendingAdditions[wallet][guardian][types];
+        uint confirmStart = pendingAdditions[wallet][guardian][group];
         require(confirmStart != 0, "NOT_PENDING");
         require(now > confirmStart && now < confirmStart + confirmPeriod, "EXPIRED");
-        controller.securityStore().addOrUpdateGuardian(wallet, guardian, types);
-        delete pendingAdditions[wallet][guardian][types];
-        emit GuardianAdded(wallet, guardian, types);
+        controller.securityStore().addOrUpdateGuardian(wallet, guardian, group);
+        delete pendingAdditions[wallet][guardian][group];
+        emit GuardianAdded(wallet, guardian, group);
     }
 
     function cancelGuardianAddition(
         address wallet,
         address guardian,
-        uint    types
+        uint    group
         )
         external
         nonReentrant
         onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
     {
-        uint confirmStart = pendingAdditions[wallet][guardian][types];
+        uint confirmStart = pendingAdditions[wallet][guardian][group];
         require(confirmStart > 0, "INVALID_GUARDIAN");
-        delete pendingAdditions[wallet][guardian][types];
+        delete pendingAdditions[wallet][guardian][group];
         emit GuardianAdditionCancelled(wallet, guardian);
     }
 

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -58,10 +58,6 @@ library GuardianUtils
                 signingGuardians[numGuardians++] = securityStore.getGuardian(wallet, signers[i]);
             }
         }
-        // Update the signingGuardians array with the actual number of guardians that have signed
-        // (could be 1 less than the length if the owner signed as well)
-        assembly { mstore(signingGuardians, numGuardians) }
-        uint[16] memory signed = countGuardians(signingGuardians);
 
         // Check owner requirements
         if (requirement == SigRequirement.OwnerRequired) {
@@ -69,6 +65,11 @@ library GuardianUtils
         } else if (requirement == SigRequirement.OwnerNotAllowed) {
             require(!walletOwnerSigned, "WALLET_OWNER_SIGNATURE_NOT_ALLOWED");
         }
+
+        // Update the signingGuardians array with the actual number of guardians that have signed
+        // (could be 1 less than the length if the owner signed as well)
+        assembly { mstore(signingGuardians, numGuardians) }
+        uint[16] memory signed = countGuardians(signingGuardians);
 
         // Count the number of votes
         uint totalNumVotes = 0;

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -36,7 +36,7 @@ library GuardianUtils
     function requireMajority(
         SecurityStore   securityStore,
         address         wallet,
-        address[]       memory signers,
+        address[]       memory signers, // Assume there are no duplicate signers
         SigRequirement  requirement
         )
         internal

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -77,30 +77,24 @@ library GuardianUtils
             totalNumVotes += 1;
             numVotes += walletOwnerSigned ? 1 : 0;
         }
-        // Group 0: No grouping
         if (total[0] > 0) {
+            // Group 0: No grouping
             totalNumVotes += total[0];
             numVotes += signed[0];
         }
-        // Groups [1, 5]: Single guardian needed per group
-        for (uint i = 1; i < 5; i++) {
+        for (uint i = 1; i < MAX_NUM_GROUPS(); i++) {
             if (total[i] > 0) {
                 totalNumVotes += 1;
-                numVotes += signed[i] > 0 ? 1 : 0;
-            }
-        }
-        // Groups [6, 10]: Half the guardians needed per group
-        for (uint i = 6; i < 10; i++) {
-            if (total[i] > 0) {
-                totalNumVotes += 1;
-                numVotes += hasHalf(signed[i], total[i]) ? 1 : 0;
-            }
-        }
-        // Groups [11, 15]: A majority of guardians needed per group
-        for (uint i = 11; i < MAX_NUM_GROUPS(); i++) {
-            if (total[i] > 0) {
-                totalNumVotes += 1;
-                numVotes += hasMajority(signed[i], total[i]) ? 1 : 0;
+                if (i < 6) {
+                    // Groups [1, 5]: Single guardian needed per group
+                    numVotes += signed[i] > 0 ? 1 : 0;
+                } else if (i < 11) {
+                    // Groups [6, 10]: Half the guardians needed per group
+                    numVotes += hasHalf(signed[i], total[i]) ? 1 : 0;
+                } else {
+                    // Groups [11, 15]: A majority of guardians needed per group
+                    numVotes += hasMajority(signed[i], total[i]) ? 1 : 0;
+                }
             }
         }
 

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -16,25 +16,16 @@
 */
 pragma solidity ^0.5.13;
 
-import "./SecurityModule.sol";
+import "../../stores/SecurityStore.sol";
+import "../../iface/Wallet.sol";
 
 
-/// @title GuardianType
+/// @title GuardianUtils
 /// @author Brecht Devos - <brecht@loopring.org>
-library GuardianType
-{
-    function None()            internal pure returns (uint) { return      0; }
-    function SelfControlled()  internal pure returns (uint) { return 1 << 0; }
-    function Family()          internal pure returns (uint) { return 1 << 1; }
-    function Friend()          internal pure returns (uint) { return 1 << 2; }
-    function Hardware()        internal pure returns (uint) { return 1 << 3; }
-    function Device()          internal pure returns (uint) { return 1 << 4; }
-    function Service()         internal pure returns (uint) { return 1 << 5; }
-    function EOA()             internal pure returns (uint) { return 1 << 6; }
-}
-
 library GuardianUtils
 {
+    function MAX_NUM_GROUPS() internal pure returns (uint) { return 16; }
+
     enum SigRequirement
     {
         OwnerNotAllowed,
@@ -42,16 +33,7 @@ library GuardianUtils
         OwnerRequired
     }
 
-    struct GuardianGroupSizes
-    {
-        uint numHardware;
-        uint numSelfControlled;
-        uint numFriends;
-        uint numFamily;
-        uint numSocialOther;
-    }
-
-    function requireSufficientSigners(
+    function requireMajority(
         SecurityStore   securityStore,
         address         wallet,
         address[]       memory signers,
@@ -61,12 +43,12 @@ library GuardianUtils
         view
     {
         // Calculate total group sizes
-        SecurityStore.Guardian[] memory allGuardians = securityStore.guardians(wallet);
-        GuardianGroupSizes memory total = countGuardians(allGuardians);
+        Data.Guardian[] memory allGuardians = securityStore.guardians(wallet);
+        uint[16] memory total = countGuardians(allGuardians);
 
         // Calculate how many signers are in each group
         bool walletOwnerSigned = false;
-        SecurityStore.Guardian[] memory signingGuardians = new SecurityStore.Guardian[](signers.length);
+        Data.Guardian[] memory signingGuardians = new Data.Guardian[](signers.length);
         address walletOwner = Wallet(wallet).owner();
         uint numGuardians = 0;
         for (uint i = 0; i < signers.length; i++) {
@@ -79,7 +61,7 @@ library GuardianUtils
         // Update the signingGuardians array with the actual number of guardians that have signed
         // (could be 1 less than the length if the owner signed as well)
         assembly { mstore(signingGuardians, numGuardians) }
-        GuardianGroupSizes memory signed = countGuardians(signingGuardians);
+        uint[16] memory signed = countGuardians(signingGuardians);
 
         // Check owner requirements
         if (requirement == SigRequirement.OwnerRequired) {
@@ -88,36 +70,53 @@ library GuardianUtils
             require(!walletOwnerSigned, "WALLET_OWNER_SIGNATURE_NOT_ALLOWED");
         }
 
+        // Count the number of votes
         uint totalNumVotes = 0;
         uint numVotes = 0;
-        // Count the number of active groups and see which ones have a majority of signers
         if (requirement != SigRequirement.OwnerNotAllowed) {
             totalNumVotes += 1;
             numVotes += walletOwnerSigned ? 1 : 0;
         }
-        if (total.numFriends > 0) {
-            totalNumVotes += 1;
-            numVotes += hasMajority(signed.numFriends, total.numFriends) ? 1 : 0;
+        // Group 0: No grouping
+        if (total[0] > 0) {
+            totalNumVotes += total[0];
+            numVotes += signed[0];
         }
-        if (total.numFamily > 0) {
-            totalNumVotes += 1;
-            numVotes += hasMajority(signed.numFamily, total.numFamily) ? 1 : 0;
+        // Groups [1, 5]: Single guardian needed per group
+        for (uint i = 1; i < 5; i++) {
+            if (total[i] > 0) {
+                totalNumVotes += 1;
+                numVotes += signed[i] > 0 ? 1 : 0;
+            }
         }
-        if (total.numSocialOther > 0) {
-            totalNumVotes += 1;
-            numVotes += hasMajority(signed.numSocialOther, total.numSocialOther) ? 1 : 0;
+        // Groups [6, 10]: Half the guardians needed per group
+        for (uint i = 6; i < 10; i++) {
+            if (total[i] > 0) {
+                totalNumVotes += 1;
+                numVotes += hasHalf(signed[i], total[i]) ? 1 : 0;
+            }
         }
-        if (total.numSelfControlled > 0) {
-            totalNumVotes += 1;
-            numVotes += hasMajority(signed.numSelfControlled, total.numSelfControlled) ? 1 : 0;
-        }
-        if (total.numHardware > 0) {
-            totalNumVotes += 1;
-            numVotes += 1;
+        // Groups [11, 15]: A majority of guardians needed per group
+        for (uint i = 11; i < MAX_NUM_GROUPS(); i++) {
+            if (total[i] > 0) {
+                totalNumVotes += 1;
+                numVotes += hasMajority(signed[i], total[i]) ? 1 : 0;
+            }
         }
 
         // We need a majority of votes
         require(hasMajority(numVotes, totalNumVotes), "NOT_ENOUGH_SIGNERS");
+    }
+
+    function hasHalf(
+        uint count,
+        uint total
+        )
+        internal
+        pure
+        returns (bool)
+    {
+        return (count >= (total + 1) / 2);
     }
 
     function hasMajority(
@@ -132,24 +131,14 @@ library GuardianUtils
     }
 
     function countGuardians(
-        SecurityStore.Guardian[] memory guardians
+        Data.Guardian[] memory guardians
         )
         internal
         pure
-        returns (GuardianGroupSizes memory groups)
+        returns (uint[16] memory total)
     {
         for (uint i = 0; i < guardians.length; i++) {
-            if (guardians[i].types & GuardianType.Hardware() != 0) {
-                groups.numHardware++;
-            } else if (guardians[i].types & GuardianType.SelfControlled() != 0) {
-                groups.numSelfControlled++;
-            } else if (guardians[i].types & GuardianType.Friend() != 0) {
-                groups.numFriends++;
-            } else if (guardians[i].types & GuardianType.Family() != 0) {
-                groups.numFamily++;
-            } else {
-                groups.numSocialOther++;
-            }
+            total[guardians[i].group]++;
         }
     }
 }

--- a/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
@@ -29,16 +29,6 @@ contract QuotaModule is SecurityModule, QuotaManager
 {
     uint public delayPeriod;
 
-    modifier onlySufficientSigners(address wallet, address[] memory signers) {
-        GuardianUtils.requireSufficientSigners(
-            securityStore,
-            wallet,
-            signers,
-            GuardianUtils.SigRequirement.OwnerRequired
-        );
-        _;
-    }
-
     constructor(
         Controller _controller,
         uint       _delayPeriod
@@ -68,7 +58,7 @@ contract QuotaModule is SecurityModule, QuotaManager
         )
         external
         nonReentrant
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
         onlyWhenWalletUnlocked(wallet)
     {
         controller.quotaStore().changeQuota(wallet, newQuota, now);

--- a/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/QuotaModule.sol
@@ -45,8 +45,8 @@ contract QuotaModule is SecurityModule, QuotaManager
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         controller.quotaStore().changeQuota(wallet, newQuota, now.add(delayPeriod));
     }
@@ -58,8 +58,12 @@ contract QuotaModule is SecurityModule, QuotaManager
         )
         external
         nonReentrant
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         controller.quotaStore().changeQuota(wallet, newQuota, now);
     }

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -71,9 +71,12 @@ contract RecoveryModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         notWalletOwner(wallet, newOwner)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerNotAllowed)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerNotAllowed
+        )
     {
         require(newOwner != address(0), "ZERO_ADDRESS");
 
@@ -99,8 +102,11 @@ contract RecoveryModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerAllowed)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerAllowed
+        )
     {
         WalletRecovery storage recovery = wallets[wallet];
         require(recovery.completeAfter > 0, "NOT_STARTED");

--- a/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/RecoveryModule.sol
@@ -46,21 +46,6 @@ contract RecoveryModule is SecurityModule
     uint public recoveryPeriod;
     uint public lockPeriod;
 
-    modifier onlySufficientSigners(
-        address wallet,
-        address[] memory signers,
-        GuardianUtils.SigRequirement requirement
-        )
-    {
-        GuardianUtils.requireSufficientSigners(
-            securityStore,
-            wallet,
-            signers,
-            requirement
-        );
-        _;
-    }
-
     constructor(
         Controller _controller,
         uint      _recoveryPeriod,
@@ -88,7 +73,7 @@ contract RecoveryModule is SecurityModule
         nonReentrant
         onlyFromMetaTx
         notWalletOwner(wallet, newOwner)
-        onlySufficientSigners(wallet, signers, GuardianUtils.SigRequirement.OwnerNotAllowed)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerNotAllowed)
     {
         require(newOwner != address(0), "ZERO_ADDRESS");
 
@@ -115,7 +100,7 @@ contract RecoveryModule is SecurityModule
         external
         nonReentrant
         onlyFromMetaTx
-        onlySufficientSigners(wallet, signers, GuardianUtils.SigRequirement.OwnerAllowed)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerAllowed)
     {
         WalletRecovery storage recovery = wallets[wallet];
         require(recovery.completeAfter > 0, "NOT_STARTED");

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -20,6 +20,7 @@ pragma experimental ABIEncoderV2;
 import "../../base/MetaTxModule.sol";
 
 import "../../iface/Controller.sol";
+import "../security/GuardianUtils.sol";
 
 
 /// @title SecurityStore
@@ -56,6 +57,21 @@ contract SecurityModule is MetaTxModule
             "NOT_FROM_METATX_OR_WALLET_OWNER"
         );
         controller.securityStore().touchLastActive(wallet);
+        _;
+    }
+
+    modifier onlyWithMajority(
+        address                      wallet,
+        address[] memory             signers,
+        GuardianUtils.SigRequirement requirement
+        )
+    {
+        GuardianUtils.requireMajority(
+            securityStore,
+            wallet,
+            signers,
+            requirement
+        );
         _;
     }
 

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -60,12 +60,13 @@ contract SecurityModule is MetaTxModule
         _;
     }
 
-    modifier onlyWithMajority(
+    modifier onlyFromMetaTxWithMajority(
         address                      wallet,
         address[] memory             signers,
         GuardianUtils.SigRequirement requirement
         )
     {
+        require(msg.sender == address(this), "NOT_FROM_META_TX");
         GuardianUtils.requireMajority(
             securityStore,
             wallet,

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -49,8 +49,8 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         controller.whitelistStore().addToWhitelist(wallet, addr, now.add(delayPeriod));
     }
@@ -62,8 +62,12 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         controller.whitelistStore().addToWhitelist(wallet, addr, now);
     }
@@ -74,8 +78,8 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         controller.whitelistStore().removeFromWhitelist(wallet, addr);
     }

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -33,16 +33,6 @@ contract WhitelistModule is SecurityModule
 
     uint public delayPeriod;
 
-    modifier onlySufficientSigners(address wallet, address[] memory signers) {
-        GuardianUtils.requireSufficientSigners(
-            securityStore,
-            wallet,
-            signers,
-            GuardianUtils.SigRequirement.OwnerRequired
-        );
-        _;
-    }
-
     constructor(
         Controller  _controller,
         uint        _delayPeriod
@@ -72,7 +62,7 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
         onlyWhenWalletUnlocked(wallet)
     {
         controller.whitelistStore().addToWhitelist(wallet, addr, now);

--- a/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -21,22 +21,10 @@ import "../../lib/ERC20.sol";
 
 import "./TransferModule.sol";
 
-import "../security/GuardianUtils.sol";
-
 
 /// @title ApprovedTransfers
 contract ApprovedTransfers is TransferModule
 {
-    modifier onlySufficientSigners(address wallet, address[] memory signers) {
-        GuardianUtils.requireSufficientSigners(
-            securityStore,
-            wallet,
-            signers,
-            GuardianUtils.SigRequirement.OwnerRequired
-        );
-        _;
-    }
-
     constructor(Controller _controller)
         public
         TransferModule(_controller)
@@ -55,7 +43,7 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
     {
         transferInternal(wallet, token, to, amount, logdata);
     }
@@ -71,13 +59,12 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
     {
         for (uint i = 0; i < tokens.length; i++) {
-            address token = tokens[i];
-            uint amount = (token == address(0)) ?
-                wallet.balance : ERC20(token).balanceOf(wallet);
-            transferInternal(wallet, token, to, amount, logdata);
+            uint amount = (tokens[i] == address(0)) ?
+                wallet.balance : ERC20(tokens[i]).balanceOf(wallet);
+            transferInternal(wallet, tokens[i], to, amount, logdata);
         }
     }
 
@@ -92,7 +79,7 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
     {
         approveInternal(wallet, token, to, amount);
     }
@@ -108,7 +95,7 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
     {
         callContractInternal(wallet, to, amount, data);
     }
@@ -125,7 +112,7 @@ contract ApprovedTransfers is TransferModule
         nonReentrant
         onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlySufficientSigners(wallet, signers)
+        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
     {
         approveInternal(wallet, token, to, amount);
         callContractInternal(wallet, to, 0, data);

--- a/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/ApprovedTransfers.sol
@@ -41,9 +41,12 @@ contract ApprovedTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         transferInternal(wallet, token, to, amount, logdata);
     }
@@ -57,9 +60,12 @@ contract ApprovedTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         for (uint i = 0; i < tokens.length; i++) {
             uint amount = (tokens[i] == address(0)) ?
@@ -77,9 +83,12 @@ contract ApprovedTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         approveInternal(wallet, token, to, amount);
     }
@@ -93,9 +102,12 @@ contract ApprovedTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         callContractInternal(wallet, to, amount, data);
     }
@@ -110,9 +122,12 @@ contract ApprovedTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTx
         onlyWhenWalletUnlocked(wallet)
-        onlyWithMajority(wallet, signers, GuardianUtils.SigRequirement.OwnerRequired)
+        onlyFromMetaTxWithMajority(
+            wallet,
+            signers,
+            GuardianUtils.SigRequirement.OwnerRequired
+        )
     {
         approveInternal(wallet, token, to, amount);
         callContractInternal(wallet, to, 0, data);

--- a/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
@@ -77,8 +77,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
         returns (bytes32 pendingTxId)
     {
         bytes32 txid = keccak256(
@@ -124,8 +124,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
         returns (bytes32 pendingTxId)
     {
         bytes32 txid = keccak256(
@@ -174,8 +174,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         (bool allowed,) = controller.whitelistStore().isWhitelisted(wallet, to);
         require(allowed, "PROHIBITED");
@@ -196,8 +196,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         (bool allowed,) = controller.whitelistStore().isWhitelisted(wallet, to);
         if (allowed) {
@@ -225,8 +225,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         (bool allowed,) = controller.whitelistStore().isWhitelisted(wallet, to);
         if (allowed) {
@@ -255,8 +255,8 @@ contract QuotaTransfers is TransferModule
         )
         external
         nonReentrant
-        onlyFromMetaTxOrWalletOwner(wallet)
         onlyWhenWalletUnlocked(wallet)
+        onlyFromMetaTxOrWalletOwner(wallet)
     {
         require(pendingTransactions[wallet][pendingTxId] != 0, "NOT_FOUND");
         pendingTransactions[wallet][pendingTxId] = 0;


### PR DESCRIPTION
Instead of using enums with specific names for guardian groups, which we don't use, I just changed it so that it's possible to put a guardian in a certain group (nameless). The group decides which rules to follow:
- Group 0: No grouping (1 vote/guardian)
- Groups [1, 5]: Single guardian needed per group
- Groups [6, 10]: Half the guardians needed per group
- Groups [11, 15]: A majority of guardians needed per group

The reason for this fixed group ordering is that it makes counting the number of votes very easy and there's no need for an unlimited number of groups.

This way we don't try to make decisions on-chain what to do with certain types of guardians because this ended up being harder than expected (I don't believe there are universal rules that always work best for this). The user/UI can now decide how to group guardians and with which rules. Of course, the existing approach is compatible with the code in this PR.