### PR TITLE
[hebao] Some small changes for price caching

### DIFF
--- a/packages/hebao_v1/contracts/base/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/base/ControllerImpl.sol
@@ -39,7 +39,6 @@ contract ControllerImpl is Claimable, Controller
         address           _collectTo,
         ModuleRegistry    _moduleRegistry,
         WalletRegistry    _walletRegistry,
-        PriceCacheStore   _priceCacheStore,
         QuotaStore        _quotaStore,
         SecurityStore     _securityStore,
         WhitelistStore    _whitelistStore,
@@ -59,7 +58,6 @@ contract ControllerImpl is Claimable, Controller
         moduleRegistry = _moduleRegistry;
         walletRegistry = _walletRegistry;
 
-        priceCacheStore = _priceCacheStore;
         quotaStore = _quotaStore;
         securityStore = _securityStore;
         whitelistStore = _whitelistStore;

--- a/packages/hebao_v1/contracts/iface/Controller.sol
+++ b/packages/hebao_v1/contracts/iface/Controller.sol
@@ -20,7 +20,6 @@ import "./ModuleRegistry.sol";
 import "./WalletRegistry.sol";
 import "./ImplementationRegistry.sol";
 
-import "../stores/PriceCacheStore.sol";
 import "../stores/QuotaStore.sol";
 import "../stores/SecurityStore.sol";
 import "../stores/WhitelistStore.sol";
@@ -43,7 +42,6 @@ contract Controller
     WalletRegistry          public walletRegistry;
     ImplementationRegistry  public implementationRegistry;
 
-    PriceCacheStore         public priceCacheStore;
     QuotaStore              public quotaStore;
     SecurityStore           public securityStore;
     WhitelistStore          public whitelistStore;

--- a/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/QuotaTransfers.sol
@@ -292,20 +292,6 @@ contract QuotaTransfers is TransferModule
         return timestamp > 0 && now <= timestamp + pendingExpiry;
     }
 
-    function getTokenValue(address token, uint amount)
-        private
-        returns (uint value)
-    {
-        if (amount == 0) return 0;
-        value = controller.priceCacheStore().tokenPrice(token, amount);
-        if (value == 0) {
-            value = controller.priceOracle().tokenPrice(token, amount);
-            if (value > 0) {
-                controller.priceCacheStore().cacheTokenPrice(token, amount, value);
-            }
-        }
-    }
-
     function extractMetaTxSigners(
         address wallet,
         bytes4  method,


### PR DESCRIPTION
- Token price caching shouldn't be done automatically when doing a transaction for a user. This will greatly increase the gas consumption of the user's transaction which will either make the transaction fail or the user ends up paying a lot more in gas than expected. In both cases it's the user that pays for it.
- The modules themselves only need to communicate with a `PriceOracle`, all caching can be hidden behind that interface. There's no need for the main smart wallets to have access to the `DataStore`. Price updates need to be started by an external party and how this is done for different tokens (manual price setting vs oracle vs public function anyone can call) can be programmed in a manager contract for example. Maybe we can even use [the system Compound is working](https://medium.com/compound-finance/announcing-compound-open-oracle-development-cff36f06aad3) in the future as a price oracle for a lot of tokens.