### PR TITLE
[protocol3] Use Map for DelayedTransactions

### DIFF
--- a/packages/loopring_v3/contracts/iface/IDelayedTransaction.sol
+++ b/packages/loopring_v3/contracts/iface/IDelayedTransaction.sol
@@ -66,7 +66,6 @@ contract IDelayedTransaction
     {
         address to;
         bytes4  functionSelector;
-        uint    delay;
     }
 
     // The maximum amount of time (in seconds) a pending transaction can be executed
@@ -74,12 +73,6 @@ contract IDelayedTransaction
     // If the transaction hasn't been executed before then it can be cancelled so it is removed
     // from the pending transaction list.
     uint public timeToLive;
-
-    // Active list of delayed functions (delay > 0)
-    DelayedFunction[] public delayedFunctions;
-
-    // Active list of pending transactions
-    Transaction[] public pendingTransactions;
 
     /// @dev Executes a pending transaction.
     /// @param to The contract address to call
@@ -127,10 +120,38 @@ contract IDelayedTransaction
         view
         returns (uint);
 
+    /// @dev Gets the pending transaction at the specified index
+    /// @return The pending transaction
+    function getPendingTransaction(
+        uint index
+        )
+        external
+        view
+        returns (
+            uint    id,
+            uint    timestamp,
+            address to,
+            uint    value,
+            bytes   memory data
+        );
+
     /// @dev Gets the number of functions that have a delay.
     /// @return The number of delayed functions.
     function getNumDelayedFunctions()
         external
         view
         returns (uint);
+
+    /// @dev Gets the delayed function at the specified index
+    /// @return The delayed function
+    function getDelayedFunction(
+        uint index
+        )
+        external
+        view
+        returns (
+            address to,
+            bytes4  functionSelector,
+            uint    delay
+        );
 }

--- a/packages/loopring_v3/contracts/lib/Map.sol
+++ b/packages/loopring_v3/contracts/lib/Map.sol
@@ -1,0 +1,131 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+
+/// @title Map
+/// @author Daniel Wang - <daniel@loopring.org>
+library Map
+{
+    struct Data
+    {
+        bytes[] keys;
+        mapping (bytes => uint) positions;
+        mapping (bytes => bytes) values;
+    }
+
+    function set(
+        Data storage map,
+        bytes memory key,
+        bytes memory value
+        )
+        internal
+    {
+        map.values[key] = value;
+        if(map.positions[key] == 0) {
+            map.keys.push(key);
+            map.positions[key] = map.keys.length;
+        }
+    }
+
+    function remove(
+        Data storage map,
+        bytes memory key
+        )
+        internal
+    {
+        uint pos = map.positions[key];
+        require(pos != 0, "NOT_FOUND");
+
+        bytes memory lastKey = map.keys[map.keys.length - 1];
+        if (keccak256(lastKey) != keccak256(key)) {
+            map.keys[pos - 1] = lastKey;
+            map.positions[lastKey] = pos;
+        }
+        map.keys.length -= 1;
+        delete map.positions[key];
+    }
+
+    function get(
+        Data storage map,
+        bytes memory key
+        )
+        internal
+        view
+        returns (bytes memory)
+    {
+        require(contains(map, key), "NOT_FOUND");
+        return map.values[key];
+    }
+
+    function contains(
+        Data storage map,
+        bytes memory key
+        )
+        internal
+        view
+        returns (bool)
+    {
+        return map.positions[key] != 0;
+    }
+
+    function clear(
+        Data storage map
+        )
+        internal
+    {
+        for (uint i = 0; i < map.keys.length; i++) {
+            delete map.positions[map.keys[i]];
+            delete map.values[map.keys[i]];
+        }
+        map.keys.length = 0;
+    }
+
+    function size(
+        Data storage map
+        )
+        internal
+        view
+        returns (uint)
+    {
+        return map.keys.length;
+    }
+
+    function getKeys(
+        Data storage map
+        )
+        internal
+        view
+        returns (bytes[] memory)
+    {
+        return map.keys;
+    }
+
+    function getValues(
+        Data storage map
+        )
+        internal
+        view
+        returns (bytes[] memory)
+    {
+        bytes[] memory _values = new bytes[](map.keys.length);
+        for (uint i = 0; i < map.keys.length; i++) {
+            _values[i] = map.values[map.keys[i]];
+        }
+        return _values;
+    }
+}

--- a/packages/loopring_v3/contracts/lib/Set.sol
+++ b/packages/loopring_v3/contracts/lib/Set.sol
@@ -1,0 +1,101 @@
+/*
+
+  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/
+pragma solidity ^0.5.11;
+
+
+/// @title Set
+/// @author Daniel Wang - <daniel@loopring.org>
+library Set
+{
+    struct Data
+    {
+        bytes[] values;
+        mapping (bytes => uint) positions;
+        uint count;
+    }
+
+    function add(
+        Data storage set,
+        bytes memory value,
+        bool maintainList
+        )
+        internal
+    {
+        require(set.positions[value] == 0, "ALREADY_IN_SET");
+        if (maintainList) {
+            set.values.push(value);
+            set.positions[value] = set.values.length;
+        } else {
+            require(set.values.length == 0, "MUST_MAINTAIN_LIST");
+            set.positions[value] = 1;
+            set.count += 1;
+        }
+    }
+
+    function remove(
+        Data storage set,
+        bytes memory value
+        )
+        internal
+    {
+        uint pos = set.positions[value];
+        require(pos != 0, "NOT_IN_SET");
+
+        if (set.values.length > 0) {
+            bytes memory lastValue = set.values[set.values.length - 1];
+            if (keccak256(lastValue) != keccak256(value)) {
+                set.values[pos - 1] = lastValue;
+                set.positions[lastValue] = pos;
+            }
+            set.values.length -= 1;
+        } else {
+            set.count -= 1;
+        }
+        delete set.positions[value];
+    }
+
+    function contains(
+        Data storage set,
+        bytes memory value
+        )
+        internal
+        view
+        returns (bool)
+    {
+        return set.positions[value] != 0;
+    }
+
+    function size(
+        Data storage set
+        )
+        internal
+        view
+        returns (uint)
+    {
+        return set.values.length + set.count;
+    }
+
+    function getValues(
+        Data storage set
+        )
+        internal
+        view
+        returns (bytes[] memory)
+    {
+        return set.values;
+    }
+}

--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -279,7 +279,7 @@ contract("DelayedOwner", (accounts: string[]) => {
     // Try to execute the same delayed transaction again
     await expectThrow(
       delayedContract.executeTransaction(event.id),
-      "TRANSACTION_NOT_FOUND"
+      "NOT_FOUND"
     );
 
     // Check the amount of ETH in the contract after the call
@@ -347,7 +347,7 @@ contract("DelayedOwner", (accounts: string[]) => {
     // Try to cancel the a transaction twice
     await expectThrow(
       delayedContract.executeTransaction(eventD.id),
-      "TRANSACTION_NOT_FOUND"
+      "NOT_FOUND"
     );
 
     // Execute the last non-cancelled transaction
@@ -362,7 +362,7 @@ contract("DelayedOwner", (accounts: string[]) => {
     // Try to cancel the transaction after it has been executed
     await expectThrow(
       delayedContract.executeTransaction(eventB.id),
-      "TRANSACTION_NOT_FOUND"
+      "NOT_FOUND"
     );
   });
 
@@ -406,11 +406,11 @@ contract("DelayedOwner", (accounts: string[]) => {
     for (const transactionId of transactionIds) {
       await expectThrow(
         delayedContract.executeTransaction(transactionId),
-        "TRANSACTION_NOT_FOUND"
+        "NOT_FOUND"
       );
       await expectThrow(
         delayedContract.cancelTransaction(transactionId),
-        "TRANSACTION_NOT_FOUND"
+        "NOT_FOUND"
       );
     }
   });
@@ -485,12 +485,12 @@ contract("DelayedOwner", (accounts: string[]) => {
     // Try to execute the same transaction again
     await expectThrow(
       delayedContract.executeTransaction(eventA.id),
-      "TRANSACTION_NOT_FOUND"
+      "NOT_FOUND"
     );
     // Try to cancel the same transaction again
     await expectThrow(
       delayedContract.cancelTransaction(eventA.id),
-      "TRANSACTION_NOT_FOUND"
+      "NOT_FOUND"
     );
 
     // Check the amount of ETH in the contract after the call


### PR DESCRIPTION
Introduces a reusable Map and Set with bytes so they could be used for any data type (see [here](https://github.com/Loopring/protocols/pull/876#discussion_r360206847)). Having a Map directly instead of making use of a Set makes more sense in this case (as we need map functionality).

It has its pro's and con's. The code is simpler, but there's also a decent amount of boilerplate code to encode/decode structs (and expose the structs without relying on `ABIEncoderV2` for now). It would have been very nice of solidity would expose encoding/decoding structs, but [that's not the design they want to make possible unfortunately](https://github.com/ethereum/solidity/issues/7134) (the design they want to implement is not coming soon in any case, while encoding/decoding structs is already possible internally...).