### PR TITLE
update version of loopring_v3.js, and publish it to npmjs

### DIFF
--- a/packages/loopring_v3.js/index.ts
+++ b/packages/loopring_v3.js/index.ts
@@ -13,3 +13,4 @@ export * from "./src/float";
 export * from "./src/protocol_v3";
 export * from "./src/exchange_v3";
 export * from "./src/explorer";
+export * from "./src/request_processors/ring_settlement_processor";

--- a/packages/loopring_v3.js/package.json
+++ b/packages/loopring_v3.js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loopring_v3.js",
-  "version": "0.1.0",
+  "version": "0.5.2",
   "description": "loopring_v3.js",
   "main": "build/index.js",
   "types": "build/index.d.ts",


### PR DESCRIPTION
loopring_v3.js version 0.5.2 has been published to npmjs, and used by dexbrowser