### PR TITLE
[Protocol3] Prover optimizations

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/loopring_v3/ethsnarks"]
 	path = packages/loopring_v3/ethsnarks
-	url = https://github.com/LoopringSecondary/ethsnarks
+	url = https://github.com/Loopring/ethsnarks
 	branch = mcl

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/loopring_v3/ethsnarks"]
 	path = packages/loopring_v3/ethsnarks
 	url = https://github.com/LoopringSecondary/ethsnarks
-	branch = mpc
+	branch = mcl

--- a/packages/loopring_v3/Makefile
+++ b/packages/loopring_v3/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR := $(shell dirname $(realpath $(MAKEFILE_LIST)))
 PYTHON=python3
 
 # CMAKE_TYPE := cmake-release
-CMAKE_TYPE := cmake-openmp-release
+CMAKE_TYPE := cmake-openmp-performance
 
 ifeq ($(OS),Windows_NT)
 	detected_OS := Windows

--- a/packages/loopring_v3/circuit/CMakeLists.txt
+++ b/packages/loopring_v3/circuit/CMakeLists.txt
@@ -1,15 +1,28 @@
 cmake_minimum_required(VERSION 3.9)
 project(circuit)
 
+set(
+  CURVE
+  "MCL_BN128"
+  CACHE
+  STRING
+  "Default curve: one of ALT_BN128, BN128, MCL_BN128, EDWARDS, MNT4, MNT6"
+)
+
 if("${MULTICORE}")
   add_definitions(-DMULTICORE=1)
 endif()
+
+add_definitions(-DCURVE_${CURVE})
 
 # Set this to the folder containing the protocol3-circuits repo
 set(circuit_src_folder "../../../../protocol3-circuits/")
 
 add_executable(dex_circuit "${circuit_src_folder}/main.cpp")
 target_link_libraries(dex_circuit ethsnarks_jubjub)
+if("${PERFORMANCE}")
+  set_target_properties(dex_circuit PROPERTIES INTERPROCEDURAL_OPTIMIZATION TRUE)
+endif()
 
 file(GLOB test_filenames
     "${circuit_src_folder}/test/*.cpp"

--- a/packages/loopring_v3/package-lock.json
+++ b/packages/loopring_v3/package-lock.json
@@ -20987,6 +20987,7 @@
         "bluebird": "^3.5.1",
         "bn.js": "^5.0.0",
         "braces": "^3.0.2",
+        "chalk": "^3.0.0",
         "dotenv": "^8.0.0",
         "es6-iterator": "^2.0.3",
         "es6-map": "^0.1.5",
@@ -21026,6 +21027,36 @@
             "chalk": "^2.0.0",
             "esutils": "^2.0.2",
             "js-tokens": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "@sindresorhus/is": {
@@ -21064,6 +21095,11 @@
           "requires": {
             "@types/node": "*"
           }
+        },
+        "@types/color-name": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+          "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
         },
         "@types/node": {
           "version": "12.12.21",
@@ -21668,19 +21704,35 @@
           }
         },
         "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
           },
           "dependencies": {
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            "ansi-styles": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+              "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+              "requires": {
+                "@types/color-name": "^1.1.1",
+                "color-convert": "^2.0.1"
+              }
+            },
+            "color-convert": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+              "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+              "requires": {
+                "color-name": "~1.1.4"
+              }
+            },
+            "color-name": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+              "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
             }
           }
         },
@@ -22375,6 +22427,16 @@
             "text-table": "^0.2.0"
           },
           "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
             "debug": {
               "version": "4.1.1",
               "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -22382,6 +22444,16 @@
               "requires": {
                 "ms": "^2.1.1"
               }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
             },
             "ms": {
               "version": "2.1.2",
@@ -22392,6 +22464,14 @@
               "version": "5.7.1",
               "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
               "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -23123,9 +23203,9 @@
           }
         },
         "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "has-symbol-support-x": {
           "version": "1.4.2",
@@ -23326,12 +23406,40 @@
               "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
               "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+              "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+            },
             "strip-ansi": {
               "version": "5.2.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
               "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -25033,11 +25141,11 @@
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^4.0.0"
           }
         },
         "swarm-js": {
@@ -33580,26 +33688,37 @@
       }
     },
     "solc": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/solc/-/solc-0.6.1.tgz",
-      "integrity": "sha512-iKqNYps2p++x8L9sBg7JeAJb7EmW8VJ/2asAzwlLYcUhj86AzuWLe94UTSQHv1SSCCj/x6lya8twvXkZtlTbIQ==",
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/solc/-/solc-0.5.11.tgz",
+      "integrity": "sha512-F8avCCVDYnJzvIm/ITsU11GFNdFI4HaNsME+zw9lK5a3ojD3LZN2Op2cIfWg7w1HeRYRiMOU1dM77saX6jUIKw==",
       "dev": true,
       "requires": {
         "command-exists": "^1.2.8",
-        "commander": "3.0.2",
         "fs-extra": "^0.30.0",
         "js-sha3": "0.8.0",
         "memorystream": "^0.3.1",
         "require-from-string": "^2.0.0",
         "semver": "^5.5.0",
-        "tmp": "0.0.33"
+        "tmp": "0.0.33",
+        "yargs": "^13.2.0"
       },
       "dependencies": {
-        "commander": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-          "integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
         },
         "fs-extra": {
           "version": "0.30.0",
@@ -33614,6 +33733,12 @@
             "rimraf": "^2.2.8"
           }
         },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+          "dev": true
+        },
         "jsonfile": {
           "version": "2.4.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
@@ -33621,6 +33746,71 @@
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
+          }
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
+          }
+        },
+        "yargs": {
+          "version": "13.3.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+          "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
+          "dev": true,
+          "requires": {
+            "cliui": "^5.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+          "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }

--- a/packages/loopring_v3/package.json
+++ b/packages/loopring_v3/package.json
@@ -75,7 +75,7 @@
     "npm-watch": "^0.6.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0",
-    "solc": "^0.6.1",
+    "solc": "0.5.11",
     "solidity-coverage": "^0.7.0-beta.2",
     "solium": "^1.2.5",
     "truffle": "^5.0.38",

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -175,7 +175,7 @@ export class ExchangeTestUtil {
     await this.explorer.initialize(web3, this.universalRegistry.address);
 
     // Initialize LoopringV3
-    this.protocolFeeVault = this.testContext.deployer;
+    this.protocolFeeVault = this.testContext.ringMatchers[0];
 
     await this.loopringV3.updateSettings(
       this.protocolFeeVault,

--- a/packages/loopring_v3/test/testLoopringV3Owner.ts
+++ b/packages/loopring_v3/test/testLoopringV3Owner.ts
@@ -6,7 +6,7 @@ import { ExchangeTestUtil } from "./testExchangeUtil";
 
 const LoopringV3Owner = artifacts.require("LoopringV3Owner");
 const ChainlinkTokenPriceOracle = artifacts.require(
-  "ChainlinkTokenPriceOracle"
+  "ChainlinkTokenPriceProvider"
 );
 
 contract("LoopringV3Owner", (accounts: string[]) => {

--- a/packages/loopring_v3/test/testUniversalRegistry.ts
+++ b/packages/loopring_v3/test/testUniversalRegistry.ts
@@ -54,6 +54,14 @@ contract("UniversalRegistry", (accounts: string[]) => {
         exchangeCreationCostLRC,
         abi.rawEncode(["uint"], [costLRC])
       );
+      // mock mockProtocol2 protocolFeeVault return some address
+      const protocolFeeVault = web3.utils
+        .sha3("protocolFeeVault()")
+        .slice(0, 10);
+      await mockProtocol2.givenMethodReturn(
+        protocolFeeVault,
+        abi.rawEncode(["address"], [mockLRC.address])
+      );
 
       // mock mockProtocol initializeExchange return true
       const initializeExchange = web3.utils


### PR DESCRIPTION
This PR (together with the circuits PR, all on the `mcl` branch) contains the following optimizations:
- **Switched to the [mcl](https://github.com/herumi/mcl) library for curve operations.** This is also what was basically discussed in #291, but I do not use any branch of SECBIT because those branches have some issues (large diffs because of formatting changes, introduces some bugs even for standard alt_bn254). The main integration code is the same to let libsnark make use of the lib (which was mainly written by herumi himself, the author of mcl), but that's it. Other changes are minimal. The result is 2x-3x faster multi exponentiations, resulting in ~50% faster proving times (but we have some overhead so this was much less, see below). The only thing we have to do to make use of this is convert our proving keys to a slightly different binary format. I have built the necessary conversion into our circuits binary, it can be used as 
`-pk_alt2mcl <block.json> <pk_alt.raw> <pk_mlc.raw>: Converts the proving key from the alt format to the mcl format `. By default the new format is used now (as there is no reason not to), the conversion is only necessary for our trusted setup proving keys.
- **Introduced a server mode in the circuits binary**. This was necessary to make efficient use of hardware with a lot of cores. Some of the operations needed to start proving a block are slow and single-threaded:
  - Creating the circuits (creating all the constraints etc...)
  - Loading the proving key (large files + needs processing)
But these operations can be reused every time the same circuit needs to be used to prove a block! And because we'll do trade blocks ~>90% of the time with some block size we can easily have some machines set to prove those kind of blocks as efficiently as possible.
  I implemented a simple http server for instructing the prover server which works surprisingly well and is very easy to use and integrate with as any langure will have libraries to communicate with an http server. For example, a block can be proven without any extra scripting with `curl "http://localhost:1234/prove?block_filename=blocks/block_3_3.json" > proof.json`. Multiple blocks can be queued so the hardware can be used 100% efficiently without any downtime. Of course if some other mechanism is needed that can be implemented as well, but this seems to work pretty well already.
- **Parallelized the witness generation**: Some extra data needs to be generated before a block can be proven (mostly intermediate values for the constraints). This was not multi-threaded and could take some time.
- **Parallelized the block validation**: Blocks don't need to be validated before they are proven, but I guess this was re-enabled to make sure no useless proofs were generated for invalid blocks. Should only be done as long as we are unsure the relayer can create invalid blocks, otherwise this should be skipped as it is still quite expensive.
- **Enabled more compiler optimizations** when the circuits binary is compiled, which were some small but easy gains.

With these changes we can make 100% use of expensive hardware with a lot of cores without wasting time doing work on a single thread while lots of cores are just idle. When using the server mode all main tasks are now done multi-threaded and no unnecessary work is done between proving different blocks.

As a result, at least on my computers, proofs can now be generated around **70% faster** so in theory the prover costs can be reduced to ~1/3 of what they currently are. Of course, results may vary between different computers (depending on number of cores used, IO speed, ....) but without a doubt the hardware is used much more efficiently.

I think there are still some areas in the prover that can be improved, but I think I got most of the low hanging fruit in this PR. 

Almost all changes in the respective libraries:
- https://github.com/Loopring/libff/tree/mcl
- https://github.com/Loopring/libsnark/tree/mcl
- https://github.com/Loopring/ethsnarks/tree/mcl