### PR TITLE
[protocol3] Prover optimizations (part 2)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "packages/loopring_v3/ethsnarks"]
 	path = packages/loopring_v3/ethsnarks
 	url = https://github.com/Loopring/ethsnarks
-	branch = mcl
+	branch = opt

--- a/packages/loopring_v3/README.md
+++ b/packages/loopring_v3/README.md
@@ -13,7 +13,7 @@ To understand the overall design for Loopring 3.0, including Ethereum smart cont
 |                           | Loopring 2.x | Loopring 3.0 <br> (w/ Data Availability) | Loopring 3.0 <br> (w/o Data Availability) |
 | :------------------------ | :----------: | :--------------------------------------: | :---------------------------------------: |
 | Trades per Ethereum Block |      26      |                  26300                   |                  216000                   |
-| Trades per Second         |      ~2      |                   2025                   |                   16400                    |
+| Trades per Second         |      ~2      |                   2025                   |                   16400                   |
 | Cost per Trade            | ~300,000 gas |                 375 gas                  |                  47 gas                   |
 
 - _Cost in USD per Trade_ in the table does not cover off-chain proof generation.
@@ -48,7 +48,7 @@ Please use node v10.
 
 ### Circuits
 
-The code of our circuits is currently not open source. If you have access to the private repo `protocol3-circuits` please clone it and update the `circuit_src_folder` variable in `circuit/CMakeLists.txt` so it points to the correct folder.
+Clone the `protocol3-circuits` repo and update the `circuit_src_folder` variable in `circuit/CMakeLists.txt` so it points to the correct folder.
 
 ```
 make
@@ -66,7 +66,7 @@ The circuit tests can be run with `npm run build && npm run testc`. A single tes
 - print info logs in tests: `npm run test -- -i`
 - print more detailed debug logs in tests: `npm run test -- -x`
 
-Running all tests takes around 3 hours on a modern PC with a CPU with 4 cores. Creating proofs is computationaly heavy and takes time even when multi-threading is used. Run individual tests when you can.
+Running all tests takes around 2 hours on a modern PC with a CPU with 4 cores. Creating proofs is computationaly heavy and takes time even when multi-threading is used. Run individual tests when you can.
 
 Verifier/Prover keys are cached in the `keys` folder. When updating the circuits make sure to delete the keys of older circuit versions because this is not automatically detected.
 

--- a/packages/loopring_v3/globals.d.ts
+++ b/packages/loopring_v3/globals.d.ts
@@ -12,6 +12,7 @@ declare var artifacts: any;
 declare var contract: any;
 declare var before: any;
 declare var beforeEach: any;
+declare var after: any;
 declare var describe: any;
 declare var it: any;
 declare var assert: any;

--- a/packages/loopring_v3/package.json
+++ b/packages/loopring_v3/package.json
@@ -75,7 +75,7 @@
     "npm-watch": "^0.6.0",
     "prettier": "^1.18.2",
     "pretty-quick": "^2.0.0",
-    "solc": "0.6.2",
+    "solc": "0.5.11",
     "solidity-coverage": "^0.7.0-beta.2",
     "solium": "^1.2.5",
     "truffle": "^5.0.38",

--- a/packages/loopring_v3/test/testBlockVerifier.ts
+++ b/packages/loopring_v3/test/testBlockVerifier.ts
@@ -222,6 +222,10 @@ contract("BlockVerifier", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("owner", () => {
     beforeEach(async () => {
       blockVerifier = await BlockVerifier.new({ from: owner });

--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -22,9 +22,10 @@ contract("DelayedOwner", (accounts: string[]) => {
   };
 
   const getFunctionDelay = async (to: string, functionSelector: string) => {
-    return (
-      await delayedContract.getFunctionDelay(to, functionSelector)
-    ).toNumber();
+    return (await delayedContract.getFunctionDelay(
+      to,
+      functionSelector
+    )).toNumber();
   };
 
   const checkFunctionDelay = async (
@@ -61,9 +62,7 @@ contract("DelayedOwner", (accounts: string[]) => {
   };
 
   const checkNumDelayedFunctions = async (numExpected: number) => {
-    const numDelayedFunctions = (
-      await delayedContract.getNumDelayedFunctions()
-    ).toNumber();
+    const numDelayedFunctions = (await delayedContract.getNumDelayedFunctions()).toNumber();
     assert.equal(
       numDelayedFunctions,
       numExpected,
@@ -72,9 +71,7 @@ contract("DelayedOwner", (accounts: string[]) => {
   };
 
   const checkNumPendingTransactions = async (numExpected: number) => {
-    const numPendingTransactions = (
-      await delayedContract.getNumPendingTransactions()
-    ).toNumber();
+    const numPendingTransactions = (await delayedContract.getNumPendingTransactions()).toNumber();
     assert.equal(
       numPendingTransactions,
       numExpected,
@@ -84,6 +81,10 @@ contract("DelayedOwner", (accounts: string[]) => {
 
   before(async () => {
     exchangeTestUtil = new ExchangeTestUtil();
+  });
+
+  after(async () => {
+    await exchangeTestUtil.stop();
   });
 
   beforeEach(async () => {

--- a/packages/loopring_v3/test/testExchangeAdmin.ts
+++ b/packages/loopring_v3/test/testExchangeAdmin.ts
@@ -56,6 +56,10 @@ contract("Exchange", (accounts: string[]) => {
     loopring = exchangeTestUtil.loopringV3;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Admin", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeBlockPermutations.ts
+++ b/packages/loopring_v3/test/testExchangeBlockPermutations.ts
@@ -123,6 +123,10 @@ contract("Exchange", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Permutations", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeBlocks.ts
+++ b/packages/loopring_v3/test/testExchangeBlocks.ts
@@ -57,6 +57,10 @@ contract("Exchange", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Blocks", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeCancel.ts
+++ b/packages/loopring_v3/test/testExchangeCancel.ts
@@ -14,6 +14,10 @@ contract("Exchange", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   beforeEach(async () => {
     // Fresh Exchange for each test
     exchangeId = await exchangeTestUtil.createExchange(

--- a/packages/loopring_v3/test/testExchangeDepositWithdraw.ts
+++ b/packages/loopring_v3/test/testExchangeDepositWithdraw.ts
@@ -123,9 +123,7 @@ contract("Exchange", (accounts: string[]) => {
       exchange.address,
       token
     );
-    const numAvailableSlotsBefore = (
-      await exchange.getNumAvailableDepositSlots()
-    ).toNumber();
+    const numAvailableSlotsBefore = (await exchange.getNumAvailableDepositSlots()).toNumber();
 
     const ethAddress = exchangeTestUtil.getTokenAddress("ETH");
     const ethValue = token === ethAddress ? amount.add(depositFee) : depositFee;
@@ -143,9 +141,7 @@ contract("Exchange", (accounts: string[]) => {
       exchange.address,
       token
     );
-    const numAvailableSlotsAfter = (
-      await exchange.getNumAvailableDepositSlots()
-    ).toNumber();
+    const numAvailableSlotsAfter = (await exchange.getNumAvailableDepositSlots()).toNumber();
 
     const expectedBalanceDelta =
       token === ethAddress ? amount.add(depositFee) : amount;
@@ -201,9 +197,7 @@ contract("Exchange", (accounts: string[]) => {
       exchange.address,
       token
     );
-    const numAvailableSlotsBefore = (
-      await exchange.getNumAvailableDepositSlots()
-    ).toNumber();
+    const numAvailableSlotsBefore = (await exchange.getNumAvailableDepositSlots()).toNumber();
 
     const ethValue = token === "ETH" ? amount.add(depositFee) : depositFee;
     await exchange.updateAccountAndDeposit(
@@ -223,9 +217,7 @@ contract("Exchange", (accounts: string[]) => {
       exchange.address,
       token
     );
-    const numAvailableSlotsAfter = (
-      await exchange.getNumAvailableDepositSlots()
-    ).toNumber();
+    const numAvailableSlotsAfter = (await exchange.getNumAvailableDepositSlots()).toNumber();
 
     const expectedBalanceDelta =
       token === "ETH" ? amount.add(depositFee) : amount;
@@ -547,6 +539,10 @@ contract("Exchange", (accounts: string[]) => {
     exchange = exchangeTestUtil.exchange;
     loopring = exchangeTestUtil.loopringV3;
     exchangeID = 1;
+  });
+
+  after(async () => {
+    await exchangeTestUtil.stop();
   });
 
   describe("DepositWithdraw", function() {

--- a/packages/loopring_v3/test/testExchangeInternalTransfer.ts
+++ b/packages/loopring_v3/test/testExchangeInternalTransfer.ts
@@ -72,6 +72,10 @@ contract("Exchange", (accounts: string[]) => {
     ownerD = exchangeTestUtil.testContext.orderOwners[3];
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("InternalTransfer", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeMaintenanceMode.ts
+++ b/packages/loopring_v3/test/testExchangeMaintenanceMode.ts
@@ -119,6 +119,10 @@ contract("Exchange", (accounts: string[]) => {
     exchangeID = 1;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Maintenance mode", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeNonReentrant.ts
+++ b/packages/loopring_v3/test/testExchangeNonReentrant.ts
@@ -22,6 +22,10 @@ contract("Exchange", (accounts: string[]) => {
     exchange = exchangeTestUtil.exchange;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Reentrancy", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeRingSettlement.ts
+++ b/packages/loopring_v3/test/testExchangeRingSettlement.ts
@@ -23,6 +23,10 @@ contract("Exchange", (accounts: string[]) => {
     exchangeID = 1;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   beforeEach(async () => {
     // Fresh Exchange for each test
     exchangeID = await exchangeTestUtil.createExchange(

--- a/packages/loopring_v3/test/testExchangeShutdown.ts
+++ b/packages/loopring_v3/test/testExchangeShutdown.ts
@@ -24,6 +24,10 @@ contract("Exchange", (accounts: string[]) => {
     loopringV3 = exchangeTestUtil.loopringV3;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Shutdown", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeTokens.ts
+++ b/packages/loopring_v3/test/testExchangeTokens.ts
@@ -92,6 +92,10 @@ contract("Exchange", (accounts: string[]) => {
     exchangeID = 1;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   describe("Tokens", function() {
     this.timeout(0);
 

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -2,6 +2,7 @@ import BN = require("bn.js");
 import childProcess = require("child_process");
 import fs = require("fs");
 import path = require("path");
+import http = require("http");
 import { performance } from "perf_hooks";
 import { SHA256 } from "sha2";
 import util = require("util");
@@ -154,6 +155,8 @@ export class ExchangeTestUtil {
   public commitWrongPublicDataOnce = false;
   public commitWrongProofOnce = false;
 
+  public useProverServer: boolean = true;
+
   private pendingRings: RingInfo[][] = [];
   private pendingDeposits: Deposit[][] = [];
   private pendingInternalTransfers: InternalTransferRequest[][] = [];
@@ -166,6 +169,9 @@ export class ExchangeTestUtil {
   private orderIDGenerator: number = 0;
 
   private MAX_NUM_EXCHANGES: number = 512;
+
+  private proverPorts = new Map<number, number>();
+  private portGenerator = 1234;
 
   public async initialize(accounts: string[]) {
     this.context = await this.createContractContext();
@@ -791,14 +797,10 @@ export class ExchangeTestUtil {
       token = this.testContext.tokenSymbolAddrMap.get(token);
     }
 
-    let numAvailableSlots = (
-      await this.exchange.getNumAvailableDepositSlots()
-    ).toNumber();
+    let numAvailableSlots = (await this.exchange.getNumAvailableDepositSlots()).toNumber();
     if (this.autoCommit && numAvailableSlots === 0) {
       await this.commitDeposits(exchangeID);
-      numAvailableSlots = (
-        await this.exchange.getNumAvailableDepositSlots()
-      ).toNumber();
+      numAvailableSlots = (await this.exchange.getNumAvailableDepositSlots()).toNumber();
       assert(numAvailableSlots > 0, "numAvailableSlots > 0");
     }
 
@@ -1027,14 +1029,10 @@ export class ExchangeTestUtil {
     }
     const tokenID = this.tokenAddressToIDMap.get(token);
 
-    let numAvailableSlots = (
-      await this.exchange.getNumAvailableWithdrawalSlots()
-    ).toNumber();
+    let numAvailableSlots = (await this.exchange.getNumAvailableWithdrawalSlots()).toNumber();
     if (this.autoCommit && numAvailableSlots === 0) {
       await this.commitOnchainWithdrawalRequests(exchangeID);
-      numAvailableSlots = (
-        await this.exchange.getNumAvailableWithdrawalSlots()
-      ).toNumber();
+      numAvailableSlots = (await this.exchange.getNumAvailableWithdrawalSlots()).toNumber();
       assert(numAvailableSlots > 0, "numAvailableSlots > 0");
     }
     const withdrawalFee = (await this.exchange.getFees())._withdrawalFeeETH;
@@ -1470,6 +1468,49 @@ export class ExchangeTestUtil {
     }
   }
 
+  public getKey(block: Block) {
+    let key = 0;
+    key |= block.blockType;
+    key <<= 16;
+    key |= block.blockSize;
+    key <<= 8;
+    key |= block.blockVersion;
+    return key;
+  }
+
+  public sleep(millis: number) {
+    return new Promise(resolve => setTimeout(resolve, millis));
+  }
+
+  // function returns a Promise
+  public async httpGetSync(url: string, port: number) {
+    return new Promise((resolve, reject) => {
+      http.get(url, { port, timeout: 600 }, response => {
+        let chunks_of_data: Buffer[] = [];
+
+        response.on("data", fragments => {
+          chunks_of_data.push(fragments);
+        });
+
+        response.on("end", () => {
+          let response_body = Buffer.concat(chunks_of_data);
+          resolve(response_body.toString());
+        });
+
+        response.on("error", error => {
+          reject(error);
+        });
+      });
+    });
+  }
+
+  public async stop() {
+    // Stop all prover servers
+    for (const port of this.proverPorts.values()) {
+      await this.httpGetSync("http://localhost/stop", port);
+    }
+  }
+
   public async verifyBlocks(blocks: Block[]) {
     if (blocks.length === 0) {
       return;
@@ -1486,12 +1527,54 @@ export class ExchangeTestUtil {
         "_" +
         block.blockIdx +
         "_proof.json";
-      const result = childProcess.spawnSync(
-        "build/circuit/dex_circuit",
-        ["-prove", block.filename, proofFilename],
-        { stdio: doDebugLogging() ? "inherit" : "ignore" }
-      );
-      assert(result.status === 0, "verifyBlock failed: " + block.filename);
+
+      if (this.useProverServer) {
+        const key = this.getKey(block);
+        if (!this.proverPorts.has(key)) {
+          const port = this.portGenerator++;
+          const process = childProcess.spawn(
+            "build/circuit/dex_circuit",
+            ["-server", block.filename, "" + port],
+            { detached: false, stdio: doDebugLogging() ? "inherit" : "ignore" }
+          );
+          let connected = false;
+          let numTries = 0;
+          while (!connected) {
+            // Wait for the prover server to start up
+            http
+              .get("http://localhost/status", { port }, res => {
+                console.log("prover server started on " + port);
+                connected = true;
+                this.proverPorts.set(key, port);
+              })
+              .on("error", e => {
+                numTries++;
+                if (numTries > 240) {
+                  assert(false, "prover server failed to start: " + e);
+                }
+              });
+            await this.sleep(1000);
+          }
+        }
+        const port = this.proverPorts.get(key);
+        // Generate the proof
+        let proveQuery =
+          "http://localhost/prove?block_filename=" + block.filename;
+        proveQuery += "&proof_filename=" + proofFilename;
+        proveQuery += "&validate=true";
+        await this.httpGetSync(proveQuery, port);
+      } else {
+        // Generate the proof by starting a dedicated circuit binary app instance
+        const result = childProcess.spawnSync(
+          "build/circuit/dex_circuit",
+          ["-prove", block.filename, proofFilename],
+          { stdio: doDebugLogging() ? "inherit" : "ignore" }
+        );
+        assert(
+          result.status === 0,
+          "Block proof generation failed: " + block.filename
+        );
+      }
 
       // Read the proof
       block.proof = this.flattenProof(
@@ -1655,17 +1738,8 @@ export class ExchangeTestUtil {
     // Sort the blocks for batching
     const blocks: Block[] = this.pendingBlocks[exchangeID].sort(
       (blockA: Block, blockB: Block) => {
-        const getKey = (block: Block) => {
-          let key = 0;
-          key |= block.blockType;
-          key <<= 16;
-          key |= block.blockSize;
-          key <<= 8;
-          key |= block.blockVersion;
-          return key;
-        };
-        const keyA = getKey(blockA);
-        const keyB = getKey(blockB);
+        const keyA = this.getKey(blockA);
+        const keyB = this.getKey(blockB);
         return keyA - keyB;
       }
     );
@@ -1759,9 +1833,7 @@ export class ExchangeTestUtil {
       assert(deposits.length === blockSize);
       numDepositsDone += blockSize;
 
-      const startIndex = (
-        await this.exchange.getNumDepositRequestsProcessed()
-      ).toNumber();
+      const startIndex = (await this.exchange.getNumDepositRequestsProcessed()).toNumber();
       // console.log("startIndex: " + startIndex);
       // console.log("numRequestsProcessed: " + numRequestsProcessed);
       const firstRequestData = await this.exchange.getDepositRequest(
@@ -2039,9 +2111,7 @@ export class ExchangeTestUtil {
         }
       }
 
-      const startIndex = (
-        await this.exchange.getNumWithdrawalRequestsProcessed()
-      ).toNumber();
+      const startIndex = (await this.exchange.getNumWithdrawalRequestsProcessed()).toNumber();
       // console.log("startIndex: " + startIndex);
       // console.log("numRequestsProcessed: " + numRequestsProcessed);
       const firstRequestData = await this.exchange.getWithdrawRequest(
@@ -2577,14 +2647,8 @@ export class ExchangeTestUtil {
     const ranges: Range[][] = [];
     ranges.push([{ offset: 0, length: 5 }]); // orderA.orderID + orderB.orderID
     ranges.push([{ offset: 5, length: 5 }]); // orderA.accountID + orderB.accountID
-    ranges.push([
-      { offset: 10, length: 1 },
-      { offset: 15, length: 1 }
-    ]); // orderA.tokenS + orderB.tokenS
-    ranges.push([
-      { offset: 11, length: 3 },
-      { offset: 16, length: 3 }
-    ]); // orderA.fillS + orderB.fillS
+    ranges.push([{ offset: 10, length: 1 }, { offset: 15, length: 1 }]); // orderA.tokenS + orderB.tokenS
+    ranges.push([{ offset: 11, length: 3 }, { offset: 16, length: 3 }]); // orderA.fillS + orderB.fillS
     ranges.push([{ offset: 14, length: 1 }]); // orderA.data
     ranges.push([{ offset: 19, length: 1 }]); // orderB.data
     return ranges;
@@ -2893,9 +2957,7 @@ export class ExchangeTestUtil {
     this.exchangeId = exchangeId;
     this.onchainDataAvailability = onchainDataAvailability;
 
-    const exchangeCreationTimestamp = (
-      await this.exchange.getExchangeCreationTimestamp()
-    ).toNumber();
+    const exchangeCreationTimestamp = (await this.exchange.getExchangeCreationTimestamp()).toNumber();
 
     const genesisBlock: Block = {
       blockIdx: 0,
@@ -3251,14 +3313,14 @@ export class ExchangeTestUtil {
   }
 
   public async advanceBlockTimestamp(seconds: number) {
-    const previousTimestamp = (
-      await web3.eth.getBlock(await web3.eth.getBlockNumber())
-    ).timestamp;
+    const previousTimestamp = (await web3.eth.getBlock(
+      await web3.eth.getBlockNumber()
+    )).timestamp;
     await this.evmIncreaseTime(seconds);
     await this.evmMine();
-    const currentTimestamp = (
-      await web3.eth.getBlock(await web3.eth.getBlockNumber())
-    ).timestamp;
+    const currentTimestamp = (await web3.eth.getBlock(
+      await web3.eth.getBlockNumber()
+    )).timestamp;
     assert(
       Math.abs(currentTimestamp - (previousTimestamp + seconds)) < 60,
       "Timestamp should have been increased by roughly the expected value"
@@ -4396,27 +4458,19 @@ export class ExchangeTestUtil {
     const tokenAddrDecimalsMap = new Map<string, number>();
     const tokenAddrInstanceMap = new Map<string, any>();
 
-    const [
-      eth,
-      weth,
-      lrc,
-      gto,
-      rdn,
-      rep,
-      inda,
-      indb,
-      test
-    ] = await Promise.all([
-      null,
-      this.contracts.WETHToken.deployed(),
-      this.contracts.LRCToken.deployed(),
-      this.contracts.GTOToken.deployed(),
-      this.contracts.RDNToken.deployed(),
-      this.contracts.REPToken.deployed(),
-      this.contracts.INDAToken.deployed(),
-      this.contracts.INDBToken.deployed(),
-      this.contracts.TESTToken.deployed()
-    ]);
+    const [eth, weth, lrc, gto, rdn, rep, inda, indb, test] = await Promise.all(
+      [
+        null,
+        this.contracts.WETHToken.deployed(),
+        this.contracts.LRCToken.deployed(),
+        this.contracts.GTOToken.deployed(),
+        this.contracts.RDNToken.deployed(),
+        this.contracts.REPToken.deployed(),
+        this.contracts.INDAToken.deployed(),
+        this.contracts.INDBToken.deployed(),
+        this.contracts.TESTToken.deployed()
+      ]
+    );
 
     const allTokens = [eth, weth, lrc, gto, rdn, rep, inda, indb, test];
 

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1475,6 +1475,8 @@ export class ExchangeTestUtil {
     key |= block.blockSize;
     key <<= 8;
     key |= block.blockVersion;
+    key <<= 1;
+    key |= this.onchainDataAvailability ? 1 : 0;
     return key;
   }
 
@@ -1543,7 +1545,6 @@ export class ExchangeTestUtil {
             // Wait for the prover server to start up
             http
               .get("http://localhost/status", { port }, res => {
-                console.log("prover server started on " + port);
                 connected = true;
                 this.proverPorts.set(key, port);
               })

--- a/packages/loopring_v3/test/testExchangeWithdrawalMode.ts
+++ b/packages/loopring_v3/test/testExchangeWithdrawalMode.ts
@@ -35,6 +35,10 @@ contract("Exchange", (accounts: string[]) => {
     exchangeID = 1;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   const withdrawFromMerkleTreeChecked = async (
     owner: string,
     token: string,

--- a/packages/loopring_v3/test/testLoopring.ts
+++ b/packages/loopring_v3/test/testLoopring.ts
@@ -12,6 +12,10 @@ contract("Loopring", (accounts: string[]) => {
     loopring = exchangeTestUtil.loopringV3;
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   const calculateProtocolFee = (
     minFee: BN,
     maxFee: BN,

--- a/packages/loopring_v3/test/testLoopringV3Owner.ts
+++ b/packages/loopring_v3/test/testLoopringV3Owner.ts
@@ -33,6 +33,10 @@ contract("LoopringV3Owner", (accounts: string[]) => {
     );
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   const doLrcPriceChange = async (
     loopringV3Owner: any,
     mockChainlink: any,

--- a/packages/loopring_v3/test/testMovingAveragePriceProvider.ts
+++ b/packages/loopring_v3/test/testMovingAveragePriceProvider.ts
@@ -28,6 +28,10 @@ contract("MovingAveragePriceProvider", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   const doLrcPriceChange = async (
     movingAverageProvider: any,
     mockProvider: any,

--- a/packages/loopring_v3/test/testOperator.ts
+++ b/packages/loopring_v3/test/testOperator.ts
@@ -22,6 +22,10 @@ contract("Operator 1", (accounts: string[]) => {
     await exchangeTestUtil.initialize(accounts);
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   beforeEach(async () => {
     exchangeId = await exchangeTestUtil.createExchange(
       exchangeTestUtil.testContext.stateOwners[0],

--- a/packages/loopring_v3/test/testSignatureBasedAddressWhitelist.ts
+++ b/packages/loopring_v3/test/testSignatureBasedAddressWhitelist.ts
@@ -31,6 +31,10 @@ contract("Exchange", (accounts: string[]) => {
     );
   });
 
+  after(async () => {
+    await exchangeTestUtil.stop();
+  });
+
   const generatePermissionBytes = async (
     now: any,
     address: any,


### PR DESCRIPTION
The next batch of optimizations building on #990. Compared to that version the prover should be about **5x faster on a 16 core CPU and uses 5x less memory** (less than 1GB per 1M constraints). Because of that we can now use a **c5.9xlarge** "compute optimized" instance at **$1.5/hour** to prove a 1024 trade block (currently our biggest circuit with 64M constraints). This instance type even has 18 CPU cores (though currently we can't make really good use of those 2 extra cores, but it already helps a bit).

**A 1024 trades block now only takes 105 seconds to prove on a c5.9xlarge.** Note that because a certain optimization that changes the circuits themselves currently cannot be used without redoing our trusted setup it's actually 5% slower for us now (110 seconds). So not too bad, but something to keep in mind for next trusted setups to not forget to do this optimization.

## Practical info

- **The proving key needs to be updated again**. The conversion needs to be done on top of the previous `mcl` format:
```
-pk_mcl2nozk <pk_mlc.raw> <pk_nozk.raw>: Converts the proving key from the mcl format to the nozk format
```
If the prover keys are still in their original format they first need to be converted to the `mcl` format first:

```
-pk_alt2mcl <pk_alt.raw> <pk_mlc.raw>: Converts the proving key from the alt format to the mcl format
```

- For the best performance on different hardware the prover can be tweaked using a config file. **This config file is currently required because the optimization `swapAB` needs to be turned off to be compatible with our trusted setup circuits**. This config file needs to be named `config.json` and needs to be placed in the working directory. A good config file for running on an c5.9xlarge instance is:
```
{
	"num_threads": 32,
	"smt": true,
	"fft": "recursive",
	"multi_exp_c": 16,
	"swapAB": false,
	"prefetch_stride": 16,
	"multi_exp_prefetch_locality": 1,
	"multi_exp_look_ahead": 2
}
```

You can verify the config file is correctly picked up as the config is the first thing that's being printed in the output:
```
Config: num_threads: 32, smt: 1, fft: recursive, radixes: [4,4], exp_c: 16, pre_stride: 16, exp_preloc: 1, exp_lookahead: 2
```

- **Compile with clang!** I always compile with clang but by chance I compiled with gcc and gcc creates an executable that is 10% slower than the clang executable (for some reason my FFT is 30% slower when compiled with gcc). On linux, clang can be installed and set as the default compiler like this:

```
sudo apt-get install clang
sudo update-alternatives --config c++
``` 
Now enter the number corresponding with clang and press enter. Delete the build files (if they exist) and run `make` again.

## Optimizations

A bit more in depth info about the optimizations. I will provide some more info in a medium article or you can ask me here for more information:
- New FFT implementation. Recursion based and with precomputed twiddle factors.
- Modified the multiexp algorithm so it works more like bellman. But with additional tweaks that have a large impact.
- Removed almost all memory allocations in the prover itself. Memory is allocated a single time when the prover starts up and it is reused for all proofs from then on.
- Removed some calculations that are only needed for the zero-knowledge part of groth16. As we only use snarks for scalability we do not need it.
- Memory use was reduced a lot by storing the circuit more efficiently in memory. There is still a flat buffer of all constraints currently but I have moved partially  away from that. There is still some work to completely move away from it, there could still be some decent memory savings into doing the complete migration.
  - There were many duplicated coefficients in our constraints. Coefficient are field elements so they are 32 bytes, which is quite large. These are now saved in a single pool and the constraint itself contains an index to the coefficient
  - Constraints themselves are duplicated a lot as most constraints are from Poseidon and SHA256, which mostly do the same thing each time data is hashed, just on different variables. Constraints for these are only stored once and they are modified on the fly for a particular instance.
- The circuits are now much faster to create in memory.
- The proving key is now substantially smaller and loads faster. The circuit was serialized into the proving key. We don't need that as we can regenerate the circuit from code which has some additional benefits. The A query is now stored and serialized in a sparse vector. Both save on storage and on memory.
- There's now a benchmark mode that allows easy testing of different parameters to find the optimal configuration on a certain system.

## Link to repos with the actual changes
- https://github.com/Loopring/libfqfft/tree/opt
- https://github.com/Loopring/libff/tree/opt
- https://github.com/Loopring/libsnark/tree/opt
- https://github.com/Loopring/ethsnarks/tree/opt
- https://github.com/Loopring/protocol3-circuits/tree/opt