### PR TITLE
[hebao] Fix max guardians check

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -71,9 +71,6 @@ contract GuardianModule is SecurityModule
         require(guardian != address(0), "ZERO_ADDRESS");
         require(group < GuardianUtils.MAX_NUM_GROUPS(), "INVALID_GROUP");
 
-        uint count = controller.securityStore().numGuardians(wallet);
-        require(count < MAX_GUARDIANS, "TOO_MANY_GUARDIANS");
-
         if (controller.securityStore().numGuardians(wallet) == 0) {
             controller.securityStore().addOrUpdateGuardian(wallet, guardian, group);
             emit GuardianAdded(wallet, guardian, group);
@@ -98,6 +95,11 @@ contract GuardianModule is SecurityModule
         require(confirmStart != 0, "NOT_PENDING");
         require(now >= confirmStart && now < confirmStart + confirmPeriod, "TOO_EARLY_OR_EXPIRED");
         controller.securityStore().addOrUpdateGuardian(wallet, guardian, group);
+
+        // Now check if we don't have too many guardians active at once
+        uint count = controller.securityStore().numGuardians(wallet);
+        require(count <= MAX_GUARDIANS, "TOO_MANY_GUARDIANS");
+
         delete pendingAdditions[wallet][guardian][group];
         emit GuardianAdded(wallet, guardian, group);
     }

--- a/packages/hebao_v1/test/testGuardians.ts
+++ b/packages/hebao_v1/test/testGuardians.ts
@@ -105,18 +105,7 @@ contract("GuardiansModule", (accounts: string[]) => {
 
         // Try to add another one
         await expectThrow(
-          executeTransaction(
-            ctx.guardianModule.contract.methods.addGuardian(
-              wallet,
-              accounts[i],
-              0
-            ),
-            ctx,
-            useMetaTx,
-            wallet,
-            [owner],
-            { from: owner }
-          ),
+          addGuardianChecked(owner, wallet, accounts[20 + i], 0),
           "TOO_MANY_GUARDIANS"
         );
       }
@@ -518,14 +507,10 @@ contract("GuardiansModule", (accounts: string[]) => {
         );
       }
     );
-
-
   });
 
   it(
-    description(
-      "anyone should be able to confirm guardian addition"
-    ),
+    description("anyone should be able to confirm guardian addition"),
     async () => {
       useMetaTx = false;
       const owner = ctx.owners[0];
@@ -625,5 +610,4 @@ contract("GuardiansModule", (accounts: string[]) => {
       );
     }
   );
-
 });


### PR DESCRIPTION
It was possible to add as many guardians as one wanted by first adding them all before confirming any of them because the check was against the count of active guardians in the store, and not also the amount of guardians already being added.

The check is moved after the actual addition to the store as this is the easiest and also most correct check possible. Earlier checks, like doing the check in `addGuardian`, would be quite difficult to do 100% correctly and it's not like this check will get triggered in a realistic scenario so this seems fine.