### PR TITLE
[hebao][audit] Fix issues 3 & 6

### DIFF
--- a/packages/hebao_v1/contracts/lib/MathInt.sol
+++ b/packages/hebao_v1/contracts/lib/MathInt.sol
@@ -1,60 +1,64 @@
-/*
+// Taken from
+// https://raw.githubusercontent.com/OpenZeppelin/openzeppelin-contracts/master/contracts/math/SignedSafeMath.sol
+// SPDX-License-Identifier: MIT
 
-  Copyright 2017 Loopring Project Ltd (Loopring Foundation).
-
-  Licensed under the Apache License, Version 2.0 (the "License");
-  you may not use this file except in compliance with the License.
-  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing, software
-  distributed under the License is distributed on an "AS IS" BASIS,
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  See the License for the specific language governing permissions and
-  limitations under the License.
-*/
 pragma solidity ^0.6.6;
 
+/**
+ * @title MathInt
+ * @dev Signed math operations with safety checks that revert on error.
+ */
+library MathInt {
+    int256 constant private _INT256_MIN = -2**255;
 
-/// @title Utility Functions for int
-/// @author Daniel Wang - <daniel@loopring.org>
-library MathInt
-{
-    function mul(
-        int a,
-        int b
-        )
-        internal
-        pure
-        returns (int c)
-    {
-        c = a * b;
-        require(a == 0 || c / a == b, "MUL_OVERFLOW");
+    /**
+     * @dev Multiplies two signed integers, reverts on overflow.
+     */
+    function mul(int256 a, int256 b) internal pure returns (int256) {
+        // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+        // benefit is lost if 'b' is also tested.
+        // See: https://github.com/OpenZeppelin/openzeppelin-contracts/pull/522
+        if (a == 0) {
+            return 0;
+        }
+
+        require(!(a == -1 && b == _INT256_MIN), "SignedSafeMath: multiplication overflow");
+
+        int256 c = a * b;
+        require(c / a == b, "SignedSafeMath: multiplication overflow");
+
+        return c;
     }
 
-    function sub(
-        int a,
-        int b
-        )
-        internal
-        pure
-        returns (int c)
-    {
+    /**
+     * @dev Integer division of two signed integers truncating the quotient, reverts on division by zero.
+     */
+    function div(int256 a, int256 b) internal pure returns (int256) {
+        require(b != 0, "SignedSafeMath: division by zero");
+        require(!(b == -1 && a == _INT256_MIN), "SignedSafeMath: division overflow");
 
-        c = a - b;
-        require(a == b + c, "SUB_UNDERFLOW");
+        int256 c = a / b;
+
+        return c;
     }
 
-    function add(
-        int a,
-        int b
-        )
-        internal
-        pure
-        returns (int c)
-    {
-        c = a + b;
-        require(a == c - b, "ADD_OVERFLOW");
+    /**
+     * @dev Subtracts two signed integers, reverts on overflow.
+     */
+    function sub(int256 a, int256 b) internal pure returns (int256) {
+        int256 c = a - b;
+        require((b >= 0 && c <= a) || (b < 0 && c > a), "SignedSafeMath: subtraction overflow");
+
+        return c;
+    }
+
+    /**
+     * @dev Adds two signed integers, reverts on overflow.
+     */
+    function add(int256 a, int256 b) internal pure returns (int256) {
+        int256 c = a + b;
+        require((b >= 0 && c >= a) || (b < 0 && c < a), "SignedSafeMath: addition overflow");
+
+        return c;
     }
 }

--- a/packages/hebao_v1/contracts/lib/MathUint.sol
+++ b/packages/hebao_v1/contracts/lib/MathUint.sol
@@ -21,8 +21,6 @@ pragma solidity ^0.6.6;
 /// @author Daniel Wang - <daniel@loopring.org>
 library MathUint
 {
-    using MathUint for uint;
-
     function mul(
         uint a,
         uint b
@@ -57,29 +55,5 @@ library MathUint
     {
         c = a + b;
         require(c >= a, "ADD_OVERFLOW");
-    }
-
-    // Decodes a decimal float value that is encoded like `exponent | mantissa`.
-    // Both exponent and mantissa are in base 10.
-    // Decoding to an integer is as simple as `mantissa * (10 ** exponent)`
-    // Will throw when the decoded value overflows an uint96
-    /// @param f The float value with 5 bits for the exponent
-    /// @param numBits The total number of bits (numBitsMantissa := numBits - numBitsExponent)
-    /// @return value The decoded integer value.
-    function decodeFloat(
-        uint f,
-        uint numBits
-        )
-        internal
-        pure
-        returns (uint value)
-    {
-        uint numBitsMantissa = numBits.sub(5);
-        uint exponent = f >> numBitsMantissa;
-        // log2(10**77) = 255.79 < 256
-        require(exponent <= 77, "EXPONENT_TOO_LARGE");
-        uint mantissa = f & ((1 << numBitsMantissa) - 1);
-        value = mantissa.mul(10 ** exponent);
-        require(value < (2 ** 96), "FLOAT_VALUE_TOO_LARGE");
     }
 }

--- a/packages/hebao_v1/contracts/lib/MathUint.sol
+++ b/packages/hebao_v1/contracts/lib/MathUint.sol
@@ -21,6 +21,8 @@ pragma solidity ^0.6.6;
 /// @author Daniel Wang - <daniel@loopring.org>
 library MathUint
 {
+    using MathUint for uint;
+
     function mul(
         uint a,
         uint b
@@ -57,16 +59,27 @@ library MathUint
         require(c >= a, "ADD_OVERFLOW");
     }
 
+    // Decodes a decimal float value that is encoded like `exponent | mantissa`.
+    // Both exponent and mantissa are in base 10.
+    // Decoding to an integer is as simple as `mantissa * (10 ** exponent)`
+    // Will throw when the decoded value overflows an uint96
+    /// @param f The float value with 5 bits for the exponent
+    /// @param numBits The total number of bits (numBitsMantissa := numBits - numBitsExponent)
+    /// @return value The decoded integer value.
     function decodeFloat(
-        uint f
+        uint f,
+        uint numBits
         )
         internal
         pure
         returns (uint value)
     {
-        uint numBitsMantissa = 23;
+        uint numBitsMantissa = numBits.sub(5);
         uint exponent = f >> numBitsMantissa;
+        // log2(10**77) = 255.79 < 256
+        require(exponent <= 77, "EXPONENT_TOO_LARGE");
         uint mantissa = f & ((1 << numBitsMantissa) - 1);
-        value = mantissa * (10 ** exponent);
+        value = mantissa.mul(10 ** exponent);
+        require(value < (2 ** 96), "FLOAT_VALUE_TOO_LARGE");
     }
 }

--- a/packages/loopring_v3/contracts/lib/MathUint.sol
+++ b/packages/loopring_v3/contracts/lib/MathUint.sol
@@ -21,6 +21,8 @@ pragma solidity ^0.6.6;
 /// @author Daniel Wang - <daniel@loopring.org>
 library MathUint
 {
+    using MathUint for uint;
+
     function mul(
         uint a,
         uint b
@@ -57,6 +59,13 @@ library MathUint
         require(c >= a, "ADD_OVERFLOW");
     }
 
+    // Decodes a decimal float value that is encoded like `exponent | mantissa`.
+    // Both exponent and mantissa are in base 10.
+    // Decoding to an integer is as simple as `mantissa * (10 ** exponent)`
+    // Will throw when the decoded value overflows an uint96
+    /// @param f The float value with 5 bits for the exponent
+    /// @param numBits The total number of bits (numBitsMantissa := numBits - numBitsExponent)
+    /// @return value The decoded integer value.
     function decodeFloat(
         uint f,
         uint numBits
@@ -65,10 +74,12 @@ library MathUint
         pure
         returns (uint value)
     {
-        uint numBitsMantissa = numBits - 5;
+        uint numBitsMantissa = numBits.sub(5);
         uint exponent = f >> numBitsMantissa;
+        // log2(10**77) = 255.79 < 256
+        require(exponent <= 77, "EXPONENT_TOO_LARGE");
         uint mantissa = f & ((1 << numBitsMantissa) - 1);
-        value = mantissa * (10 ** exponent);
-        require(value < (2 ** 96), "FLOAT_VALUE_TOO_BIG");
+        value = mantissa.mul(10 ** exponent);
+        require(value < (2 ** 96), "FLOAT_VALUE_TOO_LARGE");
     }
 }


### PR DESCRIPTION
- Issue 3: Replaced MathInt implementation with OpenZeppelin's SignedSafeMath implementation as recommended
- Issue 6: Added extra overflow checks for safety. Not used in hebao and `MathUint` isn't the best place for it actually, so I removed it in hebao. Will create a `Float` library for the protocols later so we don't have to copy this protocols specific function.