### PR TITLE
[hebao][Audit] Issue 6

### DIFF
--- a/packages/hebao_v1/contracts/lib/MathUint.sol
+++ b/packages/hebao_v1/contracts/lib/MathUint.sol
@@ -56,17 +56,4 @@ library MathUint
         c = a + b;
         require(c >= a, "ADD_OVERFLOW");
     }
-
-    function decodeFloat(
-        uint f
-        )
-        internal
-        pure
-        returns (uint value)
-    {
-        uint numBitsMantissa = 23;
-        uint exponent = f >> numBitsMantissa;
-        uint mantissa = f & ((1 << numBitsMantissa) - 1);
-        value = mantissa * (10 ** exponent);
-    }
 }

--- a/packages/loopring_v3/contracts/lib/MathUint.sol
+++ b/packages/loopring_v3/contracts/lib/MathUint.sol
@@ -21,6 +21,8 @@ pragma solidity ^0.6.6;
 /// @author Daniel Wang - <daniel@loopring.org>
 library MathUint
 {
+    using MathUint for uint;
+
     function mul(
         uint a,
         uint b
@@ -57,6 +59,13 @@ library MathUint
         require(c >= a, "ADD_OVERFLOW");
     }
 
+    // Decodes a decimal float value that is encoded like `exponent | mantissa`.
+    // Both exponent and mantissa are in base 10.
+    // Decoding to an integer is as simple as `mantissa * (10 ** exponent)`
+    // Will throw when the decoded value overflows an uint96
+    /// @param f The float value with 5 bits for the exponent
+    /// @param numBits The total number of bits (numBitsMantissa := numBits - numBitsExponent)
+    /// @return value The decoded integer value.
     function decodeFloat(
         uint f,
         uint numBits
@@ -65,10 +74,12 @@ library MathUint
         pure
         returns (uint value)
     {
-        uint numBitsMantissa = numBits - 5;
+        uint numBitsMantissa = numBits.sub(5);
         uint exponent = f >> numBitsMantissa;
+        // log2(10**77) = 255.79 < 256
+        require(exponent <= 77, "EXPONENT_TOO_LARGE");
         uint mantissa = f & ((1 << numBitsMantissa) - 1);
-        value = mantissa * (10 ** exponent);
-        require(value < (2 ** 96), "FLOAT_VALUE_TOO_BIG");
+        value = mantissa.mul(10 ** exponent);
+        require(value < (2 ** 96), "FLOAT_VALUE_TOO_LARGE");
     }
 }


### PR DESCRIPTION
Removed `decodeFloat` from `MathUint` used in hebao as it is not reusable but Loopring protocol 3 specific. Will create a `Float` library for the protocols later so we don't bloat `MathUint` with it.

Added extra overflow checks for safety in general cases. The floats we decode onchain can't have overflow issues because we only decode floats verified by the circuits, so they are guaranteed `< 2**96`.