### PR TITLE
[hebao][audit] issue 8

### DIFF
--- a/packages/hebao_v1/contracts/base/MetaTxModule.sol
+++ b/packages/hebao_v1/contracts/base/MetaTxModule.sol
@@ -216,7 +216,7 @@ abstract contract MetaTxModule is BaseModule
             wallet.sendETHAndVerify(msg.value, gasleft());
         }
 
-        require(gasleft() >= gasSettings.limit, "INSUFFICIENT_GAS");
+        require(gasleft() >= (gasSettings.limit.mul(64) / 63).add(40000), "INSUFFICIENT_GAS");
         uint gasUsed = gasleft();
         // solium-disable-next-line security/no-call-value
         (bool success, bytes memory returnData) = address(this).call{gas: gasSettings.limit}(data);

--- a/packages/hebao_v1/contracts/base/MetaTxModule.sol
+++ b/packages/hebao_v1/contracts/base/MetaTxModule.sol
@@ -216,7 +216,7 @@ abstract contract MetaTxModule is BaseModule
             wallet.sendETHAndVerify(msg.value, gasleft());
         }
 
-        require(gasleft() >= (gasSettings.limit.mul(64) / 63).add(40000), "INSUFFICIENT_GAS");
+        require(gasleft() >= (gasSettings.limit.mul(64) / 63).add(60000), "INSUFFICIENT_GAS");
         uint gasUsed = gasleft();
         // solium-disable-next-line security/no-call-value
         (bool success, bytes memory returnData) = address(this).call{gas: gasSettings.limit}(data);


### PR DESCRIPTION
8. MetaTxModule.sol: Relayer can cause transactions to fail by sending just above the limit the user provided.
Due to the way the VM provides gas to external calls since EIP 150 ws implemented, if the external call is executed with less gas than the ​gasSettings.limit​, only 63/64 of the available gas will be provided, allowing for the relayer to force transactions with a limit lower than the one set by the user.
A discussion around this issue is available at https://github.com/gnosis/safe-contracts/issues/100
Recommendation
Require that the gas available after the call is greater than than 65/64 of the user provided gasSettings.limit.
For reference: Implementation of the fix by the Gnosis Safe team: https://github.com/gnosis/safe-contracts/commit/62d4bd39925db65083b035115d6987772b2d2d ca

----

We followed the recommendation from solidified and add 40000 extra gas requirements.