### PR TITLE
allow providing gasLimitSendToken

### DIFF
--- a/packages/loopring_v3/DESIGN.md
+++ b/packages/loopring_v3/DESIGN.md
@@ -313,7 +313,7 @@ We store the deposit information on-chain so users can withdraw from these depos
 
 ## Withdrawing
 
-The user requests a withdrawal either on-chain or off-chain by sending the operator a withdrawal request. Once the operator has included this request in a block and the block is submitted on-chain the tokens will be automatically sent to the account owner if the transfer cost is below `GAS_LIMIT_SEND_TOKENS`. If the cost is higher the funds can still be withdrawn by anyone by calling `withdrawFromApprovedWithdrawal` (and the tokens will be sent to the account owner).
+The user requests a withdrawal either on-chain or off-chain by sending the operator a withdrawal request. Once the operator has included this request in a block and the block is submitted on-chain the tokens will be automatically sent to the account owner if the transfer cost is below `gasLimitSendToken`. If the cost is higher the funds can still be withdrawn by anyone by calling `withdrawFromApprovedWithdrawal` (and the tokens will be sent to the account owner).
 
 ### Protocol Fee
 

--- a/packages/loopring_v3/contracts/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/iface/ExchangeData.sol
@@ -124,7 +124,6 @@ library ExchangeData
         uint FEE_BLOCK_FINE_START_TIME;
         uint FEE_BLOCK_FINE_MAX_DURATION;
         uint MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED;
-        uint GAS_LIMIT_SEND_TOKENS;
     }
 
     function SNARK_SCALAR_FIELD() internal pure returns (uint) {
@@ -144,7 +143,6 @@ library ExchangeData
     function FEE_BLOCK_FINE_START_TIME() internal pure returns (uint32) { return 6 hours; }
     function FEE_BLOCK_FINE_MAX_DURATION() internal pure returns (uint32) { return 6 hours; }
     function MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED() internal pure returns (uint32) { return 1 days; }
-    function GAS_LIMIT_SEND_TOKENS() internal pure returns (uint32) { return 80000; }
 
     // Represents the entire exchange state except the owner of the exchange.
     struct State

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -198,7 +198,6 @@ abstract contract IExchangeV3 is IExchange
     ///         FEE_BLOCK_FINE_START_TIME
     ///         FEE_BLOCK_FINE_MAX_DURATION
     ///         MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED
-    ///         GAS_LIMIT_SEND_TOKENS
     function getConstants()
         external
         virtual

--- a/packages/loopring_v3/contracts/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/impl/ExchangeV3.sol
@@ -150,8 +150,7 @@ contract ExchangeV3 is IExchangeV3
             uint(ExchangeData.MAX_NUM_ACCOUNTS()),
             uint(ExchangeData.FEE_BLOCK_FINE_START_TIME()),
             uint(ExchangeData.FEE_BLOCK_FINE_MAX_DURATION()),
-            uint(ExchangeData.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED()),
-            uint(ExchangeData.GAS_LIMIT_SEND_TOKENS())
+            uint(ExchangeData.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED())
         );
     }
 
@@ -401,7 +400,8 @@ contract ExchangeV3 is IExchangeV3
 
     function submitBlocks(
         ExchangeData.Block[] calldata blocks,
-        address payable feeRecipient
+        address payable feeRecipient,
+        uint            gasLimitSendToken
         )
         external
         override
@@ -410,7 +410,8 @@ contract ExchangeV3 is IExchangeV3
     {
         state.submitBlocks(
             blocks,
-            feeRecipient
+            feeRecipient,
+            gasLimitSendToken
         );
     }
 

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -69,7 +69,8 @@ library ExchangeBlocks
     function submitBlocks(
         ExchangeData.State storage S,
         ExchangeData.Block[] memory blocks,
-        address payable feeRecipient
+        address payable feeRecipient,
+        uint            gasLimitSendToken
         )
         public
     {
@@ -96,7 +97,8 @@ library ExchangeBlocks
                 blocks[i],
                 feeRecipient,
                 publicDataHashes[i],
-                areUserRequestsEnabled
+                areUserRequestsEnabled,
+                gasLimitSendToken
             );
         }
 
@@ -115,7 +117,8 @@ library ExchangeBlocks
         ExchangeData.Block memory _block,
         address payable feeRecipient,
         bytes32 publicDataHash,
-        bool areUserRequestsEnabled
+        bool areUserRequestsEnabled,
+        uint gasLimitSendToken
         )
         private
     {
@@ -280,7 +283,7 @@ library ExchangeBlocks
                 withdrawals := add(data, start)
                 mstore(withdrawals, length)
             }
-            S.distributeWithdrawals(withdrawals);
+            S.distributeWithdrawals(withdrawals, gasLimitSendToken);
         }
 
         // Emit an event

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeConstants.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeConstants.sol
@@ -39,7 +39,6 @@ library ExchangeConstants
     ///         FEE_BLOCK_FINE_START_TIME
     ///         FEE_BLOCK_FINE_MAX_DURATION
     ///         MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED
-    ///         GAS_LIMIT_SEND_TOKENS
     function getConstants()
         external
         pure
@@ -58,8 +57,7 @@ library ExchangeConstants
             uint(ExchangeData.MAX_NUM_ACCOUNTS()),
             uint(ExchangeData.FEE_BLOCK_FINE_START_TIME()),
             uint(ExchangeData.FEE_BLOCK_FINE_MAX_DURATION()),
-            uint(ExchangeData.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED()),
-            uint(ExchangeData.GAS_LIMIT_SEND_TOKENS())
+            uint(ExchangeData.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED())
         ];
     }
 

--- a/packages/loopring_v3/contracts/test/Operator.sol
+++ b/packages/loopring_v3/contracts/test/Operator.sol
@@ -34,13 +34,15 @@ contract Operator {
 
     function submitBlocks(
         ExchangeData.Block[] calldata blocks,
-        address payable feeRecipient
+        address payable feeRecipient,
+        uint            gasLimitSendToken
         )
         external
     {
         exchange.submitBlocks(
             blocks,
-            feeRecipient
+            feeRecipient,
+            gasLimitSendToken
         );
     }
 }

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -136,7 +136,6 @@ export class ExchangeTestUtil {
   public FEE_BLOCK_FINE_START_TIME: number;
   public FEE_BLOCK_FINE_MAX_DURATION: number;
   public MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED: number;
-  public GAS_LIMIT_SEND_TOKENS: number;
 
   public dummyAccountId: number;
   public dummyAccountKeyPair: any;
@@ -260,7 +259,6 @@ export class ExchangeTestUtil {
     this.FEE_BLOCK_FINE_START_TIME = constants[10].toNumber();
     this.FEE_BLOCK_FINE_MAX_DURATION = constants[11].toNumber();
     this.MIN_AGE_PROTOCOL_FEES_UNTIL_UPDATED = constants[12].toNumber();
-    this.GAS_LIMIT_SEND_TOKENS = constants[13].toNumber();
   }
 
   public async setupTestState(exchangeID: number) {


### PR DESCRIPTION
@Brechtpd we listed TRB, whose transfer gas is very high. This makes me think maybe it's more flexible to allow the operator to specify what's the token transfer gas limit.

The other approach is to allow the operator to set the protocol level `gasLimitSendToken` variable.