### PR TITLE
[hebao] Added onlyWalletModule to HashStore/NonceStore functions

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
+++ b/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
@@ -37,7 +37,7 @@ library SignedRequest {
 
         bytes32 txHash = EIP712.hashPacked(domainSeperator, encodedRequest);
 
-        controller.hashStore().verifyAndUpdate(txHash);
+        controller.hashStore().verifyAndUpdate(request.wallet, txHash);
 
         // If txAwareHash from the mata-transaction is non-zero,
         // we must verify it matches the hash signed by the respective signers.

--- a/packages/hebao_v1/contracts/stores/HashStore.sol
+++ b/packages/hebao_v1/contracts/stores/HashStore.sol
@@ -7,16 +7,18 @@ import "../lib/MathUint.sol";
 
 /// @title HashStore
 /// @dev This store maintains all hashes for SignedRequest.
-contract HashStore
+contract HashStore is DataStore
 {
-    mapping(bytes32 => bool) public hashes;
+    // wallet => hash => consumed
+    mapping(address => mapping(bytes32 => bool)) public hashes;
 
     constructor() public {}
 
-    function verifyAndUpdate(bytes32 hash)
+    function verifyAndUpdate(address wallet, bytes32 hash)
         public
+        onlyWalletModule(wallet)
     {
-        require(!hashes[hash], "HASH_EXIST");
-        hashes[hash] = true;
+        require(!hashes[wallet][hash], "HASH_EXIST");
+        hashes[wallet][hash] = true;
     }
 }

--- a/packages/hebao_v1/contracts/stores/NonceStore.sol
+++ b/packages/hebao_v1/contracts/stores/NonceStore.sol
@@ -31,6 +31,7 @@ contract NonceStore is DataStore
 
     function verifyAndUpdate(address wallet, uint nonce)
         public
+        onlyWalletModule(wallet)
     {
         require(isNonceValid(wallet, nonce), "INVALID_NONCE");
         nonces[wallet] = nonce;

--- a/packages/hebao_v1/package.json
+++ b/packages/hebao_v1/package.json
@@ -101,6 +101,7 @@
     "eslint-utils": "^1.4.2",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
+    "eth-json-rpc-filters": "^4.1.1",
     "ethereumjs-abi": "^0.6.8",
     "ethereumjs-util": "^6.2.0",
     "ethers": "^4.0.42",


### PR DESCRIPTION
Adds `onlyWalletModule` in the store functions that need it.

I don't think it's necessary to keep the hashes separate for different wallets in HashStore as long as the hash already has the wallet address mixed in, but I don't think it hurts to do it just in case.