### PR TITLE
[Hebao_1.1] fix forwarderModule bug

### DIFF
--- a/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
+++ b/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
@@ -28,6 +28,12 @@ abstract contract MetaTxAware
         trustedForwarder = _trustedForwarder;
     }
 
+    modifier txAwareHashNotAllowed()
+    {
+        require(txAwareHash() == 0, "INVALID_TX_AWARE_HASH");
+        _;
+    }
+
     /// @dev Return's the function's logicial message sender. This method should be
     // used to replace `msg.sender` for all meta-tx enabled functions.
     function msgSender()

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -146,7 +146,7 @@ contract ForwarderModule is BaseModule
         );
 
         // Nonce update must come after the real transaction in case of new wallet creation.
-        if (metaTx.txAwareHash == 0) {
+        if (metaTx.nonce != 0) {
             controller.nonceStore().verifyAndUpdate(metaTx.from, metaTx.nonce);
         }
 

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -51,6 +51,7 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         notWalletOwner(wallet, guardian)
     {
@@ -74,6 +75,7 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         controller.securityStore().cancelGuardianAddition(wallet, guardian);
@@ -86,6 +88,7 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         onlyWalletGuardian(wallet, guardian)
     {
@@ -99,6 +102,7 @@ contract GuardianModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         controller.securityStore().cancelGuardianRemoval(wallet, guardian);
@@ -108,7 +112,7 @@ contract GuardianModule is SecurityModule
     function lock(address wallet)
         external
         nonReentrant
-        // onlyWhenWalletUnlocked(wallet)
+        txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
         onlyHaveEnoughGuardians(wallet)
     {
@@ -118,7 +122,7 @@ contract GuardianModule is SecurityModule
     function unlock(address wallet)
         external
         nonReentrant
-        // onlyWhenWalletLocked(wallet)
+        txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
     {
         unlockWallet(wallet, false);

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -55,6 +55,7 @@ contract InheritanceModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         eligibleWalletOwner(newOwner)
         notWalletOwner(wallet, newOwner)
     {
@@ -82,6 +83,7 @@ contract InheritanceModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         require(controller.walletRegistry().isWalletRegistered(_inheritor), "NOT_A_WALLET");

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -37,6 +37,7 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         controller.whitelistStore().addToWhitelist(wallet, addr, now.add(delayPeriod));
@@ -72,6 +73,7 @@ contract WhitelistModule is SecurityModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         controller.whitelistStore().removeFromWhitelist(wallet, addr);

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -53,6 +53,7 @@ contract TransferModule is BaseTransferModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         QuotaStore qs = controller.quotaStore();
@@ -99,6 +100,7 @@ contract TransferModule is BaseTransferModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         if (amount > 0 && !isTargetWhitelisted(wallet, to)) {
@@ -116,6 +118,7 @@ contract TransferModule is BaseTransferModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
@@ -134,6 +137,7 @@ contract TransferModule is BaseTransferModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
@@ -153,6 +157,7 @@ contract TransferModule is BaseTransferModule
         )
         external
         nonReentrant
+        txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {


### PR DESCRIPTION
Previously:

Someone can use meta transaction to call `addGuardian` with `nonce=0` and `txAwareHash !=0`, then change the `data` to call the same function with different parameters.

