### PR TITLE
[Loopring_3.6] Disable empty blocks

### DIFF
--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -110,6 +110,7 @@ library ExchangeBlocks
 
         S.merkleRoot = _block.data.toBytes32(offset);
         offset += 32;
+        require(uint(S.merkleRoot) != merkleRootBefore, "EMPTY_BLOCK_DISABLED");
         require(uint(S.merkleRoot) < ExchangeData.SNARK_SCALAR_FIELD(), "INVALID_MERKLE_ROOT");
 
         // Validate timestamp


### PR DESCRIPTION
I don't have a strong reason why empty blocks should be disabled, but I feel it's wrong to allow different blocks having the same root.

I guess the check may not be necessary if the relayer account's nonce must +1. But I just want to double check.