### PR TITLE
[Loopring_3.6] flat BlockVerifier key and include accountTreeDepth

### DIFF
--- a/packages/loopring_v3/contracts/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/iface/ExchangeData.sol
@@ -163,7 +163,7 @@ library ExchangeData
         bool    rollupMode;
         uint32  maxAgeDepositUntilWithdrawable;
         bytes32 emptyMerkleRoot;
-        uint    accountTreeDepth;
+        uint8   accountTreeDepth;
         bytes32 DOMAIN_SEPARATOR;
 
         ILoopringV3      loopring;

--- a/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
+++ b/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
@@ -13,6 +13,7 @@ abstract contract IBlockVerifier is Claimable
     // -- Events --
 
     event CircuitRegistered(
+        uint8  indexed accountTreeDepth,
         uint8  indexed blockType,
         bool           rollupMode,
         uint16         blockSize,
@@ -20,11 +21,21 @@ abstract contract IBlockVerifier is Claimable
     );
 
     event CircuitDisabled(
+        uint8  indexed accountTreeDepth,
         uint8  indexed blockType,
         bool           rollupMode,
         uint16         blockSize,
         uint8          blockVersion
     );
+
+    struct CircuitKey
+    {
+        uint8    accountTreeDepth;
+        uint8    blockType;
+        bool     rollupMode;
+        uint16   blockSize;
+        uint8    blockVersion;
+    }
 
     // -- Public functions --
 
@@ -32,16 +43,10 @@ abstract contract IBlockVerifier is Claimable
     ///      Every block permutation needs its own circuit and thus its own set of
     ///      verification keys. Only a limited number of block sizes per block
     ///      type are supported.
-    /// @param blockType The type of the block
-    /// @param rollupMode True to run in 100% zkRollup mode, false to run in Validium mode.
-    /// @param blockSize The number of requests handled in the block
-    /// @param blockVersion The block version (i.e. which circuit version needs to be used)
+    /// @param key The key for the circuit.
     /// @param vk The verification key
     function registerCircuit(
-        uint8    blockType,
-        bool     rollupMode,
-        uint16   blockSize,
-        uint8    blockVersion,
+        CircuitKey calldata key,
         uint[18] calldata vk
         )
         external
@@ -50,15 +55,9 @@ abstract contract IBlockVerifier is Claimable
     /// @dev Disables the use of the specified circuit.
     ///      This will stop NEW blocks from using the given circuit, blocks that were already committed
     ///      can still be verified.
-    /// @param blockType The type of the block
-    /// @param rollupMode True to run in 100% zkRollup mode, false to run in Validium mode.
-    /// @param blockSize The number of requests handled in the block
-    /// @param blockVersion The block version (i.e. which circuit version needs to be used)
+    /// @param key The key for the circuit.
     function disableCircuit(
-        uint8  blockType,
-        bool   rollupMode,
-        uint16 blockSize,
-        uint8  blockVersion
+        CircuitKey calldata key
         )
         external
         virtual;
@@ -66,18 +65,12 @@ abstract contract IBlockVerifier is Claimable
     /// @dev Verifies blocks with the given public data and proofs.
     ///      Verifying a block makes sure all requests handled in the block
     ///      are correctly handled by the operator.
-    /// @param blockType The type of block
-    /// @param rollupMode True to run in 100% zkRollup mode, false to run in Validium mode.
-    /// @param blockSize The number of requests handled in the block
-    /// @param blockVersion The block version (i.e. which circuit version needs to be used)
+    /// @param key The key for the circuit.
     /// @param publicInputs The hash of all the public data of the blocks
     /// @param proofs The ZK proofs proving that the blocks are correct
     /// @return True if the block is valid, false otherwise
     function verifyProofs(
-        uint8  blockType,
-        bool   rollupMode,
-        uint16 blockSize,
-        uint8  blockVersion,
+        CircuitKey calldata key,
         uint[] calldata publicInputs,
         uint[] calldata proofs
         )
@@ -87,16 +80,10 @@ abstract contract IBlockVerifier is Claimable
         returns (bool);
 
     /// @dev Checks if a circuit with the specified parameters is registered.
-    /// @param blockType The type of the block
-    /// @param rollupMode True to run in 100% zkRollup mode, false to run in Validium mode.
-    /// @param blockSize The number of requests handled in the block
-    /// @param blockVersion The block version (i.e. which circuit version needs to be used)
+    /// @param key The key for the circuit.
     /// @return True if the circuit is registered, false otherwise
     function isCircuitRegistered(
-        uint8  blockType,
-        bool   rollupMode,
-        uint16 blockSize,
-        uint8  blockVersion
+        CircuitKey calldata key
         )
         external
         virtual
@@ -104,16 +91,10 @@ abstract contract IBlockVerifier is Claimable
         returns (bool);
 
     /// @dev Checks if a circuit can still be used to commit new blocks.
-    /// @param blockType The type of the block
-    /// @param rollupMode True to run in 100% zkRollup mode, false to run in Validium mode.
-    /// @param blockSize The number of requests handled in the block
-    /// @param blockVersion The block version (i.e. which circuit version needs to be used)
+    /// @param key The key for the circuit.
     /// @return True if the circuit is enabled, false otherwise
     function isCircuitEnabled(
-        uint8  blockType,
-        bool   rollupMode,
-        uint16 blockSize,
-        uint8  blockVersion
+        CircuitKey calldata key
         )
         external
         virtual

--- a/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
+++ b/packages/loopring_v3/contracts/iface/IBlockVerifier.sol
@@ -11,6 +11,14 @@ import "../lib/Claimable.sol";
 abstract contract IBlockVerifier is Claimable
 {
     // -- Events --
+    struct CircuitKey
+    {
+        uint8    accountTreeDepth;
+        uint8    blockType;
+        bool     rollupMode;
+        uint16   blockSize;
+        uint8    blockVersion;
+    }
 
     event CircuitRegistered(
         uint8  indexed accountTreeDepth,
@@ -27,15 +35,6 @@ abstract contract IBlockVerifier is Claimable
         uint16         blockSize,
         uint8          blockVersion
     );
-
-    struct CircuitKey
-    {
-        uint8    accountTreeDepth;
-        uint8    blockType;
-        bool     rollupMode;
-        uint16   blockSize;
-        uint8    blockVersion;
-    }
 
     // -- Public functions --
 

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -34,7 +34,7 @@ abstract contract IExchangeV3 is IExchange
     );
 
     event AccountCapacityIncreased(
-        uint accountTreeDepth
+        uint8 accountTreeDepth
     );
 
     event Shutdown(

--- a/packages/loopring_v3/contracts/impl/BlockVerifier.sol
+++ b/packages/loopring_v3/contracts/impl/BlockVerifier.sol
@@ -110,7 +110,9 @@ contract BlockVerifier is ReentrancyGuard, IBlockVerifier
         }
     }
 
-    function isCircuitRegistered(CircuitKey calldata key)
+    function isCircuitRegistered(
+        CircuitKey calldata key
+        )
         external
         override
         view
@@ -119,7 +121,9 @@ contract BlockVerifier is ReentrancyGuard, IBlockVerifier
         return circuits[keyHash(key)].registered;
     }
 
-    function isCircuitEnabled(CircuitKey calldata key)
+    function isCircuitEnabled(
+        CircuitKey calldata key
+        )
         external
         override
         view
@@ -128,7 +132,9 @@ contract BlockVerifier is ReentrancyGuard, IBlockVerifier
         return circuits[keyHash(key)].enabled;
     }
 
-    function keyHash(CircuitKey calldata key)
+    function keyHash(
+        CircuitKey calldata key
+        )
         public
         pure
         returns (bytes32)

--- a/packages/loopring_v3/contracts/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/impl/ExchangeV3.sol
@@ -26,7 +26,7 @@ import "../iface/IExchangeV3.sol";
 contract ExchangeV3 is IExchangeV3
 {
     bytes32 constant public genesisMerkleRoot       = 0x1dacdc3f6863d9db1d903e7285ebf74b61f02d585ccb52ecaeaf97dbb773becf;
-    uint    constant public genesisAccountTreeDepth = 12;
+    uint8   constant public genesisAccountTreeDepth = 12;
 
     using MathUint              for uint;
     using ExchangeAdmins        for ExchangeData.State;

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -205,7 +205,7 @@ library ExchangeBlocks
 
             // Verify the proofs
             IBlockVerifier.CircuitKey memory key = IBlockVerifier.CircuitKey(
-                uint8(S.accountTreeDepth),
+                S.accountTreeDepth,
                 uint8(firstBlock.blockType),
                 S.rollupMode,
                 firstBlock.blockSize,

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeBlocks.sol
@@ -204,12 +204,16 @@ library ExchangeBlocks
             }
 
             // Verify the proofs
+            IBlockVerifier.CircuitKey memory key = IBlockVerifier.CircuitKey(
+                uint8(S.accountTreeDepth),
+                uint8(firstBlock.blockType),
+                S.rollupMode,
+                firstBlock.blockSize,
+                firstBlock.blockVersion
+            );
             require(
                 S.blockVerifier.verifyProofs(
-                    uint8(firstBlock.blockType),
-                    S.rollupMode,
-                    firstBlock.blockSize,
-                    firstBlock.blockVersion,
+                    key,
                     publicInputs,
                     proofs
                 ),

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
@@ -29,7 +29,7 @@ library ExchangeGenesis
         address payable _operator,
         bool    _rollupMode,
         bytes32 _genesisMerkleRoot,
-        uint    _genesisAccountTreeDepth,
+        uint8   _genesisAccountTreeDepth,
         bytes32 _domainSeperator
         )
         external


### PR DESCRIPTION
Flat the mapping inside BlockVerifier and make accountTreeDepth part of the key calculation.