### PR TITLE
[Loopring 3.6] support erc-1155

### DIFF
--- a/packages/loopring_v3/contracts/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/iface/ExchangeData.sol
@@ -30,7 +30,7 @@ library ExchangeData
     struct Token
     {
         address addr;
-        uint    tid;
+        uint    tid; // ERC1155 ID, must be 0 for ERC20.
     }
 
     struct ProtocolFeeData

--- a/packages/loopring_v3/contracts/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/iface/ExchangeData.sol
@@ -180,7 +180,7 @@ library ExchangeData
         // List of all tokens
         Token[] tokens;
 
-        // A map from a token to its tokenID + 1
+        // A map from a token (address, tid) to its tokenID + 1
         mapping (address => mapping (uint => uint16)) tokenToTokenId;
 
         // A map from an accountID to a tokenID to if the balance is withdrawn
@@ -215,7 +215,7 @@ library ExchangeData
         // Time when the exchange has entered withdrawal mode
         uint withdrawalModeStartTime;
 
-        // Last time the protocol fee was withdrawn for a specific token
+        // Last time the protocol fee (address, tid) was withdrawn for a specific token
         mapping (address => mapping(uint => uint)) protocolFeeLastWithdrawnTime;
     }
 }

--- a/packages/loopring_v3/contracts/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/iface/ExchangeData.sol
@@ -29,7 +29,8 @@ library ExchangeData
     // -- Structs --
     struct Token
     {
-        address token;
+        address addr;
+        uint    tid;
     }
 
     struct ProtocolFeeData
@@ -180,7 +181,7 @@ library ExchangeData
         Token[] tokens;
 
         // A map from a token to its tokenID + 1
-        mapping (address => uint16) tokenToTokenId;
+        mapping (address => mapping (uint => uint16)) tokenToTokenId;
 
         // A map from an accountID to a tokenID to if the balance is withdrawn
         mapping (uint32 => mapping (uint16 => bool)) withdrawnInWithdrawMode;
@@ -215,6 +216,6 @@ library ExchangeData
         uint withdrawalModeStartTime;
 
         // Last time the protocol fee was withdrawn for a specific token
-        mapping (address => uint) protocolFeeLastWithdrawnTime;
+        mapping (address => mapping(uint => uint)) protocolFeeLastWithdrawnTime;
     }
 }

--- a/packages/loopring_v3/contracts/iface/IDepositContract.sol
+++ b/packages/loopring_v3/contracts/iface/IDepositContract.sol
@@ -19,13 +19,15 @@ interface IDepositContract
     ///      This function can only be called by the exchange.
     ///
     /// @param from The address of the account that sends the tokens.
-    /// @param token The address of the token to transfer (`0x0` for ETH).
+    /// @param tokenAddr The address of the token to transfer (ETH is and cannot be suppported).
+    /// @param tokenTid The ERC1155 id.
     /// @param amount The amount of tokens to transfer.
     /// @param auxiliaryData Opaque data that can be used by the contract to handle the deposit
     /// @return amountReceived The amount to deposit to the user's account in the Merkle tree
     function deposit(
         address from,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint96  amount,
         bytes   calldata auxiliaryData
         )
@@ -47,13 +49,15 @@ interface IDepositContract
     ///
     /// @param from The address from which 'amount' tokens are transferred.
     /// @param to The address to which 'amount' tokens are transferred.
-    /// @param token The address of the token to transfer (`0x0` for ETH).
+    /// @param tokenAddr The address of the token to transfer (ETH is and cannot be suppported).
+    /// @param tokenTid The ERC1155 id.
     /// @param amount The amount of tokens transferred.
     /// @param auxiliaryData Opaque data that can be used by the contract to handle the withdrawal
     function withdraw(
         address from,
         address to,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint    amount,
         bytes   calldata auxiliaryData
         )
@@ -74,12 +78,14 @@ interface IDepositContract
     ///
     /// @param from The address of the account that sends the tokens.
     /// @param to The address to which 'amount' tokens are transferred.
-    /// @param token The address of the token to transfer (ETH is and cannot be suppported).
+    /// @param tokenAddr The address of the token to transfer (ETH is and cannot be suppported).
+    /// @param tokenTid The ERC1155 id.
     /// @param amount The amount of tokens transferred.
     function transfer(
         address from,
         address to,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint    amount
         )
         external

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -225,7 +225,7 @@ abstract contract IExchangeV3 is IExchange
         external
         virtual
         view
-        returns (ExchangeData.Token calldata token);
+        returns (ExchangeData.Token memory token);
 
     // -- Stakes --
     /// @dev Gets the amount of LRC the owner has staked onchain for this exchange.

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -196,7 +196,7 @@ abstract contract IExchangeV3 is IExchange
     ///
     ///      This function is only callable by the exchange owner.
     ///
-    /// @param  token The token's address
+    /// @param  token The token's address and tid
     /// @return tokenID The token's ID in this exchanges.
     function registerToken(
         ExchangeData.Token calldata token
@@ -206,7 +206,7 @@ abstract contract IExchangeV3 is IExchange
         returns (uint16 tokenID);
 
     /// @dev Returns the id of a registered token.
-    /// @param  token The token's address
+    /// @param  token The token's address and tid
     /// @return tokenID The token's ID in this exchanges.
     function getTokenID(
         ExchangeData.Token calldata token

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -218,7 +218,7 @@ abstract contract IExchangeV3 is IExchange
 
     /// @dev Returns the address of a registered token.
     /// @param  tokenID The token's ID in this exchanges.
-    /// @return token The token's address
+    /// @return token The token's address and tid
     function getToken(
         uint16 tokenID
         )
@@ -345,7 +345,7 @@ abstract contract IExchangeV3 is IExchange
     ///
     /// @param from The address that deposits the funds to the exchange
     /// @param to The account owner's address receiving the funds
-    /// @param token The address of the token, use `0x0` for Ether.
+    /// @param token The address and tid of the token, use `0x0` and 0 for Ether.
     /// @param amount The amount of tokens to deposit
     /// @param auxiliaryData Optional extra data used by the deposit contract
     function deposit(
@@ -373,7 +373,7 @@ abstract contract IExchangeV3 is IExchange
     ///      and create the deposit to the offchain account.
     ///
     /// @param owner The expected owner of the account
-    /// @param token The address of the token, use `0x0` for Ether.
+    /// @param token The address and tid of the token, use `0x0` and 0 for Ether.
     /// @param accountID The address the account in the Merkle tree.
     function forceWithdraw(
         address owner,
@@ -393,7 +393,7 @@ abstract contract IExchangeV3 is IExchange
     ///      time (no more than MAX_AGE_FORCED_REQUEST_UNTIL_WITHDRAW_MODE) to process the request
     ///      and create the deposit to the offchain account.
     ///
-    /// @param token The address of the token, use `0x0` for Ether.
+    /// @param token The address and tid of the token, use `0x0` and 0 for Ether.
     function withdrawProtocolFees(
         ExchangeData.Token calldata token
         )
@@ -402,7 +402,7 @@ abstract contract IExchangeV3 is IExchange
         payable;
 
     /// @dev Gets the time the protocol fee for a token was last withdrawn.
-    /// @param token The address of the token, use `0x0` for Ether.
+    /// @param token The address and tid of the token, use `0x0` and 0 for Ether.
     /// @return The time the protocol fee was last withdrawn.
     function getProtocolFeeLastWithdrawnTime(
         ExchangeData.Token calldata token

--- a/packages/loopring_v3/contracts/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/iface/IExchangeV3.sol
@@ -23,7 +23,8 @@ abstract contract IExchangeV3 is IExchange
     // -- Events --
 
     event TokenRegistered(
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint16  tokenId
     );
 
@@ -50,28 +51,32 @@ abstract contract IExchangeV3 is IExchange
 
     event DepositRequested(
         address owner,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint96  amount,
         uint    fee
     );
 
     event ForcedWithdrawalRequested(
         address owner,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint32  accountID
     );
 
     event WithdrawalCompleted(
         address from,
         address to,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint96  amount
     );
 
     event WithdrawalFailed(
         address from,
         address to,
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint96  amount
     );
 
@@ -191,20 +196,20 @@ abstract contract IExchangeV3 is IExchange
     ///
     ///      This function is only callable by the exchange owner.
     ///
-    /// @param  tokenAddress The token's address
+    /// @param  token The token's address
     /// @return tokenID The token's ID in this exchanges.
     function registerToken(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         virtual
         returns (uint16 tokenID);
 
     /// @dev Returns the id of a registered token.
-    /// @param  tokenAddress The token's address
+    /// @param  token The token's address
     /// @return tokenID The token's ID in this exchanges.
     function getTokenID(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         virtual
@@ -213,14 +218,14 @@ abstract contract IExchangeV3 is IExchange
 
     /// @dev Returns the address of a registered token.
     /// @param  tokenID The token's ID in this exchanges.
-    /// @return tokenAddress The token's address
-    function getTokenAddress(
+    /// @return token The token's address
+    function getToken(
         uint16 tokenID
         )
         external
         virtual
         view
-        returns (address tokenAddress);
+        returns (ExchangeData.Token calldata token);
 
     // -- Stakes --
     /// @dev Gets the amount of LRC the owner has staked onchain for this exchange.
@@ -340,13 +345,13 @@ abstract contract IExchangeV3 is IExchange
     ///
     /// @param from The address that deposits the funds to the exchange
     /// @param to The account owner's address receiving the funds
-    /// @param tokenAddress The address of the token, use `0x0` for Ether.
+    /// @param token The address of the token, use `0x0` for Ether.
     /// @param amount The amount of tokens to deposit
     /// @param auxiliaryData Optional extra data used by the deposit contract
     function deposit(
         address from,
         address to,
-        address tokenAddress,
+        ExchangeData.Token calldata token,
         uint96  amount,
         bytes   calldata auxiliaryData
         )
@@ -368,11 +373,11 @@ abstract contract IExchangeV3 is IExchange
     ///      and create the deposit to the offchain account.
     ///
     /// @param owner The expected owner of the account
-    /// @param tokenAddress The address of the token, use `0x0` for Ether.
+    /// @param token The address of the token, use `0x0` for Ether.
     /// @param accountID The address the account in the Merkle tree.
     function forceWithdraw(
         address owner,
-        address tokenAddress,
+        ExchangeData.Token calldata token,
         uint32  accountID
         )
         external
@@ -388,19 +393,19 @@ abstract contract IExchangeV3 is IExchange
     ///      time (no more than MAX_AGE_FORCED_REQUEST_UNTIL_WITHDRAW_MODE) to process the request
     ///      and create the deposit to the offchain account.
     ///
-    /// @param tokenAddress The address of the token, use `0x0` for Ether.
+    /// @param token The address of the token, use `0x0` for Ether.
     function withdrawProtocolFees(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         virtual
         payable;
 
     /// @dev Gets the time the protocol fee for a token was last withdrawn.
-    /// @param tokenAddress The address of the token, use `0x0` for Ether.
+    /// @param token The address of the token, use `0x0` for Ether.
     /// @return The time the protocol fee was last withdrawn.
     function getProtocolFeeLastWithdrawnTime(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         virtual
@@ -434,7 +439,7 @@ abstract contract IExchangeV3 is IExchange
     /// @param  token The token address
     function withdrawFromDepositRequest(
         address owner,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         virtual;
@@ -456,7 +461,7 @@ abstract contract IExchangeV3 is IExchange
     /// @param  tokens The token addresses
     function withdrawFromApprovedWithdrawals(
         address[] calldata owners,
-        address[] calldata tokens
+        ExchangeData.Token[] calldata tokens
         )
         external
         virtual;
@@ -467,7 +472,7 @@ abstract contract IExchangeV3 is IExchange
     /// @return The amount withdrawable
     function getAmountWithdrawable(
         address owner,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         virtual
@@ -483,7 +488,7 @@ abstract contract IExchangeV3 is IExchange
     /// @param  token The token address of the the forced request
     function notifyForcedRequestTooOld(
         uint32  accountID,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         virtual;
@@ -505,9 +510,9 @@ abstract contract IExchangeV3 is IExchange
     function approveOffchainTransfer(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint96  amount,
-        address feeToken,
+        ExchangeData.Token calldata feeToken,
         uint96  fee,
         uint    data,
         uint32  validUntil,
@@ -531,7 +536,7 @@ abstract contract IExchangeV3 is IExchange
     function setWithdrawalRecipient(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint96  amount,
         uint32  nonce,
         address newRecipient
@@ -552,7 +557,7 @@ abstract contract IExchangeV3 is IExchange
     function onchainTransferFrom(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint    amount
         )
         external

--- a/packages/loopring_v3/contracts/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/impl/ExchangeV3.sol
@@ -176,7 +176,7 @@ contract ExchangeV3 is IExchangeV3
     // -- Tokens --
 
     function registerToken(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         override
@@ -184,29 +184,29 @@ contract ExchangeV3 is IExchangeV3
         onlyOwner
         returns (uint16)
     {
-        return state.registerToken(tokenAddress);
+        return state.registerToken(token);
     }
 
     function getTokenID(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         override
         view
         returns (uint16)
     {
-        return state.getTokenID(tokenAddress);
+        return state.getTokenID(token);
     }
 
-    function getTokenAddress(
+    function getToken(
         uint16 tokenID
         )
         external
         override
         view
-        returns (address)
+        returns (ExchangeData.Token memory)
     {
-        return state.getTokenAddress(tokenID);
+        return state.getToken(tokenID);
     }
 
     // -- Stakes --
@@ -233,7 +233,7 @@ contract ExchangeV3 is IExchangeV3
 
     function withdrawProtocolFeeStake(
         address recipient,
-        uint amount
+        uint    amount
         )
         external
         override
@@ -244,14 +244,14 @@ contract ExchangeV3 is IExchangeV3
     }
 
     function getProtocolFeeLastWithdrawnTime(
-        address tokenAddress
+        ExchangeData.Token calldata token
         )
         external
         override
         view
         returns (uint)
     {
-        return state.protocolFeeLastWithdrawnTime[tokenAddress];
+        return state.protocolFeeLastWithdrawnTime[token.addr][token.tid];
     }
 
     function burnExchangeStake()
@@ -324,7 +324,7 @@ contract ExchangeV3 is IExchangeV3
     function deposit(
         address from,
         address to,
-        address tokenAddress,
+        ExchangeData.Token calldata token,
         uint96  amount,
         bytes   calldata auxiliaryData
         )
@@ -334,14 +334,14 @@ contract ExchangeV3 is IExchangeV3
         nonReentrant
         onlyFromUserOrAgent(from)
     {
-        state.deposit(from, to, tokenAddress, amount, auxiliaryData);
+        state.deposit(from, to, token, amount, auxiliaryData);
     }
 
     // -- Withdrawals --
 
     function forceWithdraw(
         address owner,
-        address token,
+        ExchangeData.Token calldata token,
         uint32  accountID
         )
         external
@@ -354,7 +354,7 @@ contract ExchangeV3 is IExchangeV3
     }
 
     function withdrawProtocolFees(
-        address token
+        ExchangeData.Token calldata token
         )
         external
         override
@@ -377,7 +377,7 @@ contract ExchangeV3 is IExchangeV3
 
     function withdrawFromDepositRequest(
         address owner,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         override
@@ -391,7 +391,7 @@ contract ExchangeV3 is IExchangeV3
 
     function withdrawFromApprovedWithdrawals(
         address[] calldata owners,
-        address[] calldata tokens
+        ExchangeData.Token[] calldata tokens
         )
         external
         override
@@ -405,7 +405,7 @@ contract ExchangeV3 is IExchangeV3
 
     function getAmountWithdrawable(
         address owner,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         override
@@ -418,7 +418,7 @@ contract ExchangeV3 is IExchangeV3
 
     function notifyForcedRequestTooOld(
         uint32  accountID,
-        address token
+        ExchangeData.Token calldata token
         )
         external
         override
@@ -440,9 +440,9 @@ contract ExchangeV3 is IExchangeV3
     function approveOffchainTransfer(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint96  amount,
-        address feeToken,
+        ExchangeData.Token calldata feeToken,
         uint96  fee,
         uint    data,
         uint32  validUntil,
@@ -474,7 +474,7 @@ contract ExchangeV3 is IExchangeV3
     function setWithdrawalRecipient(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint96  amount,
         uint32  nonce,
         address newRecipient
@@ -492,7 +492,7 @@ contract ExchangeV3 is IExchangeV3
     function onchainTransferFrom(
         address from,
         address to,
-        address token,
+        ExchangeData.Token calldata token,
         uint    amount
         )
         external
@@ -500,7 +500,7 @@ contract ExchangeV3 is IExchangeV3
         nonReentrant
         onlyFromUserOrAgent(from)
     {
-        state.depositContract.transfer(from, to, token, amount);
+        state.depositContract.transfer(from, to, token.addr, token.tid, amount);
     }
 
     function approveTransaction(

--- a/packages/loopring_v3/contracts/impl/agents/FastWithdrawalAgent.sol
+++ b/packages/loopring_v3/contracts/impl/agents/FastWithdrawalAgent.sol
@@ -58,9 +58,9 @@ contract FastWithdrawalAgent is ReentrancyGuard
         address exchange;
         address from;                   // The owner of the account
         address to;                     // The address that will receive the tokens withdrawn
-        address token;
+        ExchangeData.Token token;
         uint96  amount;
-        address feeToken;
+        ExchangeData.Token feeToken;
         uint96  fee;
         uint32  nonce;
         uint32  validUntil;
@@ -70,7 +70,7 @@ contract FastWithdrawalAgent is ReentrancyGuard
 
     // EIP712
     bytes32 constant public FASTWITHDRAWAL_TYPEHASH = keccak256(
-        "FastWithdrawal(address exchange,address from,address to,address token,uint96 amount,address feeToken,uint96 fee,uint32 nonce,uint32 validUntil)"
+        "FastWithdrawal(address exchange,address from,address to,address tokenAddr,uint tokenTid,uint96 amount,address feeTokenAddr,uint feeTokenTid,uint96 fee,uint32 nonce,uint32 validUntil)"
     );
     bytes32 public DOMAIN_SEPARATOR;
 
@@ -112,9 +112,11 @@ contract FastWithdrawalAgent is ReentrancyGuard
                         fastWithdrawal.exchange,
                         fastWithdrawal.from,
                         fastWithdrawal.to,
-                        fastWithdrawal.token,
+                        fastWithdrawal.token.addr,
+                        fastWithdrawal.token.tid,
                         fastWithdrawal.amount,
-                        fastWithdrawal.feeToken,
+                        fastWithdrawal.feeToken.addr,
+                        fastWithdrawal.feeToken.tid,
                         fastWithdrawal.fee,
                         fastWithdrawal.nonce,
                         fastWithdrawal.validUntil
@@ -165,16 +167,18 @@ contract FastWithdrawalAgent is ReentrancyGuard
     function transfer(
         address from,
         address to,
-        address token,
+        ExchangeData.Token memory token,
         uint    amount
         )
         internal
     {
+        require(token.tid == 0, "ERC20_ONLY");
+
         if (amount > 0) {
-            if (token == address(0)) {
+            if (token.addr == address(0)) {
                 to.sendETHAndVerify(amount, gasleft()); // ETH
             } else {
-                token.safeTransferFromAndVerify(from, to, amount);  // ERC20 token
+                token.addr.safeTransferFromAndVerify(from, to, amount);  // ERC20 token
             }
         }
     }

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeGenesis.sol
@@ -54,7 +54,7 @@ library ExchangeGenesis
         S.protocolFeeData.previousMakerFeeBips = S.protocolFeeData.makerFeeBips;
 
         // Call these after the main state has been set up
-        S.registerToken(address(0));
-        S.registerToken(loopring.lrcAddress());
+        S.registerToken(ExchangeData.Token({addr:address(0), tid:0}));
+        S.registerToken(ExchangeData.Token({addr:loopring.lrcAddress(), tid:0}));
     }
 }

--- a/packages/loopring_v3/contracts/impl/libexchange/ExchangeTokens.sol
+++ b/packages/loopring_v3/contracts/impl/libexchange/ExchangeTokens.sol
@@ -21,52 +21,50 @@ library ExchangeTokens
     using ExchangeMode      for ExchangeData.State;
 
     event TokenRegistered(
-        address token,
+        address tokenAddr,
+        uint    tokenTid,
         uint16  tokenId
     );
 
-    function getTokenAddress(
+    function getToken(
         ExchangeData.State storage S,
         uint16 tokenID
         )
         external
         view
-        returns (address)
+        returns (ExchangeData.Token memory)
     {
         require(tokenID < S.tokens.length, "INVALID_TOKEN_ID");
-        return S.tokens[tokenID].token;
+        return S.tokens[tokenID];
     }
 
     function registerToken(
         ExchangeData.State storage S,
-        address tokenAddress
+        ExchangeData.Token memory token
         )
         external
         returns (uint16 tokenID)
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
-        require(S.tokenToTokenId[tokenAddress] == 0, "TOKEN_ALREADY_EXIST");
+        require(S.tokenToTokenId[token.addr][token.tid] == 0, "TOKEN_ALREADY_EXIST");
         require(S.tokens.length < ExchangeData.MAX_NUM_TOKENS(), "TOKEN_REGISTRY_FULL");
 
-        ExchangeData.Token memory token = ExchangeData.Token(
-            tokenAddress
-        );
         tokenID = uint16(S.tokens.length);
         S.tokens.push(token);
-        S.tokenToTokenId[tokenAddress] = tokenID + 1;
+        S.tokenToTokenId[token.addr][token.tid] = tokenID + 1;
 
-        emit TokenRegistered(tokenAddress, tokenID);
+        emit TokenRegistered(token.addr, token.tid, tokenID);
     }
 
     function getTokenID(
         ExchangeData.State storage S,
-        address tokenAddress
+        ExchangeData.Token memory token
         )
         internal  // inline call
         view
         returns (uint16 tokenID)
     {
-        tokenID = S.tokenToTokenId[tokenAddress];
+        tokenID = S.tokenToTokenId[token.addr][token.tid];
         require(tokenID != 0, "TOKEN_NOT_FOUND");
         tokenID = tokenID - 1;
     }


### PR DESCRIPTION
Tests have not been updated yet.

I'm not sure how popular this standard can be in the near future, but if it will, then we can list some of these tokens to distinguish our platform from others that only support ERC20. The extra effort seems to be really small.