### PR TITLE
[protocol 3.6] Add custom genesis Merkle root

### DIFF
--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -118,10 +118,12 @@ abstract contract IExchangeV3 is IExchange
     /// @param  owner The owner of this exchange.
     /// @param  exchangeId The id of this exchange.
     /// @param  loopring The corresponding ILoopring contract address.
+    /// @param  genesisMerkleRoot The initial Merkle tree state.
     function initialize(
         address loopring,
         address owner,
-        uint    exchangeId
+        uint    exchangeId,
+        bytes32 genesisMerkleRoot
         )
         external
         virtual;

--- a/packages/loopring_v3/contracts/core/iface/ILoopring.sol
+++ b/packages/loopring_v3/contracts/core/iface/ILoopring.sol
@@ -17,7 +17,8 @@ abstract contract ILoopring is Claimable, ReentrancyGuard
     event ExchangeInitialized(
         uint    indexed exchangeId,
         address indexed exchangeAddress,
-        address indexed owner
+        address indexed owner,
+        bytes32         genesisMerkleRoot
     );
 
     /// @dev Returns the exchange version
@@ -34,10 +35,12 @@ abstract contract ILoopring is Claimable, ReentrancyGuard
     /// @param  exchangeAddress The address of the exchange to initialize and register.
     /// @param  exchangeId The unique exchange id.
     /// @param  owner The owner of the exchange.
+    /// @param  genesisMerkleRoot The initial Merkle tree state.
     function initializeExchange(
         address exchangeAddress,
         uint    exchangeId,
-        address owner
+        address owner,
+        bytes32 genesisMerkleRoot
         )
         external
         virtual;

--- a/packages/loopring_v3/contracts/core/iface/IUniversalRegistry.sol
+++ b/packages/loopring_v3/contracts/core/iface/IUniversalRegistry.sol
@@ -46,6 +46,7 @@ abstract contract IUniversalRegistry is Claimable, ReentrancyGuard
         address indexed implementation,
         address indexed exchangeAddress,
         address         owner,
+        bytes32         genesisMerkleRoot,
         ForgeMode       forgeMode,
         uint            exchangeId,
         uint            amountLRCBurned
@@ -103,12 +104,14 @@ abstract contract IUniversalRegistry is Claimable, ReentrancyGuard
     /// @param forgeMode The forge mode.
     /// @param protocol The protocol address, use 0x0 for default.
     /// @param implementation The implementation to use, use 0x0 for default.
+    /// @param genesisMerkleRoot The initial Merkle tree state.
     /// @return exchangeAddress The new exchange's address
     /// @return exchangeId The new exchange's ID.
     function forgeExchange(
         ForgeMode forgeMode,
         address   protocol,
-        address   implementation
+        address   implementation,
+        bytes32   genesisMerkleRoot
         )
         external
         virtual

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -25,8 +25,6 @@ import "./libtransactions/TransferTransaction.sol";
 /// @author Daniel Wang  - <daniel@loopring.org>
 contract ExchangeV3 is IExchangeV3
 {
-    bytes32 constant public genesisMerkleRoot = 0x160ca280c25b71c85d58fc0dd7b9eb42268c73c8812333da3cc2bdc8af3ee7b7;
-
     using MathUint              for uint;
     using ExchangeAdmins        for ExchangeData.State;
     using ExchangeBalances      for ExchangeData.State;
@@ -72,7 +70,8 @@ contract ExchangeV3 is IExchangeV3
     function initialize(
         address _loopring,
         address _owner,
-        uint    _id
+        uint    _id,
+        bytes32 _genesisMerkleRoot
         )
         external
         override
@@ -85,7 +84,7 @@ contract ExchangeV3 is IExchangeV3
         state.initializeGenesisBlock(
             _id,
             _loopring,
-            genesisMerkleRoot,
+            _genesisMerkleRoot,
             EIP712.hash(EIP712.Domain("Loopring Protocol", version(), address(this)))
         );
     }

--- a/packages/loopring_v3/contracts/core/impl/LoopringV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/LoopringV3.sol
@@ -52,7 +52,8 @@ contract LoopringV3 is ILoopringV3
     function initializeExchange(
         address exchangeAddress,
         uint    exchangeId,
-        address owner
+        address owner,
+        bytes32 genesisMerkleRoot
         )
         external
         override
@@ -70,7 +71,8 @@ contract LoopringV3 is ILoopringV3
         exchange.initialize(
             address(this),
             owner,
-            exchangeId
+            exchangeId,
+            genesisMerkleRoot
         );
 
         exchanges[exchangeId] = Exchange(exchangeAddress, 0, 0);
@@ -78,7 +80,8 @@ contract LoopringV3 is ILoopringV3
         emit ExchangeInitialized(
             exchangeId,
             exchangeAddress,
-            owner
+            owner,
+            genesisMerkleRoot
         );
     }
 

--- a/packages/loopring_v3/contracts/core/impl/UniversalRegistry.sol
+++ b/packages/loopring_v3/contracts/core/impl/UniversalRegistry.sol
@@ -128,7 +128,8 @@ contract UniversalRegistry is IUniversalRegistry {
     function forgeExchange(
         ForgeMode forgeMode,
         address   protocol,
-        address   implementation
+        address   implementation,
+        bytes32   genesisMerkleRoot
         )
         external
         override
@@ -164,7 +165,8 @@ contract UniversalRegistry is IUniversalRegistry {
         loopring.initializeExchange(
             exchangeAddress,
             exchangeId,
-            msg.sender   // owner
+            msg.sender,   // owner
+            genesisMerkleRoot
         );
 
         emit ExchangeForged(
@@ -172,6 +174,7 @@ contract UniversalRegistry is IUniversalRegistry {
             _implementation,
             exchangeAddress,
             msg.sender,
+            genesisMerkleRoot,
             forgeMode,
             exchangeId,
             exchangeCreationCostLRC

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -454,6 +454,8 @@ export class ExchangeTestUtil {
   private proverPorts = new Map<number, number>();
   private portGenerator = 1234;
 
+  private emptyMerkleRoot = "0x160ca280c25b71c85d58fc0dd7b9eb42268c73c8812333da3cc2bdc8af3ee7b7";
+
   public async initialize(accounts: string[]) {
     this.context = await this.createContractContext();
     this.testContext = await this.createExchangeTestContext(accounts);
@@ -2190,6 +2192,7 @@ export class ExchangeTestUtil {
       forgeMode,
       Constants.zeroAddress,
       Constants.zeroAddress,
+      this.emptyMerkleRoot,
       { from: owner }
     );
 
@@ -2254,7 +2257,7 @@ export class ExchangeTestUtil {
     const exchangeCreationTimestamp = (await this.exchange.getBlockInfo(0))
       .timestamp;
     this.GENESIS_MERKLE_ROOT = new BN(
-      (await this.exchange.genesisMerkleRoot()).slice(2),
+      (await this.exchange.getMerkleRoot()).slice(2),
       16
     );
 

--- a/packages/loopring_v3/test/testUniversalRegistry.ts
+++ b/packages/loopring_v3/test/testUniversalRegistry.ts
@@ -28,6 +28,8 @@ contract("UniversalRegistry", (accounts: string[]) => {
   const protocol2VersionStr = "2";
   const implVersionStr = "123";
 
+  const genesisMerkleRoot = "0x0123456789abcdef000000000000000000000000000000000000000000000000";
+
   before(async () => {
     contracts = new Artifacts(artifacts);
     MockContract = contracts.MockContract;
@@ -212,13 +214,14 @@ contract("UniversalRegistry", (accounts: string[]) => {
         const auto_mode = ForgeMode.AUTO_UPGRADABLE;
         const tx = await universalRegistry.forgeExchange(
           auto_mode,
-          true,
           mockProtocol2.address,
-          mockImplementation.address
+          mockImplementation.address,
+          genesisMerkleRoot
         );
         truffleAssert.eventEmitted(tx, "ExchangeForged", (evt: any) => {
           exchangeAddress = evt.exchangeAddress;
-          return evt.forgeMode == auto_mode;
+          return evt.forgeMode == auto_mode &&
+            evt.genesisMerkleRoot == genesisMerkleRoot;
         });
       });
 
@@ -226,13 +229,14 @@ contract("UniversalRegistry", (accounts: string[]) => {
         const manual_mode = ForgeMode.MANUAL_UPGRADABLE;
         const tx = await universalRegistry.forgeExchange(
           manual_mode,
-          true,
           mockProtocol2.address,
-          mockImplementation.address
+          mockImplementation.address,
+          genesisMerkleRoot
         );
         truffleAssert.eventEmitted(tx, "ExchangeForged", (evt: any) => {
           exchangeAddress = evt.exchangeAddress;
-          return evt.forgeMode == manual_mode;
+          return evt.forgeMode == manual_mode &&
+            evt.genesisMerkleRoot == genesisMerkleRoot;
         });
       });
 
@@ -240,13 +244,14 @@ contract("UniversalRegistry", (accounts: string[]) => {
         const proxied_mode = ForgeMode.PROXIED;
         const tx = await universalRegistry.forgeExchange(
           proxied_mode,
-          true,
           mockProtocol2.address,
-          mockImplementation.address
+          mockImplementation.address,
+          genesisMerkleRoot
         );
         truffleAssert.eventEmitted(tx, "ExchangeForged", (evt: any) => {
           exchangeAddress = evt.exchangeAddress;
-          return evt.forgeMode == proxied_mode;
+          return evt.forgeMode == proxied_mode &&
+            evt.genesisMerkleRoot == genesisMerkleRoot;
         });
       });
 
@@ -260,13 +265,14 @@ contract("UniversalRegistry", (accounts: string[]) => {
         );
         const tx = await universalRegistry.forgeExchange(
           native_mode,
-          true,
           mockProtocol2.address,
-          mockImplementation.address
+          mockImplementation.address,
+          genesisMerkleRoot
         );
         truffleAssert.eventEmitted(tx, "ExchangeForged", (evt: any) => {
           exchangeAddress = evt.exchangeAddress;
-          return evt.forgeMode == native_mode;
+          return evt.forgeMode == native_mode &&
+            evt.genesisMerkleRoot == genesisMerkleRoot;
         });
       });
 
@@ -275,9 +281,9 @@ contract("UniversalRegistry", (accounts: string[]) => {
         await expectThrow(
           universalRegistry.forgeExchange(
             mode,
-            true,
             mockProtocol2.address,
-            mockImplementation.address
+            mockImplementation.address,
+            genesisMerkleRoot
           ),
           "VM Exception while processing transaction"
         );


### PR DESCRIPTION
#1509, at least what is needed for the new exchange contract. We don't have to build anything more into the protocol, even when using the challenge system we can only allow funds to be transferred from the old exchange to the new exchange contract when `newExchange.getMerkleRoot() == expectedMerkleRoot` and `newExchange.getBlockHeight() == 1`.