### PR TITLE
[Hebao_1.1] option-2: meta-tx fees do not consume daily quota

### DIFF
--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -202,17 +202,4 @@ abstract contract BaseModule is ReentrancyGuard, Module
     {
         return Wallet(wallet).transact(uint8(3), to, 0, data);
     }
-
-    function reimburseGasFee(
-        address     wallet,
-        address     recipient,
-        address     gasToken,
-        uint        gasPrice,
-        uint        gasAmount
-        )
-        internal
-    {
-        uint gasCost = gasAmount.mul(gasPrice);
-        transactTokenTransfer(wallet, gasToken, recipient, gasCost);
-    }
 }

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -213,11 +213,6 @@ abstract contract BaseModule is ReentrancyGuard, Module
         internal
     {
         uint gasCost = gasAmount.mul(gasPrice);
-        uint value = controller().priceOracle().tokenValue(gasToken, gasCost);
-        if (value > 0) {
-          controller().quotaStore().checkAndAddToSpent(wallet, value);
-        }
-
         transactTokenTransfer(wallet, gasToken, recipient, gasCost);
     }
 }

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -160,12 +160,13 @@ abstract contract ForwarderModule is BaseModule
         // wallet funds.
         if (metaTx.gasPrice > 0 && (metaTx.txAwareHash == 0 || success)) {
             uint gasAmount = gasUsed < metaTx.gasLimit ? gasUsed : metaTx.gasLimit;
-            reimburseGasFee(
+            uint gasTokenAmount = gasAmount.add(GAS_OVERHEAD).mul(metaTx.gasPrice);
+
+            transactTokenTransfer(
                 metaTx.from,
-                controller().collectTo(),
                 metaTx.gasToken,
-                metaTx.gasPrice,
-                gasAmount.add(GAS_OVERHEAD)
+                controller().collectTo(),
+                gasTokenAmount
             );
         }
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -162,6 +162,8 @@ abstract contract ForwarderModule is BaseModule
             uint gasAmount = gasUsed < metaTx.gasLimit ? gasUsed : metaTx.gasLimit;
             uint gasTokenAmount = gasAmount.add(GAS_OVERHEAD).mul(metaTx.gasPrice);
 
+            // MetaTx fees do not consume wallet's daily quota for the sake of
+            // reducing meta-transactions cost.
             transactTokenTransfer(
                 metaTx.from,
                 metaTx.gasToken,

--- a/packages/hebao_v1/legacy/version1.0/test/testMetaTransactions.ts
+++ b/packages/hebao_v1/legacy/version1.0/test/testMetaTransactions.ts
@@ -306,7 +306,7 @@ contract("MetaTxmodule", () => {
 
   ["ETH", "LRC"].forEach(function(gasToken) {
     it(
-      "should be able to pay (using the daily quota) for a meta tx (" +
+      "should be able to pay (without using the daily quota) for a meta tx (" +
         gasToken +
         ")",
       async () => {
@@ -375,10 +375,7 @@ contract("MetaTxmodule", () => {
         );
         // Quota
         const newSpentQuota = await ctx.quotaStore.spentQuota(wallet);
-        assert(
-          newSpentQuota.eq(oldSpentQuota.add(assetValue)),
-          "incorrect spent quota"
-        );
+        assert(newSpentQuota.eq(oldSpentQuota), "incorrect spent quota");
       }
     );
   });

--- a/packages/hebao_v1/test/testMetaTransactions.ts
+++ b/packages/hebao_v1/test/testMetaTransactions.ts
@@ -288,7 +288,7 @@ contract("ForwarderModule", () => {
 
   ["ETH", "LRC"].forEach(function(gasToken) {
     it(
-      "should be able to pay (using the daily quota) for a meta tx (" +
+      "should be able to pay (without using the daily quota) for a meta tx (" +
         gasToken +
         ")",
       async () => {
@@ -372,10 +372,7 @@ contract("ForwarderModule", () => {
         );
         // Quota
         const newSpentQuota = await ctx.quotaStore.spentQuota(wallet);
-        assert(
-          newSpentQuota.eq(oldSpentQuota.add(assetValue)),
-          "incorrect spent quota"
-        );
+        assert(newSpentQuota.eq(oldSpentQuota), "incorrect spent quota");
       }
     );
   });


### PR DESCRIPTION
The main purpose of this change is to reduce meta-transaction cost overhead.
But this PR actually introduces a security risk, a hacker who steals a wallet's owner private key can deplete the wallet by giving away tokens as meta-tx fees.

Please also see https://github.com/Loopring/protocols/pull/1551
[Please do not merge yet!!!]