### PR TITLE
[Hebao_1.1] option-3: meta-tx fees consume daily quota only when their value > a threshold

### DIFF
--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -34,11 +34,18 @@ contract ControllerImpl is Claimable, Controller
     // Make sure this value if false in production env.
     // Ideally we can use chainid(), but there is a bug in truffle so testing is buggy:
     // https://github.com/trufflesuite/ganache/issues/1643
-    bool                public allowChangingWalletFactory;
+    bool public allowChangingWalletFactory;
+
+    uint public metaTxFeeAccoutingThreshold;
 
     event AddressChanged(
         string   name,
         address  addr
+    );
+
+    event ValueChanged(
+        string   name,
+        uint     value
     );
 
     constructor(
@@ -114,6 +121,18 @@ contract ControllerImpl is Claimable, Controller
         require(_collectTo != address(0), "ZERO_ADDRESS");
         collectTo = _collectTo;
         emit AddressChanged("CollectTo", collectTo);
+    }
+
+    function setmetaTxFeeAccoutingThreshold(uint _metaTxFeeAccoutingThreshold)
+        external
+        onlyOwner
+    {
+        require(
+            metaTxFeeAccoutingThreshold != _metaTxFeeAccoutingThreshold,
+            "SAME_VALUE"
+        );
+        metaTxFeeAccoutingThreshold = _metaTxFeeAccoutingThreshold;
+        emit ValueChanged("metaTxFeeAccoutingThreshold", metaTxFeeAccoutingThreshold);
     }
 
     function setPriceOracle(PriceOracle _priceOracle)

--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -123,7 +123,7 @@ contract ControllerImpl is Claimable, Controller
         emit AddressChanged("CollectTo", collectTo);
     }
 
-    function setmetaTxFeeAccoutingThreshold(uint _metaTxFeeAccoutingThreshold)
+    function setMetaTxFeeAccoutingThreshold(uint _metaTxFeeAccoutingThreshold)
         external
         onlyOwner
     {

--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -36,6 +36,8 @@ contract ControllerImpl is Claimable, Controller
     // https://github.com/trufflesuite/ganache/issues/1643
     bool public allowChangingWalletFactory;
 
+    // Meta-transaction fees will not be deducted from user's daily quota
+    // if the actual fee value is smaller than or equal to this value.
     uint public metaTxFeeAccoutingThreshold;
 
     event AddressChanged(

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -214,7 +214,7 @@ abstract contract BaseModule is ReentrancyGuard, Module
     {
         uint gasCost = gasAmount.mul(gasPrice);
         uint value = controller().priceOracle().tokenValue(gasToken, gasCost);
-        if (value > 0) {
+        if (value > controller().metaTxFeeAccoutingThreshold()) {
           controller().quotaStore().checkAndAddToSpent(wallet, value);
         }
 


### PR DESCRIPTION
The goal is to reduce meta-tx overhead.
If the owner key is leaked, the hacker can still deplete the account by sending a lot of meta-tx whose fee is smaller than the threshold.

Please also see https://github.com/Loopring/protocols/pull/1549