### PR TITLE
a few renaming for better readability (tests should also be updated)

### DIFF
--- a/packages/loopring_v3/contracts/core/iface/IDepositContract.sol
+++ b/packages/loopring_v3/contracts/core/iface/IDepositContract.sol
@@ -33,13 +33,13 @@ interface IDepositContract
     /// @param from The address of the account that sends the tokens.
     /// @param token The address of the token to transfer (`0x0` for ETH).
     /// @param amount The amount of tokens to transfer.
-    /// @param auxiliaryData Opaque data that can be used by the contract to handle the deposit
+    /// @param extraData Opaque data that can be used by the contract to handle the deposit
     /// @return amountReceived The amount to deposit to the user's account in the Merkle tree
     function deposit(
         address from,
         address token,
         uint96  amount,
-        bytes   calldata auxiliaryData
+        bytes   calldata extraData
         )
         external
         payable
@@ -62,13 +62,13 @@ interface IDepositContract
     /// @param to The address to which 'amount' tokens are transferred.
     /// @param token The address of the token to transfer (`0x0` for ETH).
     /// @param amount The amount of tokens transferred.
-    /// @param auxiliaryData Opaque data that can be used by the contract to handle the withdrawal
+    /// @param extraData Opaque data that can be used by the contract to handle the withdrawal
     function withdraw(
         address from,
         address to,
         address token,
         uint    amount,
-        bytes   calldata auxiliaryData
+        bytes   calldata extraData
         )
         external
         payable;

--- a/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol
+++ b/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol
@@ -85,7 +85,7 @@ contract DefaultDepositContract is IDepositContract, Claimable
         address from,
         address token,
         uint96  amount,
-        bytes   calldata /*auxiliaryData*/
+        bytes   calldata /*extraData*/
         )
         external
         override
@@ -117,7 +117,7 @@ contract DefaultDepositContract is IDepositContract, Claimable
         address to,
         address token,
         uint    amount,
-        bytes   calldata /*auxiliaryData*/
+        bytes   calldata /*extraData*/
         )
         external
         override

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -323,7 +323,7 @@ contract ExchangeV3 is IExchangeV3
         address to,
         address tokenAddress,
         uint96  amount,
-        bytes   calldata auxiliaryData
+        bytes   calldata extraData
         )
         external
         payable
@@ -331,7 +331,7 @@ contract ExchangeV3 is IExchangeV3
         nonReentrant
         onlyFromUserOrAgent(from)
     {
-        state.deposit(from, to, tokenAddress, amount, auxiliaryData);
+        state.deposit(from, to, tokenAddress, amount, extraData);
     }
 
     // -- Withdrawals --

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -461,7 +461,7 @@ contract ExchangeV3 is IExchangeV3
             validUntil: validUntil,
             storageID: storageID
         });
-        bytes32 txHash = TransferTransaction.hash(state.DOMAIN_SEPARATOR, transfer);
+        bytes32 txHash = TransferTransaction.hashTx(state.DOMAIN_SEPARATOR, transfer);
         state.approvedTx[transfer.from][txHash] = true;
         emit TransactionApproved(transfer.from, txHash);
     }

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -34,7 +34,7 @@ library ExchangeDeposits
         address to,
         address tokenAddress,
         uint96  amount,                 // can be zero
-        bytes   memory auxiliaryData
+        bytes   memory extraData
         )
         internal  // inline call
     {
@@ -52,7 +52,7 @@ library ExchangeDeposits
             from,
             tokenAddress,
             amount,
-            auxiliaryData
+            extraData
         );
 
         // Add the amount to the deposit request and reset the time the operator has to process it
@@ -75,7 +75,7 @@ library ExchangeDeposits
         address from,
         address tokenAddress,
         uint96  amount,
-        bytes   memory auxiliaryData
+        bytes   memory extraData
         )
         private
         returns (
@@ -97,7 +97,7 @@ library ExchangeDeposits
             from,
             tokenAddress,
             amount,
-            auxiliaryData
+            extraData
         );
     }
 }

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
@@ -197,7 +197,7 @@ library ExchangeWithdrawals
         address to,
         uint16  tokenID,
         uint    amount,
-        bytes   memory auxiliaryData,
+        bytes   memory extraData,
         uint    gasLimit
         )
         public
@@ -209,7 +209,7 @@ library ExchangeWithdrawals
             to,
             tokenID,
             amount,
-            auxiliaryData,
+            extraData,
             gasLimit,
             true
         );
@@ -232,7 +232,7 @@ library ExchangeWithdrawals
         address to,
         uint16  tokenID,
         uint    amount,
-        bytes   memory auxiliaryData,
+        bytes   memory extraData,
         uint    gasLimit,
         bool    allowFailure
         )
@@ -246,7 +246,7 @@ library ExchangeWithdrawals
 
         // Transfer the tokens from the deposit contract to the owner
         if (gasLimit > 0) {
-            try S.depositContract.withdraw{gas: gasLimit}(from, to, token, amount, auxiliaryData) {
+            try S.depositContract.withdraw{gas: gasLimit}(from, to, token, amount, extraData) {
                 success = true;
             } catch {
                 success = false;

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/AccountUpdateTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/AccountUpdateTransaction.sol
@@ -56,7 +56,7 @@ library AccountUpdateTransaction
         returns (uint /*feeETH*/)
     {
         // Read the account update
-        AccountUpdate memory accountUpdate = readAccountUpdate(data, offset);
+        AccountUpdate memory accountUpdate = readTx(data, offset);
         AccountUpdateAuxiliaryData memory auxData = abi.decode(auxiliaryData, (AccountUpdateAuxiliaryData));
 
         // Check validUntil
@@ -64,7 +64,7 @@ library AccountUpdateTransaction
         accountUpdate.validUntil = auxData.validUntil;
 
         // Calculate the tx hash
-        bytes32 txHash = hash(ctx.DOMAIN_SEPARATOR, accountUpdate);
+        bytes32 txHash = hashTx(ctx.DOMAIN_SEPARATOR, accountUpdate);
 
         // Check onchain authorization
         S.requireAuthorizedTx(accountUpdate.owner, auxData.signature, txHash);
@@ -72,7 +72,7 @@ library AccountUpdateTransaction
         //emit AccountUpdated(accountID, publicKey);
     }
 
-    function readAccountUpdate(
+    function readTx(
         bytes memory data,
         uint         offset
         )
@@ -102,7 +102,7 @@ library AccountUpdateTransaction
         offset += 4;
     }
 
-    function hash(
+    function hashTx(
         bytes32 DOMAIN_SEPARATOR,
         AccountUpdate memory accountUpdate
         )

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/DepositTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/DepositTransaction.sol
@@ -42,7 +42,7 @@ library DepositTransaction
         returns (uint feeETH)
     {
         // Read in the deposit
-        Deposit memory deposit = readDeposit(data, offset);
+        Deposit memory deposit = readTx(data, offset);
 
         // Process the deposit
         ExchangeData.Deposit memory pendingDeposit = S.pendingDeposits[deposit.owner][deposit.tokenID];
@@ -79,7 +79,7 @@ library DepositTransaction
         //emit DepositProcessed(owner, accountID, tokenID, amount);
     }
 
-    function readDeposit(
+    function readTx(
         bytes memory data,
         uint         offset
         )

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
@@ -61,7 +61,7 @@ library TransferTransaction
         returns (uint /*feeETH*/)
     {
         // Read the transfer
-        Transfer memory transfer = readTransfer(data, offset);
+        Transfer memory transfer = readTx(data, offset);
         TransferAuxiliaryData memory auxData = abi.decode(auxiliaryData, (TransferAuxiliaryData));
 
         // Check validUntil
@@ -69,7 +69,7 @@ library TransferTransaction
         transfer.validUntil = auxData.validUntil;
 
         // Calculate the tx hash
-        bytes32 txHash = hash(ctx.DOMAIN_SEPARATOR, transfer);
+        bytes32 txHash = hashTx(ctx.DOMAIN_SEPARATOR, transfer);
 
         // Check the on-chain authorization
         S.requireAuthorizedTx(transfer.from, auxData.signature, txHash);
@@ -77,7 +77,7 @@ library TransferTransaction
         //emit ConditionalTransferProcessed(from, to, tokenID, amount);
     }
 
-    function readTransfer(
+    function readTx(
         bytes memory data,
         uint         offset
         )
@@ -114,7 +114,7 @@ library TransferTransaction
         offset += 20;
     }
 
-    function hash(
+    function hashTx(
         bytes32 DOMAIN_SEPARATOR,
         Transfer memory transfer
         )

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
@@ -82,7 +82,7 @@ library WithdrawTransaction
         internal
         returns (uint feeETH)
     {
-        Withdrawal memory withdrawal = readWithdrawal(data, offset);
+        Withdrawal memory withdrawal = readTx(data, offset);
         WithdrawalAuxiliaryData memory auxData = abi.decode(auxiliaryData, (WithdrawalAuxiliaryData));
 
         // Validate the withdrawal data not directly part of the DA
@@ -110,7 +110,7 @@ library WithdrawTransaction
             require(block.timestamp < withdrawal.validUntil, "WITHDRAWAL_EXPIRED");
             // Check appproval onchain
             // Calculate the tx hash
-            bytes32 txHash = hash(ctx.DOMAIN_SEPARATOR, withdrawal);
+            bytes32 txHash = hashTx(ctx.DOMAIN_SEPARATOR, withdrawal);
             // Check onchain authorization
             S.requireAuthorizedTx(withdrawal.owner, auxData.signature, txHash);
         } else if (withdrawal.withdrawalType == 2 || withdrawal.withdrawalType == 3) {
@@ -189,7 +189,7 @@ library WithdrawTransaction
         );
     }
 
-    function readWithdrawal(
+    function readTx(
         bytes memory data,
         uint         offset
         )
@@ -220,7 +220,7 @@ library WithdrawTransaction
         offset += 4;
     }
 
-    function hash(
+    function hashTx(
         bytes32 DOMAIN_SEPARATOR,
         Withdrawal memory withdrawal
         )


### PR DESCRIPTION
Lets only use "auxilary" word consistently as opposed to DA, and use "extraData" for IDepositContract.