### PR TITLE
[protocol 3.6] Added missing await

### DIFF
--- a/packages/loopring_v3/test/testDelayedOwner.ts
+++ b/packages/loopring_v3/test/testDelayedOwner.ts
@@ -256,7 +256,7 @@ contract("DelayedOwner", (accounts: string[]) => {
     );
 
     // Now execute it after the necessary delay
-    delayedContract.executeTransaction(event.id);
+    await delayedContract.executeTransaction(event.id);
     assert(
       (await targetContract.value()).eq(newValue),
       "Test value unexpected"


### PR DESCRIPTION
Classic forgetting to `await` which makes tests randomly fail.