### PR TITLE
[hebao1.1] Fix a bug in UpgraderModule

### DIFF
--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -120,14 +120,15 @@ contract UpgraderModule is BaseModule {
             w.setController(controller_);
         }
 
-        for(uint i = 0; i < modulesToAdd.length; i++) {
-            if (!w.hasModule(modulesToAdd[i])) {
-                w.addModule(modulesToAdd[i]);
-            }
-        }
         for(uint i = 0; i < modulesToRemove.length; i++) {
             if (w.hasModule(modulesToRemove[i])) {
                 w.removeModule(modulesToRemove[i]);
+            }
+        }
+
+        for(uint i = 0; i < modulesToAdd.length; i++) {
+            if (!w.hasModule(modulesToAdd[i])) {
+                w.addModule(modulesToAdd[i]);
             }
         }
 


### PR DESCRIPTION
需要先删除module然后再添加。
因为添加ERC1271Module会触发bindMethod，
然后删除老的ERC1271Module的时候，又会触发unbindMethod，导致上一步bindMethod失效。
