### PR TITLE
[Hebao_1.1] add AddOfficialGuardianModule

### DIFF
--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -14,13 +14,6 @@ import "../base/BaseModule.sol";
 ///
 /// @author Daniel Wang - <daniel@loopring.org>
 contract AddOfficialGuardianModule is BaseModule {
-    event GuardianAdded (
-        address indexed wallet,
-        address         guardian,
-        uint            group,
-        uint            effectiveTime
-    );
-
     ControllerImpl private controller_;
     address        public  officialGuardian;
     uint           public  officialGuardianGroup;
@@ -66,13 +59,6 @@ contract AddOfficialGuardianModule is BaseModule {
         );
 
         ss.addGuardian(
-            wallet,
-            officialGuardian,
-            officialGuardianGroup,
-            block.timestamp
-        );
-
-        emit GuardianAdded(
             wallet,
             officialGuardian,
             officialGuardianGroup,

--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -13,7 +13,7 @@ import "../base/BaseModule.sol";
 ///      from the module list.
 ///
 /// @author Daniel Wang - <daniel@loopring.org>
-contract OfficialGuardianModule is BaseModule {
+contract AddOfficialGuardianModule is BaseModule {
     event GuardianAdded (
         address indexed wallet,
         address         guardian,

--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -60,8 +60,10 @@ contract AddOfficialGuardianModule is BaseModule {
         address payable wallet = msg.sender;
 
         SecurityStore ss = controller().securityStore();
-        uint numGuardians = ss.numGuardiansWithPending(wallet);
-        require(numGuardians == 0, "NOT_FIRST_GUARDIAN");
+        require(
+            ss.numGuardiansWithPending(wallet) == 0,
+            "NOT_THE_FIRST_GUARDIAN"
+        );
 
         ss.addGuardian(
             wallet,

--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -8,7 +8,7 @@ import "../../stores/SecurityStore.sol";
 import "../base/BaseModule.sol";
 
 
-/// @title OfficialGuardianModule
+/// @title AddOfficialGuardianModule
 /// @dev This module adds the official guardian to a wallet and removes itself
 ///      from the module list.
 ///

--- a/packages/hebao_v1/contracts/modules/aux/OfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/OfficialGuardianModule.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../base/BaseWallet.sol";
+import "../../stores/SecurityStore.sol";
+import "../base/BaseModule.sol";
+
+
+/// @title OfficialGuardianModule
+/// @dev This module adds the official guardian to a wallet and removes itself
+///      from the module list.
+///
+/// @author Daniel Wang - <daniel@loopring.org>
+contract OfficialGuardianModule is BaseModule {
+    event GuardianAdded (
+        address indexed wallet,
+        address         guardian,
+        uint            group,
+        uint            effectiveTime
+    );
+
+    ControllerImpl private controller_;
+    address        public  officialGuardian;
+    uint           public  officialGuardianGroup;
+
+    constructor(
+        ControllerImpl   _controller,
+        address          _officialGuardian,
+        uint             _officialGuardianGroup
+        )
+    {
+        controller_ = _controller;
+        officialGuardian = _officialGuardian;
+        officialGuardianGroup = _officialGuardianGroup;
+    }
+
+    function controller()
+        internal
+        view
+        override
+        returns(ControllerImpl)
+    {
+        return ControllerImpl(controller_);
+    }
+
+    function bindableMethods()
+        public
+        pure
+        override
+        returns (bytes4[] memory methods)
+    {
+    }
+
+    function activate()
+        external
+        override
+    {
+        address payable wallet = msg.sender;
+
+        SecurityStore ss = controller().securityStore();
+        uint numGuardians = ss.numGuardiansWithPending(wallet);
+        require(numGuardians == 0, "NOT_FIRST_GUARDIAN");
+
+        ss.addGuardian(
+            wallet,
+            officialGuardian,
+            officialGuardianGroup,
+            block.timestamp
+        );
+
+        emit GuardianAdded(
+            wallet,
+            officialGuardian,
+            officialGuardianGroup,
+            block.timestamp
+        );
+
+        BaseWallet(wallet).removeModule(address(this));
+    }
+}


### PR DESCRIPTION
AddOfficialGuardianModule is a self-removal module whose only job is to add the official guardian as the very first guardian to a newly created wallet.