### PR TITLE
[Loopring_v3] Two step deposit

### DIFF
--- a/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
@@ -202,6 +202,8 @@ library ExchangeData
         // A map from an account owner to a destination address to a tokenID to an amount to a nonce to a new recipient address
         mapping (address => mapping (address => mapping (uint16 => mapping (uint => mapping (uint32 => address))))) withdrawalRecipient;
 
+        // A map from apps to users to tokens to their balances
+        mapping (address => mapping(address => mapping(address => uint))) custody;
 
         // Counter to keep track of how many of forced requests are open so we can limit the work that needs to be done by the owner
         uint32 numPendingForcedTransactions;

--- a/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
@@ -203,7 +203,7 @@ library ExchangeData
         mapping (address => mapping (address => mapping (uint16 => mapping (uint => mapping (uint32 => address))))) withdrawalRecipient;
 
         // A map from apps to users to tokens to their balances
-        mapping (address => mapping(address => mapping(address => uint))) custody;
+        mapping(address => mapping(address => uint)) custody;
 
         // Counter to keep track of how many of forced requests are open so we can limit the work that needs to be done by the owner
         uint32 numPendingForcedTransactions;

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -353,18 +353,7 @@ abstract contract IExchangeV3 is IExchange
         returns (uint);
 
     function depositToCustody(
-        address user,
-        address tokenAddress,
-        uint96  amount,
-        bool    fromCustody,
-        bytes   calldata extraData
-        )
-        external
-        virtual
-        payable;
-
-    function withdrawFromCustody(
-        address payable user,
+        address from,
         address tokenAddress,
         uint96  amount,
         bytes   calldata extraData
@@ -373,6 +362,15 @@ abstract contract IExchangeV3 is IExchange
         virtual
         payable
         returns (uint _amount);
+
+    function withdrawFromCustody(
+        address to,
+        address tokenAddress,
+        uint96  amount,
+        bytes   calldata extraData
+        )
+        external
+        virtual;
 
     // -- Deposits --
 
@@ -394,6 +392,7 @@ abstract contract IExchangeV3 is IExchange
         address to,
         address tokenAddress,
         uint96  amount,
+        bool    fromCustody,
         bytes   calldata extraData
         )
         external

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -356,6 +356,7 @@ abstract contract IExchangeV3 is IExchange
         address user,
         address tokenAddress,
         uint96  amount,
+        bool    fromCustody,
         bytes   calldata extraData
         )
         external

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -352,8 +352,11 @@ abstract contract IExchangeV3 is IExchange
         view
         returns (uint);
 
+    // -- Custody --
+
     function depositToCustody(
         address from,
+        address to,
         address tokenAddress,
         uint96  amount,
         bytes   calldata extraData
@@ -364,6 +367,7 @@ abstract contract IExchangeV3 is IExchange
         returns (uint _amount);
 
     function withdrawFromCustody(
+        address from,
         address to,
         address tokenAddress,
         uint96  amount,
@@ -371,6 +375,15 @@ abstract contract IExchangeV3 is IExchange
         )
         external
         virtual;
+
+    function getCustodyBalance(
+        address user,
+        address tokenAddress
+        )
+        public
+        view
+        virtual
+        returns (uint);
 
     // -- Deposits --
 

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -352,6 +352,27 @@ abstract contract IExchangeV3 is IExchange
         view
         returns (uint);
 
+    function depositToCustody(
+        address user,
+        address tokenAddress,
+        uint96  amount,
+        bytes   calldata extraData
+        )
+        external
+        virtual
+        payable;
+
+    function withdrawFromCustody(
+        address payable user,
+        address tokenAddress,
+        uint96  amount,
+        bytes   calldata extraData
+        )
+        external
+        virtual
+        payable
+        returns (uint _amount);
+
     // -- Deposits --
 
     /// @dev Deposits Ether or ERC20 tokens to the specified account.
@@ -366,13 +387,13 @@ abstract contract IExchangeV3 is IExchange
     /// @param to The account owner's address receiving the funds
     /// @param tokenAddress The address of the token, use `0x0` for Ether.
     /// @param amount The amount of tokens to deposit
-    /// @param auxiliaryData Optional extra data used by the deposit contract
+    /// @param extraData Optional extra data used by the deposit contract
     function deposit(
         address from,
         address to,
         address tokenAddress,
         uint96  amount,
-        bytes   calldata auxiliaryData
+        bytes   calldata extraData
         )
         external
         virtual

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -360,6 +360,37 @@ contract ExchangeV3 is IExchangeV3
         return state.getNumAvailableForcedSlots();
     }
 
+    function depositToCustody(
+        address from,
+        address tokenAddress,
+        uint96  amount,
+        bytes   calldata extraData
+        )
+        external
+        payable
+        override
+        nonReentrant
+        onlyFromUserOrAgent(from)
+        returns (uint _amount)
+    {
+        return state.depositToCustody(from, tokenAddress, amount, extraData);
+    }
+
+    function withdrawFromCustody(
+        address payable to,
+        address tokenAddress,
+        uint96  amount,
+        bytes   calldata extraData
+        )
+        external
+        override
+        nonReentrant
+        onlyFromUserOrAgent(to)
+        returns (uint _amount)
+    {
+        return state.withdrawFromCustody(to, tokenAddress, amount, extraData);
+    }
+
     // -- Deposits --
 
     function deposit(

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -370,14 +370,13 @@ contract ExchangeV3 is IExchangeV3
         payable
         override
         nonReentrant
-        onlyFromUserOrAgent(from)
         returns (uint _amount)
     {
-        return state.depositToCustody(from, tokenAddress, amount, extraData);
+        return state.depositToCustody(from, msg.sender, tokenAddress, amount, extraData);
     }
 
     function withdrawFromCustody(
-        address payable to,
+        address to,
         address tokenAddress,
         uint96  amount,
         bytes   calldata extraData
@@ -385,10 +384,8 @@ contract ExchangeV3 is IExchangeV3
         external
         override
         nonReentrant
-        onlyFromUserOrAgent(to)
-        returns (uint _amount)
     {
-        return state.withdrawFromCustody(to, tokenAddress, amount, extraData);
+        state.withdrawFromCustody(msg.sender, to, tokenAddress, amount, extraData);
     }
 
     // -- Deposits --

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -360,8 +360,11 @@ contract ExchangeV3 is IExchangeV3
         return state.getNumAvailableForcedSlots();
     }
 
+    // -- Custody --
+
     function depositToCustody(
         address from,
+        address to,
         address tokenAddress,
         uint96  amount,
         bytes   calldata extraData
@@ -370,12 +373,14 @@ contract ExchangeV3 is IExchangeV3
         payable
         override
         nonReentrant
+        onlyFromUserOrAgent(from)
         returns (uint _amount)
     {
-        return state.depositToCustody(from, msg.sender, tokenAddress, amount, extraData);
+        return state.depositToCustody(from, to, tokenAddress, amount, extraData);
     }
 
     function withdrawFromCustody(
+        address from,
         address to,
         address tokenAddress,
         uint96  amount,
@@ -384,8 +389,21 @@ contract ExchangeV3 is IExchangeV3
         external
         override
         nonReentrant
+        onlyFromUserOrAgent(from)
     {
-        state.withdrawFromCustody(msg.sender, to, tokenAddress, amount, extraData);
+        state.withdrawFromCustody(from, to, tokenAddress, amount, extraData);
+    }
+
+    function getCustodyBalance(
+        address user,
+        address tokenAddress
+        )
+        public
+        override
+        view
+        returns (uint)
+    {
+        return state.custody[user][tokenAddress];
     }
 
     // -- Deposits --

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -398,6 +398,7 @@ contract ExchangeV3 is IExchangeV3
         address to,
         address tokenAddress,
         uint96  amount,
+        bool    fromCustody,
         bytes   calldata extraData
         )
         external
@@ -406,7 +407,7 @@ contract ExchangeV3 is IExchangeV3
         nonReentrant
         onlyFromUserOrAgent(from)
     {
-        state.deposit(from, to, tokenAddress, amount, extraData);
+        state.deposit(from, to, tokenAddress, amount, fromCustody, extraData);
     }
 
     // -- Withdrawals --

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2017 Loopring Technology Limited. pragma solidity ^0.7.0;
+// Copyright 2017 Loopring Technology Limited.
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright 2017 Loopring Technology Limited.
+// Copyright 2017 Loopring Technology Limited. pragma solidity ^0.7.0;
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
@@ -31,6 +31,7 @@ library ExchangeDeposits
     function depositToCustody(
         ExchangeData.State storage S,
         address from,
+        address to,
         address tokenAddress,
         uint96  amount,                 // can be zero
         bytes   memory extraData
@@ -47,15 +48,8 @@ library ExchangeDeposits
             extraData
         );
 
-        S.custody[msg.sender][from][tokenAddress] =
-            S.custody[msg.sender][from][tokenAddress].add(_amount);
-
-        // emit DepositRequested(
-        //     to,
-        //     tokenAddress,
-        //     tokenID,
-        //     uint96(amountDeposited)
-        // );
+        S.custody[to][tokenAddress] =
+            S.custody[to][tokenAddress].add(_amount);
     }
 
     function deposit(
@@ -78,10 +72,10 @@ library ExchangeDeposits
         uint96 amountDeposited;
 
         if (fromCustody) {
-            uint balance = S.custody[msg.sender][from][tokenAddress];
+            uint balance = S.custody[from][tokenAddress];
             require(balance >= amount, "INSUFFCIENT_BALANCE");
-            S.custody[msg.sender][from][tokenAddress] =
-                S.custody[msg.sender][from][tokenAddress].sub(amount);
+            S.custody[from][tokenAddress] =
+                S.custody[from][tokenAddress].sub(amount);
 
             amountDeposited = amount;
         } else {

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -28,6 +28,36 @@ library ExchangeDeposits
         uint96  amount
     );
 
+    function depositToCustody(
+        ExchangeData.State storage S,
+        address from,
+        address tokenAddress,
+        uint96  amount,                 // can be zero
+        bytes   memory extraData
+        )
+        internal  // inline call
+        returns (uint _amount)
+    {
+        require(from != address(0), "ZERO_ADDRESS");
+
+        _amount = S.depositContract.deposit{value: msg.value}(
+            from,
+            tokenAddress,
+            amount,
+            extraData
+        );
+
+        S.custody[msg.sender][from][tokenAddress] =
+            S.custody[msg.sender][from][tokenAddress].add(_amount);
+
+        // emit DepositRequested(
+        //     to,
+        //     tokenAddress,
+        //     tokenID,
+        //     uint96(amountDeposited)
+        // );
+    }
+
     function deposit(
         ExchangeData.State storage S,
         address from,

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -73,9 +73,6 @@ library ExchangeDeposits
 
         if (fromCustody) {
             require(extraData.length == 0, "INVALID_EXTRA_DATA");
-
-            uint balance = S.custody[from][tokenAddress];
-            require(balance >= amount, "INSUFFCIENT_BALANCE");
             S.custody[from][tokenAddress] =
                 S.custody[from][tokenAddress].sub(amount);
 

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeDeposits.sol
@@ -72,6 +72,8 @@ library ExchangeDeposits
         uint96 amountDeposited;
 
         if (fromCustody) {
+            require(extraData.length == 0, "INVALID_EXTRA_DATA");
+
             uint balance = S.custody[from][tokenAddress];
             require(balance >= amount, "INSUFFCIENT_BALANCE");
             S.custody[from][tokenAddress] =

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
@@ -46,35 +46,28 @@ library ExchangeWithdrawals
 
     function withdrawFromCustody(
         ExchangeData.State storage S,
-        address payable to,
+        address from,
+        address to,
         address tokenAddress,
-        uint96  amount,                 // can be zero
+        uint96  amount,             // can be zero
         bytes   memory extraData
         )
         internal  // inline call
-        returns (uint _amount)
     {
         require(to != address(0), "ZERO_ADDRESS");
 
-        S.custody[msg.sender][to][tokenAddress] =
-            S.custody[msg.sender][to][tokenAddress].sub(amount);
+        S.custody[from][tokenAddress] =
+            S.custody[from][tokenAddress].sub(amount);
 
         // Transfer the tokens to this contract
-        _amount = S.depositContract.withdraw{value: msg.value}(
+         S.depositContract.withdraw{value: msg.value}(
+            from,
             to,
             tokenAddress,
             amount,
             extraData
         );
-
-        // emit DepositRequested(
-        //     to,
-        //     tokenAddress,
-        //     tokenID,
-        //     uint96(amountDeposited)
-        // );
     }
-
 
     function forceWithdraw(
         ExchangeData.State storage S,

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
@@ -44,6 +44,38 @@ library ExchangeWithdrawals
         uint96  amount
     );
 
+    function withdrawFromCustody(
+        ExchangeData.State storage S,
+        address payable to,
+        address tokenAddress,
+        uint96  amount,                 // can be zero
+        bytes   memory extraData
+        )
+        internal  // inline call
+        returns (uint _amount)
+    {
+        require(to != address(0), "ZERO_ADDRESS");
+
+        S.custody[msg.sender][to][tokenAddress] =
+            S.custody[msg.sender][to][tokenAddress].sub(amount);
+
+        // Transfer the tokens to this contract
+        _amount = S.depositContract.withdraw{value: msg.value}(
+            to,
+            tokenAddress,
+            amount,
+            extraData
+        );
+
+        // emit DepositRequested(
+        //     to,
+        //     tokenAddress,
+        //     tokenID,
+        //     uint96(amountDeposited)
+        // );
+    }
+
+
     function forceWithdraw(
         ExchangeData.State storage S,
         address owner,


### PR DESCRIPTION
Users can use a dapp (AMM pool for example) to deposit funds into Loopring Exchange for custody, then later, the dapp can use these funds directly for deposits without another ERC20 transfer. 

Another benefit is that once a dapp becomes a global agent, it can use a user's existing ERC20 authorization.