### PR TITLE
[protocol 3.6] Add maxFee to withdrawals/transfers

### DIFF
--- a/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
@@ -53,6 +53,7 @@ class TransferCircuit : public BaseTransactionCircuit
     DualVariableGadget payer_toAccountID;
     DualVariableGadget payer_to;
     DualVariableGadget payee_toAccountID;
+    DualVariableGadget maxFee;
 
     // Check if the inputs are valid
     EqualGadget isTransferTx;
@@ -63,6 +64,7 @@ class TransferCircuit : public BaseTransactionCircuit
     IfThenRequireEqualGadget ifrequire_payee_toAccountID_eq_toAccountID;
     IfThenRequireNotEqualGadget ifrequire_NotZero_to;
     RequireLtGadget requireValidUntil;
+    RequireLeqGadget requireValidFee;
 
     // Fill in standard dual author key if none is given
     IsNonZero isNonZero_dualAuthorX;
@@ -133,6 +135,7 @@ class TransferCircuit : public BaseTransactionCircuit
           payer_toAccountID(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".payer_toAccountID")),
           payer_to(pb, NUM_BITS_ADDRESS, FMT(prefix, ".payer_to")),
           payee_toAccountID(pb, NUM_BITS_ACCOUNT, FMT(prefix, ".payee_toAccountID")),
+          maxFee(pb, NUM_BITS_AMOUNT, FMT(prefix, ".maxFee")),
 
           // Check if the inputs are valid
           isTransferTx(pb, state.type, state.constants.txTypeTransfer, FMT(prefix, ".isTransferTx")),
@@ -168,6 +171,12 @@ class TransferCircuit : public BaseTransactionCircuit
             validUntil.packed,
             NUM_BITS_TIMESTAMP,
             FMT(prefix, ".requireValidUntil")),
+          requireValidFee(
+            pb,
+            fee.packed,
+            maxFee.packed,
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".requireValidFee")),
 
           // Fill in standard dual author key if none is given
           isNonZero_dualAuthorX(pb, dualAuthorX, FMT(prefix, ".isNonZero_dualAuthorX")),
@@ -199,7 +208,7 @@ class TransferCircuit : public BaseTransactionCircuit
                tokenID.packed,
                amount.packed,
                feeTokenID.packed,
-               fee.packed,
+               maxFee.packed,
                payer_to.packed,
                dualAuthorX,
                dualAuthorY,
@@ -215,7 +224,7 @@ class TransferCircuit : public BaseTransactionCircuit
                tokenID.packed,
                amount.packed,
                feeTokenID.packed,
-               fee.packed,
+               maxFee.packed,
                to.packed,
                dualAuthorX,
                dualAuthorY,
@@ -349,6 +358,7 @@ class TransferCircuit : public BaseTransactionCircuit
         payer_toAccountID.generate_r1cs_witness(pb, transfer.payerToAccountID);
         payer_to.generate_r1cs_witness(pb, transfer.payerTo);
         payee_toAccountID.generate_r1cs_witness(pb, transfer.payeeToAccountID);
+        maxFee.generate_r1cs_witness(pb, transfer.maxFee);
 
         // Check if the inputs are valid
         isTransferTx.generate_r1cs_witness();
@@ -359,6 +369,7 @@ class TransferCircuit : public BaseTransactionCircuit
         ifrequire_payee_toAccountID_eq_toAccountID.generate_r1cs_witness();
         ifrequire_NotZero_to.generate_r1cs_witness();
         requireValidUntil.generate_r1cs_witness();
+        requireValidFee.generate_r1cs_witness();
 
         // Fill in standard dual author key if none is given
         isNonZero_dualAuthorX.generate_r1cs_witness();
@@ -424,6 +435,7 @@ class TransferCircuit : public BaseTransactionCircuit
         payer_toAccountID.generate_r1cs_constraints(true);
         payer_to.generate_r1cs_constraints(true);
         payee_toAccountID.generate_r1cs_constraints(true);
+        maxFee.generate_r1cs_constraints(true);
 
         // Check if the inputs are valid
         isTransferTx.generate_r1cs_constraints();
@@ -434,6 +446,7 @@ class TransferCircuit : public BaseTransactionCircuit
         ifrequire_payee_toAccountID_eq_toAccountID.generate_r1cs_constraints();
         ifrequire_NotZero_to.generate_r1cs_constraints();
         requireValidUntil.generate_r1cs_constraints();
+        requireValidFee.generate_r1cs_constraints();
 
         // Fill in standard dual author key if none is given
         isNonZero_dualAuthorX.generate_r1cs_constraints();

--- a/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
@@ -36,6 +36,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
     DualVariableGadget fee;
     DualVariableGadget validUntil;
     DualVariableGadget onchainDataHash;
+    DualVariableGadget maxFee;
     DualVariableGadget type;
 
     // Special case protocol fee withdrawal
@@ -50,6 +51,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
 
     // Validate
     RequireLtGadget requireValidUntil;
+    RequireLeqGadget requireValidFee;
 
     // Type
     IsNonZero isConditional;
@@ -111,6 +113,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
           fee(pb, NUM_BITS_AMOUNT, FMT(prefix, ".fee")),
           validUntil(pb, NUM_BITS_TIMESTAMP, FMT(prefix, ".validUntil")),
           onchainDataHash(pb, NUM_BITS_HASH, FMT(prefix, ".onchainDataHash")),
+          maxFee(pb, NUM_BITS_AMOUNT, FMT(prefix, ".maxFee")),
           type(pb, NUM_BITS_TYPE, FMT(prefix, ".type")),
 
           // Special case protocol fee withdrawal
@@ -139,7 +142,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
                tokenID.packed,
                amount.packed,
                feeTokenID.packed,
-               fee.packed,
+               maxFee.packed,
                onchainDataHash.packed,
                validUntil.packed,
                state.accountA.account.nonce}),
@@ -152,6 +155,12 @@ class WithdrawCircuit : public BaseTransactionCircuit
             validUntil.packed,
             NUM_BITS_TIMESTAMP,
             FMT(prefix, ".requireValidUntil")),
+          requireValidFee(
+            pb,
+            fee.packed,
+            maxFee.packed,
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".requireValidFee")),
 
           // Type
           isConditional(pb, type.packed, FMT(prefix, ".isConditional")),
@@ -278,6 +287,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
         fee.generate_r1cs_witness(pb, withdrawal.fee);
         validUntil.generate_r1cs_witness(pb, withdrawal.validUntil);
         onchainDataHash.generate_r1cs_witness(pb, withdrawal.onchainDataHash);
+        maxFee.generate_r1cs_witness(pb, withdrawal.maxFee);
         type.generate_r1cs_witness(pb, withdrawal.type);
 
         // Special case protocol fee withdrawal
@@ -292,6 +302,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
 
         // Validate
         requireValidUntil.generate_r1cs_witness();
+        requireValidFee.generate_r1cs_witness();
 
         // Type
         isConditional.generate_r1cs_witness();
@@ -350,6 +361,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
         fee.generate_r1cs_constraints(true);
         validUntil.generate_r1cs_constraints(true);
         onchainDataHash.generate_r1cs_constraints(true);
+        maxFee.generate_r1cs_constraints(true);
         type.generate_r1cs_constraints(true);
 
         // Special case protocol fee withdrawal
@@ -364,6 +376,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
 
         // Validate
         requireValidUntil.generate_r1cs_constraints();
+        requireValidFee.generate_r1cs_constraints();
 
         // Type
         isConditional.generate_r1cs_constraints();

--- a/packages/loopring_v3/circuit/Utils/Data.h
+++ b/packages/loopring_v3/circuit/Utils/Data.h
@@ -56,6 +56,7 @@ static auto dummyTransfer = R"({
     "feeTokenID": 0,
     "tokenID": 0,
     "validUntil": 4294967295,
+    "maxFee": "0",
     "type": 0,
     "ownerFrom": "0",
     "to": "2",
@@ -76,6 +77,7 @@ static auto dummyWithdraw = R"({
     "feeTokenID": 0,
     "fee": "0",
     "validUntil": 4294967295,
+    "maxFee": "0",
     "onchainDataHash": "0",
     "type": 0
 })"_json;
@@ -354,6 +356,7 @@ class Withdrawal
     ethsnarks::FieldT fee;
     ethsnarks::FieldT onchainDataHash;
     ethsnarks::FieldT validUntil;
+    ethsnarks::FieldT maxFee;
     ethsnarks::FieldT type;
 };
 
@@ -366,6 +369,7 @@ static void from_json(const json &j, Withdrawal &withdrawal)
     withdrawal.fee = ethsnarks::FieldT(j["fee"].get<std::string>().c_str());
     withdrawal.onchainDataHash = ethsnarks::FieldT(j["onchainDataHash"].get<std::string>().c_str());
     withdrawal.validUntil = ethsnarks::FieldT(j.at("validUntil"));
+    withdrawal.maxFee = ethsnarks::FieldT(j["maxFee"].get<std::string>().c_str());
     withdrawal.type = ethsnarks::FieldT(j.at("type"));
 }
 
@@ -426,6 +430,7 @@ class Transfer
     ethsnarks::FieldT payerToAccountID;
     ethsnarks::FieldT payerTo;
     ethsnarks::FieldT payeeToAccountID;
+    ethsnarks::FieldT maxFee;
     ethsnarks::FieldT type;
 };
 
@@ -445,6 +450,7 @@ static void from_json(const json &j, Transfer &transfer)
     transfer.payerToAccountID = ethsnarks::FieldT(j.at("payerToAccountID"));
     transfer.payerTo = ethsnarks::FieldT(j["payerTo"].get<std::string>().c_str());
     transfer.payeeToAccountID = ethsnarks::FieldT(j.at("payeeToAccountID"));
+    transfer.maxFee = ethsnarks::FieldT(j["maxFee"].get<std::string>().c_str());
     transfer.type = ethsnarks::FieldT(j.at("type"));
 }
 
@@ -604,8 +610,6 @@ class Block
     ethsnarks::FieldT operatorAccountID;
     AccountUpdate accountUpdate_O;
 
-    AccountUpdate accountUpdate_I;
-
     std::vector<Loopring::UniversalTransaction> transactions;
 };
 
@@ -627,8 +631,6 @@ static void from_json(const json &j, Block &block)
 
     block.operatorAccountID = ethsnarks::FieldT(j.at("operatorAccountID"));
     block.accountUpdate_O = j.at("accountUpdate_O").get<AccountUpdate>();
-
-    block.accountUpdate_I = j.at("accountUpdate_I").get<AccountUpdate>();
 
     // Read transactions
     json jTransactions = j["transactions"];

--- a/packages/loopring_v3/operator/create_block.py
+++ b/packages/loopring_v3/operator/create_block.py
@@ -74,6 +74,7 @@ def transferFromJSON(jTransfer):
     transfer.payerToAccountID = int(jTransfer["payerToAccountID"])
     transfer.payerTo = str(jTransfer["payerTo"])
     transfer.payeeToAccountID = int(jTransfer["payeeToAccountID"])
+    transfer.maxFee = str(jTransfer["maxFee"])
     transfer.signature = None
     transfer.dualSignature = None
     transfer.onchainSignature = None
@@ -95,6 +96,7 @@ def withdrawFromJSON(jWithdraw):
     withdraw.onchainDataHash = str(jWithdraw["onchainDataHash"])
     withdraw.type = int(jWithdraw["type"])
     withdraw.validUntil = int(jWithdraw["validUntil"])
+    withdraw.maxFee = str(jWithdraw["maxFee"])
     withdraw.signature = None
     if "signature" in jWithdraw:
         withdraw.signature = jWithdraw["signature"]
@@ -154,9 +156,8 @@ def createBlock(state, data):
 
     context = Context(block.operatorAccountID, block.timestamp, block.protocolTakerFeeBips, block.protocolMakerFeeBips)
 
-    # Protocol fee payment / index
+    # Protocol fee payment
     accountBefore_P = copyAccountInfo(state.getAccount(0))
-    accountBefore_I = copyAccountInfo(state.getAccount(1))
 
     for transactionInfo in data["transactions"]:
         txType = transactionInfo["txType"]
@@ -203,14 +204,6 @@ def createBlock(state, data):
     accountAfter = copyAccountInfo(state.getAccount(0))
     rootAfter = state._accountsTree._root
     block.accountUpdate_P = AccountUpdateData(0, proof, rootBefore, rootAfter, accountBefore_P, accountAfter)
-
-    # Index
-    rootBefore = state._accountsTree._root
-    proof = state._accountsTree.createProof(1)
-    state.updateAccountTree(1)
-    accountAfter = copyAccountInfo(state.getAccount(1))
-    rootAfter = state._accountsTree._root
-    block.accountUpdate_I = AccountUpdateData(1, proof, rootBefore, rootAfter, accountBefore_I, accountAfter)
 
     # Operator
     account = state.getAccount(context.operatorAccountID)

--- a/packages/loopring_v3/test/testExchangeInternalTransfer.ts
+++ b/packages/loopring_v3/test/testExchangeInternalTransfer.ts
@@ -102,7 +102,8 @@ contract("Exchange", (accounts: string[]) => {
         token,
         amount.mul(new BN(2)),
         feeToken,
-        fee.mul(new BN(2))
+        fee.mul(new BN(2)),
+        { maxFee: fee.mul(new BN(3)) }
       );
       await exchangeTestUtil.transfer(ownerB, ownerA, token, amount, feeToken, fee);
 
@@ -250,6 +251,27 @@ contract("Exchange", (accounts: string[]) => {
 
       // Verify the block
       await exchangeTestUtil.submitPendingBlocks();
+    });
+
+    it("should not be able to do transfer with fee > maxFee", async () => {
+      await createExchange();
+
+      const token = "ETH";
+      const feeToken = "LRC";
+      const amount = new BN(web3.utils.toWei("1", "ether"));
+      const fee = new BN(web3.utils.toWei("0.1", "ether"));
+
+      // Do some transfers transfer
+      await exchangeTestUtil.transfer(
+        ownerA, ownerD, token, amount, feeToken, fee,
+        {maxFee: fee.div(new BN(2))}
+      );
+
+      // Commit the transfers
+      await expectThrow(
+        exchangeTestUtil.submitTransactions(),
+        "invalid block"
+      );
     });
 
     it("should be able to transfer to a new account", async () => {

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -63,6 +63,7 @@ function replacer(name: any, val: any) {
     name === "amountB" ||
     name === "amount" ||
     name === "fee" ||
+    name === "maxFee" ||
     name === "tokenWeight"
   ) {
     return new BN(val, 16).toString(10);
@@ -99,6 +100,7 @@ export interface TransferOptions {
   signer?: string;
   validUntil?: number;
   storageID?: number;
+  maxFee?: BN;
 }
 
 export interface WithdrawOptions {
@@ -109,6 +111,7 @@ export interface WithdrawOptions {
   extraData?: string;
   signer?: string;
   validUntil?: number;
+  maxFee?: BN;
 }
 
 export interface AccountUpdateOptions {
@@ -277,7 +280,7 @@ export namespace WithdrawalUtils {
       withdrawal.tokenID,
       withdrawal.amount,
       withdrawal.feeTokenID,
-      withdrawal.fee,
+      withdrawal.maxFee,
       withdrawal.onchainDataHash,
       withdrawal.validUntil,
       withdrawal.nonce
@@ -353,7 +356,7 @@ export namespace TransferUtils {
       transfer.tokenID,
       transfer.amount,
       transfer.feeTokenID,
-      transfer.fee,
+      transfer.maxFee,
       payer ? transfer.payerTo : transfer.to,
       transfer.dualAuthorX,
       transfer.dualAuthorY,
@@ -674,6 +677,8 @@ export class ExchangeTestUtil {
       options.storageID !== undefined
         ? options.storageID
         : this.storageIDGenerator++;
+    const maxFee =
+      options.maxFee !== undefined ? options.maxFee : fee;
 
     // From
     await this.deposit(from, from, token, amountToDeposit);
@@ -732,6 +737,7 @@ export class ExchangeTestUtil {
       amount,
       feeTokenID,
       fee,
+      maxFee,
       from,
       to,
       type: authMethod === AuthMethod.EDDSA ? 0 : 1,
@@ -1190,6 +1196,8 @@ export class ExchangeTestUtil {
       options.extraData !== undefined ? options.extraData : "0x";
     const validUntil =
       options.validUntil !== undefined ? options.validUntil : 0xffffffff;
+    const maxFee =
+      options.maxFee !== undefined ? options.maxFee : fee;
 
     let type = 0;
     if (authMethod === AuthMethod.ECDSA || authMethod === AuthMethod.APPROVE) {
@@ -1266,6 +1274,7 @@ export class ExchangeTestUtil {
       amount,
       feeTokenID,
       fee,
+      maxFee,
       to,
       extraData,
       withdrawalFee: await this.loopringV3.forcedWithdrawalFee(),

--- a/packages/loopring_v3/test/types.ts
+++ b/packages/loopring_v3/test/types.ts
@@ -115,6 +115,7 @@ export class Transfer {
 
   feeTokenID: number;
   fee: BN;
+  maxFee: BN;
 
   from: string;
   to: string;
@@ -151,6 +152,7 @@ export interface WithdrawalRequest {
 
   feeTokenID?: number;
   fee?: BN;
+  maxFee: BN;
 
   minGas: number;
   gas?: number;


### PR DESCRIPTION
#1688

Currently only supports `fee != maxFee` when using an EdDSA signature. I can add support for it with onchain signatures as well if requested. The reason for this is that only the actual fee is part of the DA, but if `fee != maxFee` we need to calculate the hash for the signature with `maxFee` instead of `fee`, so we need to put the `maxFee` onchain (using the auxiliary data) and check that `fee < maxFee` onchain.