### PR TITLE
[hebao] Optimized memory copies

### DIFF
--- a/packages/hebao_v1/contracts/base/BaseWallet.sol
+++ b/packages/hebao_v1/contracts/base/BaseWallet.sol
@@ -266,10 +266,10 @@ abstract contract BaseWallet is ReentrancyGuard, Wallet
     // This call is introduced to support reentrany check.
     // The caller shall NOT have the nonReentrant modifier.
     function nonReentrantCall(
-        uint8        mode,
-        address      target,
-        uint         value,
-        bytes memory data
+        uint8          mode,
+        address        target,
+        uint           value,
+        bytes calldata data
         )
         private
         nonReentrant

--- a/packages/hebao_v1/contracts/lib/AddressUtil.sol
+++ b/packages/hebao_v1/contracts/lib/AddressUtil.sol
@@ -34,7 +34,7 @@ library AddressUtil
         pure
         returns (address payable)
     {
-        return address(uint160(addr));
+        return payable(addr);
     }
 
     // Works like address.send but with a customizable gas limit

--- a/packages/hebao_v1/contracts/lib/AddressUtil.sol
+++ b/packages/hebao_v1/contracts/lib/AddressUtil.sol
@@ -68,4 +68,49 @@ library AddressUtil
         success = to.sendETH(amount, gasLimit);
         require(success, "TRANSFER_FAILURE");
     }
+
+    // Works like call but is slightly more efficient when data
+    // needs to be copied from memory to do the call.
+    function fastCall(
+        address to,
+        uint    gasLimit,
+        uint    value,
+        bytes   memory data
+        )
+        internal
+        returns (bool success, bytes memory returnData)
+    {
+        if (to != address(0)) {
+            assembly {
+                // Do the call
+                success := call(gasLimit, to, value, add(data, 32), mload(data), 0, 0)
+                // Copy the return data
+                let size := returndatasize()
+                returnData := mload(0x40)
+                mstore(returnData, size)
+                returndatacopy(add(returnData, 32), 0, size)
+                // Update free memory pointer
+                mstore(0x40, add(returnData, add(32, size)))
+            }
+        }
+    }
+
+    // Like fastCall, but throws when the call is unsuccessful.
+    function fastCallAndVerify(
+        address to,
+        uint    gasLimit,
+        uint    value,
+        bytes   memory data
+        )
+        internal
+        returns (bytes memory returnData)
+    {
+        bool success;
+        (success, returnData) = fastCall(to, gasLimit, value, data);
+        if (!success) {
+            assembly {
+                revert(add(returnData, 32), mload(returnData))
+            }
+        }
+    }
 }

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -129,7 +129,15 @@ abstract contract BaseModule is ReentrancyGuard, Module
         internal
         returns (bytes memory)
     {
-        return Wallet(wallet).transact(uint8(1), to, value, data);
+        bytes memory callData = abi.encodeWithSelector(
+            Wallet.transact.selector,
+            uint8(1),
+            to,
+            value,
+            data
+        );
+        bytes memory ret = wallet.fastCallAndVerify(gasleft(), 0, callData);
+        return abi.decode(ret, (bytes));
     }
 
     // Special case for transactCall to support transfers on "bad" ERC20 tokens
@@ -184,7 +192,7 @@ abstract contract BaseModule is ReentrancyGuard, Module
         address wallet,
         address to,
         uint    value,
-        bytes   memory data
+        bytes   calldata data
         )
         internal
         returns (bytes memory)
@@ -195,7 +203,7 @@ abstract contract BaseModule is ReentrancyGuard, Module
     function transactStaticCall(
         address wallet,
         address to,
-        bytes   memory data
+        bytes   calldata data
         )
         internal
         returns (bytes memory)

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -129,15 +129,7 @@ abstract contract BaseModule is ReentrancyGuard, Module
         internal
         returns (bytes memory)
     {
-        bytes memory callData = abi.encodeWithSelector(
-            Wallet.transact.selector,
-            uint8(1),
-            to,
-            value,
-            data
-        );
-        bytes memory ret = wallet.fastCallAndVerify(gasleft(), 0, callData);
-        return abi.decode(ret, (bytes));
+        return Wallet(wallet).transact(uint8(1), to, value, data);
     }
 
     // Special case for transactCall to support transfers on "bad" ERC20 tokens

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -122,9 +122,7 @@ abstract contract ForwarderModule is BaseModule
 
         // The trick is to append the really logical message sender and the
         // transaction-aware hash to the end of the call data.
-        (success, ret) = metaTx.to.fastCall(
-            metaTx.gasLimit,
-            0,
+        (success, ret) = metaTx.to.call{gas : metaTx.gasLimit, value : 0}(
             abi.encodePacked(metaTx.data, metaTx.from, metaTx.txAwareHash)
         );
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -3,6 +3,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "../../lib/AddressUtil.sol";
 import "../../lib/EIP712.sol";
 import "../../lib/ERC20.sol";
 import "../../lib/MathUint.sol";
@@ -17,6 +18,7 @@ import "./WalletFactory.sol";
 /// @author Daniel Wang - <daniel@loopring.org>
 abstract contract ForwarderModule is BaseModule
 {
+    using AddressUtil   for address;
     using BytesUtil     for bytes;
     using MathUint      for uint;
     using SignatureUtil for bytes32;
@@ -120,7 +122,9 @@ abstract contract ForwarderModule is BaseModule
 
         // The trick is to append the really logical message sender and the
         // transaction-aware hash to the end of the call data.
-        (success, ret) = metaTx.to.call{gas : metaTx.gasLimit, value : 0}(
+        (success, ret) = metaTx.to.fastCall(
+            metaTx.gasLimit,
+            0,
             abi.encodePacked(metaTx.data, metaTx.from, metaTx.txAwareHash)
         );
 

--- a/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
@@ -39,7 +39,7 @@ abstract contract BaseTransferModule is SecurityModule
         address token,
         address to,
         uint    amount,
-        bytes   memory logdata
+        bytes   calldata logdata
         )
         internal
     {
@@ -80,7 +80,7 @@ abstract contract BaseTransferModule is SecurityModule
         address wallet,
         address to,
         uint    value,
-        bytes   memory txData
+        bytes   calldata txData
         )
         internal
         virtual

--- a/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
@@ -162,8 +162,8 @@ contract BaseENSManager is IENSManager, OwnerManagable, ENSConsumer {
     function verifyApproval(
         address _wallet,
         address _owner,
-        string  memory _label,
-        bytes   memory _approval
+        string  calldata _label,
+        bytes   calldata _approval
         )
         internal
         view

--- a/packages/hebao_v1/legacy/version1.0/contracts/transfers/QuotaTransfers.sol
+++ b/packages/hebao_v1/legacy/version1.0/contracts/transfers/QuotaTransfers.sol
@@ -152,7 +152,7 @@ contract QuotaTransfers is TransferModule
         address wallet,
         address to,
         uint    value,
-        bytes   memory txData
+        bytes   calldata txData
         )
         internal
         override

--- a/packages/hebao_v1/legacy/version1.0/contracts/transfers/TransferModule.sol
+++ b/packages/hebao_v1/legacy/version1.0/contracts/transfers/TransferModule.sol
@@ -93,7 +93,7 @@ abstract contract TransferModule is SecurityModule
         address wallet,
         address to,
         uint    value,
-        bytes   memory txData
+        bytes   calldata txData
         )
         internal
         virtual

--- a/packages/loopring_v3/contracts/lib/AddressUtil.sol
+++ b/packages/loopring_v3/contracts/lib/AddressUtil.sol
@@ -68,4 +68,49 @@ library AddressUtil
         success = to.sendETH(amount, gasLimit);
         require(success, "TRANSFER_FAILURE");
     }
+
+    // Works like call but is slightly more efficient when data
+    // needs to be copied from memory to do the call.
+    function fastCall(
+        address to,
+        uint    gasLimit,
+        uint    value,
+        bytes   memory data
+        )
+        internal
+        returns (bool success, bytes memory returnData)
+    {
+        if (to != address(0)) {
+            assembly {
+                // Do the call
+                success := call(gasLimit, to, value, add(data, 32), mload(data), 0, 0)
+                // Copy the return data
+                let size := returndatasize()
+                returnData := mload(0x40)
+                mstore(returnData, size)
+                returndatacopy(add(returnData, 32), 0, size)
+                // Update free memory pointer
+                mstore(0x40, add(returnData, add(32, size)))
+            }
+        }
+    }
+
+    // Like fastCall, but throws when the call is unsuccessful.
+    function fastCallAndVerify(
+        address to,
+        uint    gasLimit,
+        uint    value,
+        bytes   memory data
+        )
+        internal
+        returns (bytes memory returnData)
+    {
+        bool success;
+        (success, returnData) = fastCall(to, gasLimit, value, data);
+        if (!success) {
+            assembly {
+                revert(add(returnData, 32), mload(returnData))
+            }
+        }
+    }
 }


### PR DESCRIPTION
Optimized most frequent paths. In normal cases this only saves ~0.5%-1.0% of gas. Calls with a lot of data will save more gas, but probably quite infrequent.

I do feel like the compiler should be able to do this so we don't have to worry about this. Maybe I'll make an issue on the solidity github.