### PR TITLE
[protocol 3.6] Remove short storageID uses

### DIFF
--- a/packages/loopring_v3.js/src/exchange_v3.ts
+++ b/packages/loopring_v3.js/src/exchange_v3.ts
@@ -703,7 +703,9 @@ export class ExchangeV3 {
             }
           }
         ],
-        "0x" + data/*transaction.input*/.slice(2 + 4 * 2)
+        "0x" +
+          data /*transaction.input*/
+            .slice(2 + 4 * 2)
       );
       //console.log(decodedInputs);
       const numBlocks = decodedInputs[0].length;
@@ -889,8 +891,13 @@ export class ExchangeV3 {
     };
 
     for (let i = 0; i < block.blockSize; i++) {
-      const txData1 = data.extractData(offset + i * 25, 25);
-      const txData2 = data.extractData(offset + block.blockSize * 25 + i * 43, 43);
+      const size1 = 29;
+      const size2 = 39;
+      const txData1 = data.extractData(offset + i * size1, size1);
+      const txData2 = data.extractData(
+        offset + block.blockSize * size1 + i * size2,
+        size2
+      );
       const txData = new Bitstream(txData1 + txData2);
 
       const txType = txData.extractUint8(0);

--- a/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
+++ b/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
@@ -23,7 +23,11 @@ interface Withdrawal {
  * Processes internal transfer requests.
  */
 export class WithdrawalProcessor {
-  public static process(state: ExchangeState, block: BlockContext, txData: Bitstream) {
+  public static process(
+    state: ExchangeState,
+    block: BlockContext,
+    txData: Bitstream
+  ) {
     const withdrawal = this.extractData(txData);
 
     const account = state.getAccount(withdrawal.accountID);
@@ -42,8 +46,9 @@ export class WithdrawalProcessor {
 
     if (withdrawal.type === 0 || withdrawal.type === 1) {
       // Nonce
-      const storageSlot = withdrawal.storageID % Constants.NUM_STORAGE_SLOTS;
-      const storage = account.getBalance(withdrawal.tokenID).getStorage(storageSlot);
+      const storage = account
+        .getBalance(withdrawal.tokenID)
+        .getStorage(withdrawal.storageID);
       storage.storageID = withdrawal.storageID;
       storage.data = new BN(1);
     }
@@ -67,7 +72,10 @@ export class WithdrawalProcessor {
     offset += 12;
     withdrawal.feeTokenID = data.extractUint16(offset);
     offset += 2;
-    withdrawal.fee = fromFloat(data.extractUint16(offset), Constants.Float16Encoding);
+    withdrawal.fee = fromFloat(
+      data.extractUint16(offset),
+      Constants.Float16Encoding
+    );
     offset += 2;
     withdrawal.storageID = data.extractUint32(offset);
     offset += 4;

--- a/packages/loopring_v3/DESIGN.md
+++ b/packages/loopring_v3/DESIGN.md
@@ -228,14 +228,14 @@ The `fillAmountBorS` parameter can be used to decide which amount is the limitin
 ```
 - For both Orders:
     - Account ID: 4 bytes
-    - Short StorageID: 2 bytes
+    - Storage ID: 4 bytes
     - TokenS: 2 bytes
     - FillS: 3 bytes （24 bits, 19 bits for the mantissa part and 5 for the exponent part)
     - Order data (fillAmountBorS,feeBips): 1 byte
 ```
 
-- => **24 bytes/ring**
-- => Calldata cost: 24 \* 16 = **384 gas/ring**
+- => **28 bytes/ring**
+- => Calldata cost: 28 \* 16 = **448 gas/ring**
 
 ### Fee Model
 
@@ -321,7 +321,7 @@ If the order never left the DEX and the user trusts the DEX, the order can simpl
 
 ### Storage
 
-Every account has a storage tree with 2^14 leaves **for every token**. Which leaf is used for storing e.g., the trading history for an order is completely left up to the user, and we call this the **storageID**. The storageID is stored in a 32-bit value and works as a 2D nonce. We allow the user to overwrite the existing storage stored at `storageID % 2^14` if `order.storageID == storage.storageID + 2^14`. If `order.storageID < storage.storageID` the order is automatically canceled. If `order.storageID == storage.storageID` we use the data stored in the leaf. If `order.storageID > storage.storageID + 2^14`, the order cannot be used yet as the storageID can only be incremented by `2^14`. This allows the account to create 2^32 unique orders for every token, and the only limitation is that only 2^14 of these orders selling a certain token can be active at the same time.
+Every account has a storage tree with 2^14 leaves **for every token**. Which leaf is used for storing e.g., the trading history for an order is completely left up to the user, and we call this the **storageID**. The storageID is stored in a 32-bit value and works as a 2D nonce. We allow the user to overwrite the existing storage stored at `storageID % 2^14` if `order.storageID > storage.storageID`. If `order.storageID < storage.storageID` the order is automatically canceled. If `order.storageID == storage.storageID` we use the data stored in the leaf. This allows the account to create 2^32 unique orders for every token, and the only limitation is that only 2^14 of these orders selling a certain token can be active at the same time.
 
 While this was done for performance reasons (so we do not have to have a storage tree with a large depth using the order hash as an address), this does open up some interesting possibilities.
 
@@ -390,14 +390,13 @@ Not all features available for transfers using EdDSA signatures are available us
 - Amount: 3 bytes （24 bits, 19 bits for the mantissa part and 5 for the exponent part)
 - Fee token ID: 2 bytes
 - Fee amount: 2 bytes （16 bits, 11 bits for the mantissa part and 5 for the exponent part)
-- Short storageID: 2 bytes
+- StorageID: 4 bytes
 - To: 20 bytes （only set when transferring to a new account)
-- storageID: 4 bytes （only set for conditional transfers)
 - From: 20 bytes （only set for conditional transfers)
 ```
 
-- => **20 bytes/transfer** (in the most common case)
-- => Calldata cost: 20 \* 16 = **320 gas/transfer**
+- => **22 bytes/transfer** (in the most common case)
+- => Calldata cost: 22 \* 16 = **352 gas/transfer**
 
 ## Deposit
 

--- a/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
@@ -333,12 +333,8 @@ class SpotTradeCircuit : public BaseTransactionCircuit
     const VariableArrayT getPublicData() const
     {
         return flattenReverse({
-          VariableArrayT(1, state.constants._0),
-          VariableArrayT(1, tradeHistory_A.getOverwrite()),
-          subArray(orderA.storageID.bits, 0, NUM_BITS_STORAGE_ADDRESS),
-          VariableArrayT(1, state.constants._0),
-          VariableArrayT(1, tradeHistory_B.getOverwrite()),
-          subArray(orderB.storageID.bits, 0, NUM_BITS_STORAGE_ADDRESS),
+          orderA.storageID.bits,
+          orderB.storageID.bits,
 
           orderA.accountID.bits,
           orderB.accountID.bits,

--- a/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
@@ -95,7 +95,6 @@ class TransferCircuit : public BaseTransactionCircuit
     OrGadget da_NeedsToAddress;
     ArrayTernaryGadget da_To;
     ArrayTernaryGadget da_From;
-    ArrayTernaryGadget da_StorageID;
 
     // Fee as float
     FloatGadget fFee;
@@ -271,12 +270,6 @@ class TransferCircuit : public BaseTransactionCircuit
             from.bits,
             VariableArrayT(NUM_BITS_ADDRESS, state.constants._0),
             FMT(prefix, ".da_From")),
-          da_StorageID(
-            pb,
-            isConditional.result(),
-            storageID.bits,
-            VariableArrayT(NUM_BITS_STORAGEID, state.constants._0),
-            FMT(prefix, ".da_StorageID")),
 
           // Fee as float
           fFee(pb, state.constants, Float16Encoding, FMT(prefix, ".fFee")),
@@ -409,7 +402,6 @@ class TransferCircuit : public BaseTransactionCircuit
         da_NeedsToAddress.generate_r1cs_witness();
         da_To.generate_r1cs_witness();
         da_From.generate_r1cs_witness();
-        da_StorageID.generate_r1cs_witness();
 
         // Fee as float
         fFee.generate_r1cs_witness(toFloat(transfer.fee, Float16Encoding));
@@ -487,7 +479,6 @@ class TransferCircuit : public BaseTransactionCircuit
         da_NeedsToAddress.generate_r1cs_constraints();
         da_To.generate_r1cs_constraints();
         da_From.generate_r1cs_constraints();
-        da_StorageID.generate_r1cs_constraints();
 
         // Fee as float
         fFee.generate_r1cs_constraints();
@@ -516,9 +507,8 @@ class TransferCircuit : public BaseTransactionCircuit
            fAmount.bits(),
            feeTokenID.bits,
            fFee.bits(),
-           nonce.getShortStorageID(),
+           storageID.bits,
            da_To.result(),
-           da_StorageID.result(),
            da_From.result()});
     }
 };

--- a/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
@@ -1554,8 +1554,8 @@ class PublicDataGadget : public GadgetT
             transformedBits.emplace_back(publicDataBits[i]);
         }
 
-        unsigned int sizePart1 = 25 * 8;
-        unsigned int sizePart2 = 43 * 8;
+        unsigned int sizePart1 = 29 * 8;
+        unsigned int sizePart2 = 39 * 8;
 
         unsigned int startPart1 = start;
         unsigned int startPart2 = startPart1 + sizePart1 * count;

--- a/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
@@ -161,11 +161,7 @@ class StorageReaderGadget : public GadgetT
             storage.storageID,
             NUM_BITS_STORAGEID,
             FMT(prefix, ".storageID_leq_leafStorageID")),
-          requireValidStorageID(
-            pb,
-            verify,
-            storageID_leq_leafStorageID.gte(),
-            FMT(prefix, ".requireValidStorageID")),
+          requireValidStorageID(pb, verify, storageID_leq_leafStorageID.gte(), FMT(prefix, ".requireValidStorageID")),
 
           data(pb, storageID_leq_leafStorageID.eq(), storage.data, constants._0, FMT(prefix, ".data"))
     {

--- a/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
@@ -140,18 +140,8 @@ class UpdateStorageGadget : public GadgetT
 
 class StorageReaderGadget : public GadgetT
 {
-    VariableT address;
-    libsnark::packing_gadget<FieldT> packAddress;
-    IsNonZero isNonZeroStorageLeafStorageID;
-    TernaryGadget leafStorageID;
-
-    UnsafeAddGadget nextStorageID;
-
-    EqualGadget storageID_eq_leafStorageID;
-    EqualGadget storageID_eq_nextStorageID;
-
-    OrGadget isValidStorageID;
-    IfThenRequireEqualGadget requireValidStorageID;
+    LeqGadget storageID_leq_leafStorageID;
+    IfThenRequireGadget requireValidStorageID;
 
     TernaryGadget data;
 
@@ -165,55 +155,25 @@ class StorageReaderGadget : public GadgetT
       const std::string &prefix)
         : GadgetT(pb, prefix),
 
-          address(make_variable(pb, FMT(prefix, ".address"))),
-          packAddress(pb, subArray(storageID.bits, 0, NUM_BITS_STORAGE_ADDRESS), address, FMT(prefix, ".packAddress")),
-
-          isNonZeroStorageLeafStorageID(pb, storage.storageID, FMT(prefix, ".isNonZeroStorageLeafStorageID")),
-          leafStorageID(
+          storageID_leq_leafStorageID(
             pb,
-            isNonZeroStorageLeafStorageID.result(),
+            storageID.packed,
             storage.storageID,
-            address,
-            FMT(prefix, ".leafStorageID")),
-
-          nextStorageID(pb, leafStorageID.result(), constants.numStorageSlots, FMT(prefix, ".nextStorageID")),
-
-          storageID_eq_leafStorageID(
-            pb,
-            storageID.packed,
-            leafStorageID.result(),
-            FMT(prefix, ".storageID_eq_leafStorageID")),
-          storageID_eq_nextStorageID(
-            pb,
-            storageID.packed,
-            nextStorageID.result(),
-            FMT(prefix, ".storageID_eq_nextStorageID")),
-          isValidStorageID(
-            pb,
-            {storageID_eq_leafStorageID.result(), storageID_eq_nextStorageID.result()},
-            FMT(prefix, ".isValidStorageID")),
+            NUM_BITS_STORAGEID,
+            FMT(prefix, ".storageID_leq_leafStorageID")),
           requireValidStorageID(
             pb,
             verify,
-            isValidStorageID.result(),
-            constants._1,
+            storageID_leq_leafStorageID.gte(),
             FMT(prefix, ".requireValidStorageID")),
 
-          data(pb, storageID_eq_leafStorageID.result(), storage.data, constants._0, FMT(prefix, ".data"))
+          data(pb, storageID_leq_leafStorageID.eq(), storage.data, constants._0, FMT(prefix, ".data"))
     {
     }
 
     void generate_r1cs_witness()
     {
-        packAddress.generate_r1cs_witness_from_bits();
-        isNonZeroStorageLeafStorageID.generate_r1cs_witness();
-        leafStorageID.generate_r1cs_witness();
-
-        nextStorageID.generate_r1cs_witness();
-
-        storageID_eq_leafStorageID.generate_r1cs_witness();
-        storageID_eq_nextStorageID.generate_r1cs_witness();
-        isValidStorageID.generate_r1cs_witness();
+        storageID_leq_leafStorageID.generate_r1cs_witness();
         requireValidStorageID.generate_r1cs_witness();
 
         data.generate_r1cs_witness();
@@ -221,15 +181,7 @@ class StorageReaderGadget : public GadgetT
 
     void generate_r1cs_constraints()
     {
-        packAddress.generate_r1cs_constraints(false);
-        isNonZeroStorageLeafStorageID.generate_r1cs_constraints();
-        leafStorageID.generate_r1cs_constraints();
-
-        nextStorageID.generate_r1cs_constraints();
-
-        storageID_eq_leafStorageID.generate_r1cs_constraints();
-        storageID_eq_nextStorageID.generate_r1cs_constraints();
-        isValidStorageID.generate_r1cs_constraints();
+        storageID_leq_leafStorageID.generate_r1cs_constraints();
         requireValidStorageID.generate_r1cs_constraints();
 
         data.generate_r1cs_constraints();
@@ -238,11 +190,6 @@ class StorageReaderGadget : public GadgetT
     const VariableT &getData() const
     {
         return data.result();
-    }
-
-    const VariableT &getOverwrite() const
-    {
-        return storageID_eq_nextStorageID.result();
     }
 };
 
@@ -287,19 +234,6 @@ class NonceGadget : public GadgetT
     const VariableT &getData() const
     {
         return constants._1;
-    }
-
-    const VariableArrayT getShortStorageID() const
-    {
-        return reverse(flattenReverse(
-          {VariableArrayT(1, constants._0),
-           VariableArrayT(1, storageReader.getOverwrite()),
-           subArray(storageID.bits, 0, NUM_BITS_STORAGE_ADDRESS)}));
-    }
-
-    const VariableT &getOverwrite() const
-    {
-        return storageReader.getOverwrite();
     }
 };
 

--- a/packages/loopring_v3/circuit/test/StorageTests.cpp
+++ b/packages/loopring_v3/circuit/test/StorageTests.cpp
@@ -10,8 +10,7 @@ TEST_CASE("StorageReader", "[StorageReaderGadget]")
                                   const FieldT &_storageID,
                                   bool _verify,
                                   bool expectedSatisfied,
-                                  const FieldT &expectedFilled = FieldT::zero(),
-                                  const FieldT &expectedOverwrite = FieldT::zero()) {
+                                  const FieldT &expectedFilled = FieldT::zero()) {
         protoboard<FieldT> pb;
 
         VariableT verify = make_variable(pb, _verify ? FieldT::one() : FieldT::zero(), ".verify");
@@ -31,7 +30,6 @@ TEST_CASE("StorageReader", "[StorageReaderGadget]")
         if (expectedSatisfied)
         {
             REQUIRE((pb.val(storageReaderGadget.getData()) == expectedFilled));
-            REQUIRE((pb.val(storageReaderGadget.getOverwrite()) == expectedOverwrite));
         }
     };
 
@@ -43,19 +41,19 @@ TEST_CASE("StorageReader", "[StorageReaderGadget]")
     {
         SECTION("Initial state storageID == 0")
         {
-            storageReaderChecked({0, 0}, 0, true, true, 0, 0);
+            storageReaderChecked({0, 0}, 0, true, true, 0);
         }
         SECTION("Initial state storageID > 0")
         {
-            storageReaderChecked({0, 0}, storageID, true, true, 0, 0);
+            storageReaderChecked({0, 0}, storageID, true, true, 0);
         }
         SECTION("Order filled")
         {
-            storageReaderChecked({filled, storageID}, storageID, true, true, filled, 0);
+            storageReaderChecked({filled, storageID}, storageID, true, true, filled);
         }
         SECTION("Initial state storageID == delta - 1")
         {
-            storageReaderChecked({0, 0}, delta - 1, true, true, 0, 0);
+            storageReaderChecked({0, 0}, delta - 1, true, true, 0);
         }
     }
 
@@ -63,27 +61,24 @@ TEST_CASE("StorageReader", "[StorageReaderGadget]")
     {
         SECTION("First overwrite")
         {
-            storageReaderChecked({0, 0}, delta, true, true, 0, 1);
+            storageReaderChecked({0, 0}, delta, true, true, 0);
         }
         SECTION("Previous order not filled")
         {
-            storageReaderChecked({0, storageID}, delta + storageID, true, true, 0, 1);
+            storageReaderChecked({0, storageID}, delta + storageID, true, true, 0);
         }
         SECTION("Previous order filled")
         {
-            storageReaderChecked({filled, storageID}, delta + storageID, true, true, 0, 1);
+            storageReaderChecked({filled, storageID}, delta + storageID, true, true, 0);
         }
-        SECTION("Max overwrite delta")
+        SECTION("Overwrite delta")
         {
-            storageReaderChecked({0, 0}, delta + storageID, true, true, 0, 1);
-        }
-        SECTION("storageID too big")
-        {
-            storageReaderChecked({0, 0}, delta + delta + storageID, true, false);
-            storageReaderChecked({0, 0}, delta * 9 + storageID, true, false);
-            storageReaderChecked({0, 0}, delta * 99 + storageID, true, false);
-            storageReaderChecked({0, 0}, delta * 999 + storageID, true, false);
-            storageReaderChecked({0, 0}, delta * 9999 + storageID, true, false);
+            storageReaderChecked({0, 0}, delta + storageID, true, true, 0);
+            storageReaderChecked({0, 0}, delta + delta + storageID, true, true);
+            storageReaderChecked({0, 0}, delta * 9 + storageID, true, true);
+            storageReaderChecked({0, 0}, delta * 99 + storageID, true, true);
+            storageReaderChecked({0, 0}, delta * 999 + storageID, true, true);
+            storageReaderChecked({0, 0}, delta * 9999 + storageID, true, true);
         }
     }
 
@@ -114,8 +109,7 @@ TEST_CASE("Nonce", "[NonceGadget]")
                           const StorageLeaf &storageLeaf,
                           const FieldT &_storageID,
                           bool _verify,
-                          bool expectedSatisfied,
-                          const FieldT &expectedOverwrite = FieldT::zero()) {
+                          bool expectedSatisfied) {
         protoboard<FieldT> pb;
 
         VariableT verify = make_variable(pb, _verify ? FieldT::one() : FieldT::zero(), ".verify");
@@ -136,7 +130,7 @@ TEST_CASE("Nonce", "[NonceGadget]")
         if (expectedSatisfied)
         {
             REQUIRE((pb.val(nonceGadget.getData()) == FieldT::one()));
-            REQUIRE((pb.val(nonceGadget.getOverwrite()) == expectedOverwrite));
+
         }
     };
 
@@ -148,31 +142,31 @@ TEST_CASE("Nonce", "[NonceGadget]")
     {
         SECTION("Initial state storageID == 0")
         {
-            nonceChecked({0, 0}, 0, true, true, 0);
+            nonceChecked({0, 0}, 0, true, true);
         }
         SECTION("Initial state storageID > 0")
         {
-            nonceChecked({0, 0}, storageID, true, true, 0);
+            nonceChecked({0, 0}, storageID, true, true);
         }
         SECTION("Initial state storageID == delta - 1")
         {
-            nonceChecked({0, 0}, delta - 1, true, true, 0);
+            nonceChecked({0, 0}, delta - 1, true, true);
         }
         SECTION("Slot not used")
         {
-            nonceChecked({0, storageID}, storageID, true, true, 0);
+            nonceChecked({0, storageID}, storageID, true, true);
         }
         SECTION("Slot used")
         {
-            nonceChecked({filled, storageID}, storageID, true, false, 0);
+            nonceChecked({filled, storageID}, storageID, true, false);
         }
         SECTION("Slot not used (don't validate)")
         {
-            nonceChecked({0, storageID}, storageID, false, true, 0);
+            nonceChecked({0, storageID}, storageID, false, true);
         }
         SECTION("Slot used (don't validate)")
         {
-            nonceChecked({filled, storageID}, storageID, false, true, 0);
+            nonceChecked({filled, storageID}, storageID, false, true);
         }
     }
 
@@ -180,27 +174,24 @@ TEST_CASE("Nonce", "[NonceGadget]")
     {
         SECTION("First overwrite")
         {
-            nonceChecked({0, 0}, delta, true, true, 1);
+            nonceChecked({0, 0}, delta, true, true);
         }
         SECTION("Previous slot unused")
         {
-            nonceChecked({0, storageID}, delta + storageID, true, true, 1);
+            nonceChecked({0, storageID}, delta + storageID, true, true);
         }
         SECTION("Previous slot used")
         {
-            nonceChecked({filled, storageID}, delta + storageID, true, true, 1);
+            nonceChecked({filled, storageID}, delta + storageID, true, true);
         }
-        SECTION("Max overwrite delta")
+        SECTION("Overwrite")
         {
-            nonceChecked({0, 0}, delta + storageID, true, true, 1);
-        }
-        SECTION("storageID too big")
-        {
-            nonceChecked({0, 0}, delta + delta + storageID, true, false);
-            nonceChecked({0, 0}, delta * 9 + storageID, true, false);
-            nonceChecked({0, 0}, delta * 99 + storageID, true, false);
-            nonceChecked({0, 0}, delta * 999 + storageID, true, false);
-            nonceChecked({0, 0}, delta * 9999 + storageID, true, false);
+            nonceChecked({0, 0}, delta + storageID, true, true);
+            nonceChecked({0, 0}, delta + delta + storageID, true, true);
+            nonceChecked({0, 0}, delta * 9 + storageID, true, true);
+            nonceChecked({0, 0}, delta * 99 + storageID, true, true);
+            nonceChecked({0, 0}, delta * 999 + storageID, true, true);
+            nonceChecked({0, 0}, delta * 9999 + storageID, true, true);
         }
     }
 

--- a/packages/loopring_v3/circuit/test/StorageTests.cpp
+++ b/packages/loopring_v3/circuit/test/StorageTests.cpp
@@ -105,34 +105,30 @@ TEST_CASE("StorageReader", "[StorageReaderGadget]")
 
 TEST_CASE("Nonce", "[NonceGadget]")
 {
-    auto nonceChecked = [](
-                          const StorageLeaf &storageLeaf,
-                          const FieldT &_storageID,
-                          bool _verify,
-                          bool expectedSatisfied) {
-        protoboard<FieldT> pb;
+    auto nonceChecked =
+      [](const StorageLeaf &storageLeaf, const FieldT &_storageID, bool _verify, bool expectedSatisfied) {
+          protoboard<FieldT> pb;
 
-        VariableT verify = make_variable(pb, _verify ? FieldT::one() : FieldT::zero(), ".verify");
+          VariableT verify = make_variable(pb, _verify ? FieldT::one() : FieldT::zero(), ".verify");
 
-        StorageGadget storage(pb, "storage");
-        storage.generate_r1cs_witness(storageLeaf);
+          StorageGadget storage(pb, "storage");
+          storage.generate_r1cs_witness(storageLeaf);
 
-        DualVariableGadget storageID(pb, NUM_BITS_STORAGEID, "storageID");
-        storageID.generate_r1cs_witness(pb, _storageID);
+          DualVariableGadget storageID(pb, NUM_BITS_STORAGEID, "storageID");
+          storageID.generate_r1cs_witness(pb, _storageID);
 
-        jubjub::Params params;
-        Constants constants(pb, "constants");
-        NonceGadget nonceGadget(pb, constants, storage, storageID, verify, "nonceGadget");
-        nonceGadget.generate_r1cs_witness();
-        nonceGadget.generate_r1cs_constraints();
+          jubjub::Params params;
+          Constants constants(pb, "constants");
+          NonceGadget nonceGadget(pb, constants, storage, storageID, verify, "nonceGadget");
+          nonceGadget.generate_r1cs_witness();
+          nonceGadget.generate_r1cs_constraints();
 
-        REQUIRE(pb.is_satisfied() == expectedSatisfied);
-        if (expectedSatisfied)
-        {
-            REQUIRE((pb.val(nonceGadget.getData()) == FieldT::one()));
-
-        }
-    };
+          REQUIRE(pb.is_satisfied() == expectedSatisfied);
+          if (expectedSatisfied)
+          {
+              REQUIRE((pb.val(nonceGadget.getData()) == FieldT::one()));
+          }
+      };
 
     unsigned int delta = pow(2, NUM_BITS_STORAGE_ADDRESS);
     unsigned int storageID = rand() % delta;

--- a/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
@@ -127,8 +127,8 @@ library ExchangeData
     function MAX_AGE_DEPOSIT_UNTIL_WITHDRAWABLE_UPPERBOUND() internal pure returns (uint32) { return 15 days; }
     function ACCOUNTID_PROTOCOLFEE() internal pure returns (uint32) { return 0; }
 
-    function TX_DATA_AVAILABILITY_SIZE_PART_1() internal pure returns (uint32) { return 25; }
-    function TX_DATA_AVAILABILITY_SIZE_PART_2() internal pure returns (uint32) { return 43; }
+    function TX_DATA_AVAILABILITY_SIZE_PART_1() internal pure returns (uint32) { return 29; }
+    function TX_DATA_AVAILABILITY_SIZE_PART_2() internal pure returns (uint32) { return 39; }
 
     struct AccountLeaf
     {

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/BlockReader.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/BlockReader.sol
@@ -78,8 +78,8 @@ library BlockReader {
             _block.blockSize * ExchangeData.TX_DATA_AVAILABILITY_SIZE_PART_1() +
             txIdx * ExchangeData.TX_DATA_AVAILABILITY_SIZE_PART_2();
         assembly {
-            mstore(add(txData, 57 /*32 + 25*/), mload(add(data, add(txDataOffset, 32))))
-            mstore(add(txData, 68            ), mload(add(data, add(txDataOffset, 43))))
+            mstore(add(txData, 61 /*32 + 29*/), mload(add(data, add(txDataOffset, 32))))
+            mstore(add(txData, 68            ), mload(add(data, add(txDataOffset, 39))))
         }
         return txData;
     }

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
@@ -104,12 +104,10 @@ library TransferTransaction
         _offset += 2;
         transfer.fee = uint(data.toUint16(_offset)).decodeFloat(16);
         _offset += 2;
-        //uint16 shortStorageID = data.toUint16(_offset);
-        _offset += 2;
-        transfer.to = data.toAddress(_offset);
-        _offset += 20;
         transfer.storageID = data.toUint32(_offset);
         _offset += 4;
+        transfer.to = data.toAddress(_offset);
+        _offset += 20;
         transfer.from = data.toAddress(_offset);
         _offset += 20;
     }

--- a/packages/loopring_v3/test/testExchangeRingSettlement.ts
+++ b/packages/loopring_v3/test/testExchangeRingSettlement.ts
@@ -4,7 +4,6 @@ import { expectThrow } from "./expectThrow";
 import { ExchangeTestUtil } from "./testExchangeUtil";
 import { AuthMethod, OrderInfo, SpotTrade } from "./types";
 
-
 contract("Exchange", (accounts: string[]) => {
   let exchangeTestUtil: ExchangeTestUtil;
 
@@ -690,10 +689,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("Specific taker (correct)", async () => {
@@ -751,10 +747,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("No funds available", async () => {
@@ -938,10 +931,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("fillAmountB is 0 because of rounding error", async () => {
@@ -968,10 +958,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("operator == order owner", async () => {
@@ -1060,10 +1047,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("tokenS == tokenB", async () => {
@@ -1085,10 +1069,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("Wrong order signature", async () => {
@@ -1111,10 +1092,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("validUntil < now", async () => {
@@ -1141,10 +1119,7 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.setupRing(ring);
       await exchangeTestUtil.sendRing(ring);
 
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("Multiple rings", async () => {
@@ -1312,10 +1287,7 @@ contract("Exchange", (accounts: string[]) => {
 
       await exchangeTestUtil.setupRing(ringB);
       await exchangeTestUtil.sendRing(ringB);
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
 
     it("Trimmed storageID (order.storageID > storage.storageID)", async () => {
@@ -1396,7 +1368,7 @@ contract("Exchange", (accounts: string[]) => {
           amountS: new BN(web3.utils.toWei("100", "ether")),
           amountB: new BN(web3.utils.toWei("200", "ether")),
           owner: ownerA,
-            storageID: storageIDA + Constants.NUM_STORAGE_SLOTS
+          storageID: storageIDA + Constants.NUM_STORAGE_SLOTS
         },
         orderB: {
           tokenS: "GTO",
@@ -1404,8 +1376,7 @@ contract("Exchange", (accounts: string[]) => {
           amountS: new BN(web3.utils.toWei("200", "ether")),
           amountB: new BN(web3.utils.toWei("100", "ether")),
           owner: ownerB,
-          storageID:
-            storageIDB + 2 * Constants.NUM_STORAGE_SLOTS
+          storageID: storageIDB + 2 * Constants.NUM_STORAGE_SLOTS
         },
         expected: {
           orderA: { filledFraction: 0.0, spread: new BN(0) },
@@ -1419,8 +1390,7 @@ contract("Exchange", (accounts: string[]) => {
           amountS: new BN(web3.utils.toWei("100", "ether")),
           amountB: new BN(web3.utils.toWei("200", "ether")),
           owner: ownerA,
-          storageID:
-            storageIDA + 2 * Constants.NUM_STORAGE_SLOTS
+          storageID: storageIDA + 2 * Constants.NUM_STORAGE_SLOTS
         },
         orderB: {
           tokenS: "GTO",
@@ -1428,8 +1398,7 @@ contract("Exchange", (accounts: string[]) => {
           amountS: new BN(web3.utils.toWei("200", "ether")),
           amountB: new BN(web3.utils.toWei("100", "ether")),
           owner: ownerB,
-          storageID:
-            storageIDB + 3 * Constants.NUM_STORAGE_SLOTS
+          storageID: storageIDB + 5 * Constants.NUM_STORAGE_SLOTS
         },
         expected: {
           orderA: { filledFraction: 1.0, spread: new BN(0) },
@@ -1451,65 +1420,6 @@ contract("Exchange", (accounts: string[]) => {
       await exchangeTestUtil.submitTransactions();
 
       await verify();
-    });
-
-    it("Invalid storageID (order.storageID > storage.storageID)", async () => {
-      const storageID = 8;
-      const ringA: SpotTrade = {
-        orderA: {
-          tokenS: "WETH",
-          tokenB: "GTO",
-          amountS: new BN(web3.utils.toWei("100", "ether")),
-          amountB: new BN(web3.utils.toWei("200", "ether")),
-          owner: exchangeTestUtil.testContext.orderOwners[0],
-          storageID
-        },
-        orderB: {
-          tokenS: "GTO",
-          tokenB: "WETH",
-          amountS: new BN(web3.utils.toWei("200", "ether")),
-          amountB: new BN(web3.utils.toWei("100", "ether")),
-          owner: exchangeTestUtil.testContext.orderOwners[1]
-        },
-        expected: {
-          orderA: { filledFraction: 1.0, spread: new BN(0) },
-          orderB: { filledFraction: 1.0 }
-        }
-      };
-      const ringB: SpotTrade = {
-        orderA: {
-          tokenS: "WETH",
-          tokenB: "GTO",
-          amountS: new BN(web3.utils.toWei("100", "ether")),
-          amountB: new BN(web3.utils.toWei("200", "ether")),
-          owner: exchangeTestUtil.testContext.orderOwners[0],
-          storageID:
-            storageID + 2 * 2 ** Constants.BINARY_TREE_DEPTH_STORAGE
-        },
-        orderB: {
-          tokenS: "GTO",
-          tokenB: "WETH",
-          amountS: new BN(web3.utils.toWei("200", "ether")),
-          amountB: new BN(web3.utils.toWei("100", "ether")),
-          owner: exchangeTestUtil.testContext.orderOwners[3]
-        },
-        expected: {
-          orderA: { filledFraction: 1.0, spread: new BN(0) },
-          orderB: { filledFraction: 1.0 }
-        }
-      };
-
-      await exchangeTestUtil.setupRing(ringA);
-      await exchangeTestUtil.sendRing(ringA);
-      await exchangeTestUtil.submitTransactions();
-      await verify();
-
-      await exchangeTestUtil.setupRing(ringB);
-      await exchangeTestUtil.sendRing(ringB);
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
     });
 
     it("Cancelled storageID (order.storageID < storage.storageID)", async () => {
@@ -1564,10 +1474,7 @@ contract("Exchange", (accounts: string[]) => {
 
       await exchangeTestUtil.setupRing(ringB);
       await exchangeTestUtil.sendRing(ringB);
-      await expectThrow(
-        exchangeTestUtil.submitTransactions(),
-        "invalid block"
-      );
+      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
     });
   });
 });

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -47,9 +47,7 @@ import {
   WithdrawalRequest
 } from "./types";
 
-const LoopringIOExchangeOwner = artifacts.require(
-  "LoopringIOExchangeOwner"
-);
+const LoopringIOExchangeOwner = artifacts.require("LoopringIOExchangeOwner");
 
 type TxType =
   | Noop
@@ -397,7 +395,6 @@ export namespace TransferUtils {
   }
 }
 
-
 export namespace AmmUpdateUtils {
   export function toTypedData(update: AmmUpdate, verifyingContract: string) {
     const typedData = {
@@ -516,7 +513,6 @@ export class ExchangeTestUtil {
 
   private emptyMerkleRoot =
     "0x1efe4f31c90f89eb9b139426a95e5e87f6e0c9e8dab9ddf295e3f9d651f54698";
-
 
   public async initialize(accounts: string[]) {
     this.context = await this.createContractContext();
@@ -699,8 +695,7 @@ export class ExchangeTestUtil {
       options.storageID !== undefined
         ? options.storageID
         : this.storageIDGenerator++;
-    const maxFee =
-      options.maxFee !== undefined ? options.maxFee : fee;
+    const maxFee = options.maxFee !== undefined ? options.maxFee : fee;
 
     // From
     await this.deposit(from, from, token, amountToDeposit);
@@ -863,7 +858,11 @@ export class ExchangeTestUtil {
     ring.fee = ring.fee ? ring.fee : new BN(web3.utils.toWei("1", "ether"));
   }
 
-  public async setupOrder(order: OrderInfo, index: number, bDeposit: boolean = true) {
+  public async setupOrder(
+    order: OrderInfo,
+    index: number,
+    bDeposit: boolean = true
+  ) {
     if (order.owner === undefined) {
       const accountIndex = index % this.testContext.orderOwners.length;
       order.owner = this.testContext.orderOwners[accountIndex];
@@ -1224,16 +1223,13 @@ export class ExchangeTestUtil {
       options.extraData !== undefined ? options.extraData : "0x";
     const validUntil =
       options.validUntil !== undefined ? options.validUntil : 0xffffffff;
-    const maxFee =
-      options.maxFee !== undefined ? options.maxFee : fee;
+    const maxFee = options.maxFee !== undefined ? options.maxFee : fee;
     let storageID =
       options.storageID !== undefined
         ? options.storageID
         : this.storageIDGenerator++;
     let storeRecipient =
-      options.storeRecipient !== undefined
-        ? options.storeRecipient
-        : false;
+      options.storeRecipient !== undefined ? options.storeRecipient : false;
 
     let type = 0;
     if (authMethod === AuthMethod.ECDSA || authMethod === AuthMethod.APPROVE) {
@@ -1454,10 +1450,7 @@ export class ExchangeTestUtil {
 
     // Aprove
     if (authMethod === AuthMethod.ECDSA) {
-      const hash = AmmUpdateUtils.getHash(
-        ammUpdate,
-        this.exchange.address
-      );
+      const hash = AmmUpdateUtils.getHash(ammUpdate, this.exchange.address);
       ammUpdate.onchainSignature = await sign(
         owner,
         hash,
@@ -1465,10 +1458,7 @@ export class ExchangeTestUtil {
       );
       await verifySignature(owner, hash, ammUpdate.onchainSignature);
     } else if (authMethod === AuthMethod.APPROVE) {
-      const hash = AmmUpdateUtils.getHash(
-        ammUpdate,
-        this.exchange.address
-      );
+      const hash = AmmUpdateUtils.getHash(ammUpdate, this.exchange.address);
       await this.exchange.approveTransaction(owner, hash, { from: owner });
     }
 
@@ -1804,7 +1794,7 @@ export class ExchangeTestUtil {
     ).toNumber();
 
     // Submit the blocks onchain
-    const operatorContract = this.operator ? this.operator :  this.exchange;
+    const operatorContract = this.operator ? this.operator : this.exchange;
 
     // Compress the data
     const txData = this.exchange.contract.methods
@@ -2066,13 +2056,8 @@ export class ExchangeTestUtil {
           }
         } else if (transaction.txType === "AmmUpdate") {
           numConditionalTransactions++;
-          const encodedAmmUpdateData = this.getAmmUpdateAuxData(
-            transaction
-          );
-          auxiliaryData.push([
-            i,
-            web3.utils.hexToBytes(encodedAmmUpdateData)
-          ]);
+          const encodedAmmUpdateData = this.getAmmUpdateAuxData(transaction);
+          auxiliaryData.push([i, web3.utils.hexToBytes(encodedAmmUpdateData)]);
         }
       }
       logDebug("numConditionalTransactions: " + numConditionalTransactions);
@@ -2136,17 +2121,8 @@ export class ExchangeTestUtil {
           const orderB = spotTrade.orderB;
 
           da.addNumber(TransactionType.SPOT_TRADE, 1);
-
-          da.addNumber(
-            spotTrade.overwriteDataSlotA * Constants.NUM_STORAGE_SLOTS +
-              (orderA.storageID % Constants.NUM_STORAGE_SLOTS),
-            2
-          );
-          da.addNumber(
-            spotTrade.overwriteDataSlotB * Constants.NUM_STORAGE_SLOTS +
-              (orderB.storageID % Constants.NUM_STORAGE_SLOTS),
-            2
-          );
+          da.addNumber(orderA.storageID, 4);
+          da.addNumber(orderB.storageID, 4);
           da.addNumber(orderA.accountID, 4);
           da.addNumber(orderB.accountID, 4);
           da.addNumber(orderA.tokenS, 2);
@@ -2175,18 +2151,13 @@ export class ExchangeTestUtil {
             toFloat(new BN(transfer.fee), Constants.Float16Encoding),
             2
           );
-          da.addNumber(
-            transfer.overwriteDataSlot * Constants.NUM_STORAGE_SLOTS +
-              (transfer.storageID % Constants.NUM_STORAGE_SLOTS),
-            2
-          );
+          da.addNumber(transfer.storageID, 4);
           da.addBN(
             new BN(
               transfer.type > 0 || transfer.toNewAccount ? transfer.to : "0"
             ),
             20
           );
-          da.addNumber(transfer.type > 0 ? transfer.storageID : 0, 4);
           da.addBN(new BN(transfer.type > 0 ? transfer.from : "0"), 20);
         } else if (tx.withdraw) {
           const withdraw = tx.withdraw;
@@ -2252,14 +2223,14 @@ export class ExchangeTestUtil {
       // Transform DA
       const transformedDa = new Bitstream();
       const size = Constants.TX_DATA_AVAILABILITY_SIZE;
-      const sizeA = 25;
-      const sizeB = 43;
-      assert.equal(sizeA + sizeB, size, "invalid transform sizes");
+      const size1 = 29;
+      const size2 = 39;
+      assert.equal(size1 + size2, size, "invalid transform sizes");
       for (let i = 0; i < blockSize; i++) {
-        transformedDa.addHex(allDa.extractData(i * size, sizeA));
+        transformedDa.addHex(allDa.extractData(i * size, size1));
       }
       for (let i = 0; i < blockSize; i++) {
-        transformedDa.addHex(allDa.extractData(i * size + sizeA, sizeB));
+        transformedDa.addHex(allDa.extractData(i * size + size1, size2));
       }
       bs.addHex(transformedDa.getData());
 
@@ -2364,13 +2335,13 @@ export class ExchangeTestUtil {
     return undefined;
   }
 
-  public async createExchange(
-      owner: string,
-      options: ExchangeOptions = {}
-    ) {
-    const setupTestState = options.setupTestState !== undefined ? options.setupTestState : true;
-    const deterministic = options.deterministic !== undefined ? options.deterministic : false;
-    const useOwnerContract = options.useOwnerContract !== undefined ? options.useOwnerContract : true;
+  public async createExchange(owner: string, options: ExchangeOptions = {}) {
+    const setupTestState =
+      options.setupTestState !== undefined ? options.setupTestState : true;
+    const deterministic =
+      options.deterministic !== undefined ? options.deterministic : false;
+    const useOwnerContract =
+      options.useOwnerContract !== undefined ? options.useOwnerContract : true;
 
     this.deterministic = deterministic;
     const operator = this.testContext.operators[0];
@@ -2499,11 +2470,13 @@ export class ExchangeTestUtil {
       );
       await this.setOperatorContract(ownerContract);
 
-      await this.exchange.transferOwnership(ownerContract.address, {from: this.exchangeOwner});
+      await this.exchange.transferOwnership(ownerContract.address, {
+        from: this.exchangeOwner
+      });
       const txData = this.exchange.contract.methods
         .claimOwnership()
         .encodeABI();
-      await ownerContract.transact(txData, {from: this.exchangeOwner});
+      await ownerContract.transact(txData, { from: this.exchangeOwner });
     }
 
     return exchangeId;
@@ -2956,7 +2929,9 @@ export class ExchangeTestUtil {
   }
 
   public getRandomFee() {
-    return this.deterministic ? new BN(0) : new BN(web3.utils.toWei("" + this.getRandomInt(10000) / 1000000));
+    return this.deterministic
+      ? new BN(0)
+      : new BN(web3.utils.toWei("" + this.getRandomInt(10000) / 1000000));
   }
 
   public async depositExchangeStakeChecked(amount: BN, owner: string) {


### PR DESCRIPTION
https://github.com/Loopring/team/issues/124

Numbers in the design doc updated for the worst case scenario where all bytes are non-zero (like we do for all other data as well), cost will be lower in practice.