### PR TITLE
[AMM Pool] Rename variables and extract methods

### DIFF
--- a/packages/loopring_v3/contracts/test/AmmPool.sol
+++ b/packages/loopring_v3/contracts/test/AmmPool.sol
@@ -130,8 +130,8 @@ contract AmmPool is IBlockReceiver, IAgent {
         uint    txIdx;
         bytes32 DOMAIN_SEPARATOR;
         bytes32 exchangeDomainSeparator;
-        uint[]  ammBalancesInAccount;
-        uint[]  ammBalances;
+        uint[]  ammBalancesBefore;
+        uint[]  ammBalancesAfter;
         uint    numTransactionsConsumed;
         Token[] tokens;
     }
@@ -449,8 +449,8 @@ contract AmmPool is IBlockReceiver, IAgent {
             txIdx: txIdx,
             DOMAIN_SEPARATOR: DOMAIN_SEPARATOR,
             exchangeDomainSeparator: exchange.getDomainSeparator(),
-            ammBalancesInAccount: new uint[](tokens.length),
-            ammBalances: new uint[](tokens.length),
+            ammBalancesBefore: new uint[](tokens.length),
+            ammBalancesAfter: new uint[](tokens.length),
             numTransactionsConsumed: 0,
             tokens: tokens
         });
@@ -476,11 +476,11 @@ contract AmmPool is IBlockReceiver, IAgent {
 
         // Deposit/Withdraw to/from the AMM account when necessary
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            if (ctx.ammBalances[i] > ctx.ammBalancesInAccount[i]) {
-                uint amount = ctx.ammBalances[i] - ctx.ammBalancesInAccount[i];
+            if (ctx.ammBalancesAfter[i] > ctx.ammBalancesBefore[i]) {
+                uint amount = ctx.ammBalancesAfter[i] - ctx.ammBalancesBefore[i];
                 processDeposit(ctx, ctx.tokens[i], amount);
-            } else if (ctx.ammBalancesInAccount[i] > ctx.ammBalances[i]) {
-                uint amount = ctx.ammBalancesInAccount[i] - ctx.ammBalances[i];
+            } else if (ctx.ammBalancesBefore[i] > ctx.ammBalancesAfter[i]) {
+                uint amount = ctx.ammBalancesBefore[i] - ctx.ammBalancesAfter[i];
                 processWithdrawal(ctx, ctx.tokens[i], amount);
             }
         }
@@ -535,10 +535,10 @@ contract AmmPool is IBlockReceiver, IAgent {
             ctx.numTransactionsConsumed++;
             if (start) {
                 // AMM account balance now available onchain
-                ctx.ammBalancesInAccount[i] = update.balance;
-                ctx.ammBalances[i] = ctx.ammBalancesInAccount[i];
+                ctx.ammBalancesBefore[i] = update.balance;
+                ctx.ammBalancesAfter[i] = update.balance;
             } else {
-                require(ctx.ammBalances[i] == update.balance, "UNEXPECTED_AMM_BALANCE");
+                require(ctx.ammBalancesAfter[i] == update.balance, "UNEXPECTED_AMM_BALANCE");
             }
         }
     }
@@ -573,7 +573,7 @@ contract AmmPool is IBlockReceiver, IAgent {
         bool valid = true;
         uint[] memory amounts = new uint[](ctx.tokens.length);
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            amounts[i] = ctx.ammBalances[i] * ratio / BASE;
+            amounts[i] = ctx.ammBalancesAfter[i] * ratio / BASE;
             if (poolTotal == 0) {
                 amounts[i] = join.maxAmountsIn[i];
             }
@@ -606,13 +606,13 @@ contract AmmPool is IBlockReceiver, IAgent {
                     // Update the amount to the actual amount transferred (which can have some some small rounding errors)
                     amount = transfer.amount;
                     // Update the balances in the account
-                    ctx.ammBalancesInAccount[i] = ctx.ammBalancesInAccount[i].add(amount);
+                    ctx.ammBalancesBefore[i] = ctx.ammBalancesBefore[i].add(amount);
                 } else {
                     // Make the amount unavailable for withdrawing
                     address token = ctx.tokens[i].addr;
                     balance[token][join.owner] = balance[token][join.owner].sub(amount);
                 }
-                ctx.ammBalances[i] = ctx.ammBalances[i].add(amount);
+                ctx.ammBalancesAfter[i] = ctx.ammBalancesAfter[i].add(amount);
             }
 
             // Mint liquidity tokens
@@ -652,7 +652,7 @@ contract AmmPool is IBlockReceiver, IAgent {
         bool valid = availableBalance(address(this), exit.owner) >= exit.poolAmountIn;
         uint[] memory amounts = new uint[](ctx.tokens.length);
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            amounts[i] = ctx.ammBalances[i] * ratio / BASE;
+            amounts[i] = ctx.ammBalancesAfter[i] * ratio / BASE;
             if(amounts[i] < exit.minAmountsOut[i]) {
                 valid = false;
             }
@@ -681,12 +681,12 @@ contract AmmPool is IBlockReceiver, IAgent {
                     // Update the amount to the actual amount transferred (which can have some some small rounding errors)
                     amount = transfer.amount;
                     // Update the balances in the account
-                    ctx.ammBalancesInAccount[i] = ctx.ammBalancesInAccount[i].sub(amount);
+                    ctx.ammBalancesBefore[i] = ctx.ammBalancesBefore[i].sub(amount);
                 } else {
                     // Make the amount available for withdrawing
                     balance[ctx.tokens[i].addr][exit.owner] = balance[ctx.tokens[i].addr][exit.owner].add(amount);
                 }
-                ctx.ammBalances[i] = ctx.ammBalances[i].sub(amount);
+                ctx.ammBalancesAfter[i] = ctx.ammBalancesAfter[i].sub(amount);
             }
 
             // Burn liquidity tokens

--- a/packages/loopring_v3/contracts/test/AmmPool.sol
+++ b/packages/loopring_v3/contracts/test/AmmPool.sol
@@ -630,9 +630,9 @@ contract AmmPool is IBlockReceiver, IAgent {
         uint ratio;
         if (poolTotal > 0) {
             ratio = join.poolAmountOut.mul(BASE) / poolTotal;
+        } else if (join.poolAmountOut != INITIAL_SUPPLY) {
+            return (false, amounts);
         } else {
-            // Important for accuracy
-            require(join.poolAmountOut == INITIAL_SUPPLY, "INITIAL_SUPPLY_UNEXPECTED");
             ratio = BASE;
         }
 


### PR DESCRIPTION
@Brechtpd After working on this PR, I finally figured out how your design works :) I do have the following suggestions regarding the pool token's mint/burn logic:

- Now we calculate the amount of tokens that will be accepted into the pool based on the Join's `poolAmountOut` parameter. If `poolAmountOut` is large enough, this join will likely to fail; otherwise, if it is small enough, the user ends up with a smaller amount of pool tokens than he deserves. I suggest we calculate the amount of pool tokens assuming his join will be accepted, then compare the new pool tokens to mint to him with a `minPoolTokenAmount` parameter that the user provides. If `minPoolTokenAmount` is smaller than or equal to the pool tokens to be minted, then this Join will be accepted, otherwise, the join will be rejected. By doing this, a user will feel really comfortable by providing a small value for `minPoolTokenAmount`, or even zero if he doesn't care about slippage.

- For exits, I suggest we only take one parameter - the amount of pool tokens the user would like to burn. Then calculate the amount of each token that will be released back to layer1 for withdrawal. There should be no slippage option for exits at all, as users collectively owns what's left in the pool anyway.  I believe this is also the case with uniswap.