### PR TITLE
[protocol 3.6] Changed lib functions from external to public

### DIFF
--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeAdmins.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeAdmins.sol
@@ -35,7 +35,7 @@ library ExchangeAdmins
         ExchangeData.State storage S,
         uint32 newValue
         )
-        external
+        public
         returns (uint32 oldValue)
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
@@ -58,7 +58,7 @@ library ExchangeAdmins
         ExchangeData.State storage S,
         address recipient
         )
-        external
+        public
         returns (uint)
     {
         // Exchange needs to be shutdown

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeBalances.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeBalances.sol
@@ -19,7 +19,7 @@ library ExchangeBalances
         uint                              merkleRoot,
         ExchangeData.MerkleProof calldata merkleProof
         )
-        external
+        public
         pure
     {
         require(

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeGenesis.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeGenesis.sol
@@ -25,7 +25,7 @@ library ExchangeGenesis
         bytes32 _genesisMerkleRoot,
         bytes32 _domainSeperator
         )
-        external
+        public
     {
         require(0 != _id, "INVALID_ID");
         require(address(0) != _loopring, "INVALID_LOOPRING_ADDRESS");

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeTokens.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeTokens.sol
@@ -27,7 +27,7 @@ library ExchangeTokens
         ExchangeData.State storage S,
         uint16 tokenID
         )
-        external
+        public
         view
         returns (address)
     {
@@ -39,7 +39,7 @@ library ExchangeTokens
         ExchangeData.State storage S,
         address tokenAddress
         )
-        external
+        public
         returns (uint16 tokenID)
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
@@ -50,7 +50,7 @@ library ExchangeWithdrawals
         address token,
         uint32  accountID
         )
-        external
+        public
     {
         require(!S.isInWithdrawalMode(), "INVALID_MODE");
         require(S.getNumAvailableForcedSlots() > 0, "TOO_MANY_REQUESTS_OPEN");
@@ -93,7 +93,7 @@ library ExchangeWithdrawals
         ExchangeData.State       storage S,
         ExchangeData.MerkleProof calldata merkleProof
         )
-        external
+        public
     {
         require(S.isInWithdrawalMode(), "NOT_IN_WITHDRAW_MODE");
 
@@ -130,7 +130,7 @@ library ExchangeWithdrawals
         address owner,
         address token
         )
-        external
+        public
     {
         uint16 tokenID = S.getTokenID(token);
         ExchangeData.Deposit storage deposit = S.pendingDeposits[owner][tokenID];


### PR DESCRIPTION
Only for consistency. I did not measure any gas cost difference in any practical test, but in a completely isolated test case `public` used 40 gas less than `external`.