### PR TITLE
Update WithdrawTransaction.sol

### DIFF
--- a/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
@@ -33,7 +33,7 @@ library WithdrawTransaction
     using ExchangeWithdrawals  for ExchangeData.State;
 
     bytes32 constant public WITHDRAWAL_TYPEHASH = keccak256(
-        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes32 extraDataHash,uint256 minGas,uint32 validUntil,uint32 storageID)"
+        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes extraData,uint256 minGas,uint32 validUntil,uint32 storageID)"
     );
 
     struct Withdrawal

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
@@ -33,7 +33,7 @@ library WithdrawTransaction
     using ExchangeWithdrawals  for ExchangeData.State;
 
     bytes32 constant public WITHDRAWAL_TYPEHASH = keccak256(
-        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes extraData,uint minGas,uint32 validUntil,uint32 storageID)"
+        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes32 extraDataHash,uint256 minGas,uint32 validUntil,uint32 storageID)"
     );
 
     struct Withdrawal


### PR DESCRIPTION
Change WITHDRAWAL_TYPEHASH signature to fully comply with eip-712, so that external integrators could use 3rd party eip-712 libs to get correct hash, i.e. this hash:

```
return EIP712.hashPacked(
            DOMAIN_SEPARATOR,
            keccak256(
                abi.encode(
                    WITHDRAWAL_TYPEHASH,
                    withdrawal.owner,
                    withdrawal.accountID,
                    withdrawal.tokenID,
                    withdrawal.amount,
                    withdrawal.feeTokenID,
                    withdrawal.fee,
                    withdrawal.to,
                    keccak256(withdrawal.extraData),
                    withdrawal.minGas,
                    withdrawal.validUntil,
                    withdrawal.storageID
                )
            )
        );
```