### PR TITLE
[Loopring AMM] alternative protection of replay

### DIFF
--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -40,7 +40,6 @@ library AmmData
         uint     minPoolAmountOut;
         uint96[] maxAmountsIn;
         uint96[] fees;
-        uint32[] storageIDs;
         uint     validUntil;
     }
 
@@ -50,7 +49,6 @@ library AmmData
         bool     toLayer2;
         uint     poolAmountIn;
         uint96[] minAmountsOut;
-        uint32[] storageIDs;
         uint     validUntil;
     }
 
@@ -125,5 +123,7 @@ library AmmData
 
         // A map from an owner to if a user is currently exiting using an onchain approval.
         mapping (address => bool) isExiting;
+
+        mapping (bytes32 => bool) consumedOffchainTx;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -111,11 +111,6 @@ library AmmExitProcess
                     "INVALID_TX_DATA"
                 );
 
-                // Replay protection when using a signature (otherwise the approved hash is cleared onchain)
-                if (signature.length > 0) {
-                    require(transfer.storageID == exit.storageIDs[i], "INVALID_TX_DATA");
-                }
-
                 // Now approve this transfer
                 transfer.validUntil = 0xffffffff;
                 bytes32 txHash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitRequest.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitRequest.sol
@@ -29,7 +29,7 @@ library AmmExitRequest
     );
 
     bytes32 constant public POOLEXIT_TYPEHASH = keccak256(
-        "PoolExit(address owner,bool toLayer2,uint256 poolAmountIn,uint256[] minAmountsOut,uint32[] storageIDs,uint256 validUntil)"
+        "PoolExit(address owner,bool toLayer2,uint256 poolAmountIn,uint256[] minAmountsOut,uint256 validUntil)"
     );
 
     event Withdrawal(address owner, uint[] amountOuts);
@@ -103,7 +103,6 @@ library AmmExitRequest
             toLayer2: toLayer2,
             poolAmountIn: poolAmountIn,
             minAmountsOut: minAmountsOut,
-            storageIDs: new uint32[](0),
             validUntil: 0xffffffff
         });
 
@@ -131,7 +130,6 @@ library AmmExitRequest
                     exit.toLayer2,
                     exit.poolAmountIn,
                     keccak256(abi.encodePacked(exit.minAmountsOut)),
-                    keccak256(abi.encodePacked(exit.storageIDs)),
                     exit.validUntil
                 )
             )

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -112,11 +112,6 @@ library AmmJoinProcess
                     "INVALID_TX_DATA"
                 );
 
-                // Replay protection when using a signature (otherwise the approved hash is cleared onchain)
-                if (signature.length > 0) {
-                    require(transfer.storageID == join.storageIDs[i], "INVALID_TX_DATA");
-                }
-
                 // Now approve this transfer
                 transfer.validUntil = 0xffffffff;
                 bytes32 txHash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinRequest.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinRequest.sol
@@ -23,7 +23,7 @@ library AmmJoinRequest
     using SafeCast          for uint;
 
     bytes32 constant public POOLJOIN_TYPEHASH = keccak256(
-        "PoolJoin(address owner,bool fromLayer2,uint256 minPoolAmountOut,uint256[] maxAmountsIn,uint256[] fees,uint32[] storageIDs,uint256 validUntil)"
+        "PoolJoin(address owner,bool fromLayer2,uint256 minPoolAmountOut,uint256[] maxAmountsIn,uint256[] fees,uint256 validUntil)"
     );
 
     event Deposit(address owner, uint96[] amounts);
@@ -103,7 +103,6 @@ library AmmJoinRequest
             minPoolAmountOut: minPoolAmountOut,
             maxAmountsIn: maxAmountsIn,
             fees: fees,
-            storageIDs: new uint32[](0),
             validUntil: validUntil
         });
 
@@ -132,7 +131,6 @@ library AmmJoinRequest
                     join.minPoolAmountOut,
                     keccak256(abi.encodePacked(join.maxAmountsIn)),
                     keccak256(abi.encodePacked(join.fees)),
-                    keccak256(abi.encodePacked(join.storageIDs)),
                     join.validUntil
                 )
             )

--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -175,6 +175,8 @@ library AmmStatus
             delete S.approvedTx[poolTxHash];
         } else {
             require(poolTxHash.verifySignature(owner, signature), "INVALID_SIGNATURE");
+            require(!S.consumedOffchainTx[poolTxHash], "CONSUMED_ALREADY");
+            S.consumedOffchainTx[poolTxHash] = true;
         }
     }
 }


### PR DESCRIPTION
This will make it much easier for the relayer to maintain storage IDs for parallelization.