### PR TITLE
[protocol 3.6] Rename owner to from/to for withdrawals/deposits

### DIFF
--- a/packages/loopring_v3.js/src/request_processors/deposit_processor.ts
+++ b/packages/loopring_v3.js/src/request_processors/deposit_processor.ts
@@ -4,8 +4,8 @@ import { Constants } from "../constants";
 import { Account, BlockContext, ExchangeState } from "../types";
 
 interface Deposit {
-  owner?: string;
-  accountID?: number;
+  to?: string;
+  toAccountID?: number;
   tokenID?: number;
   amount?: BN;
 }
@@ -14,11 +14,15 @@ interface Deposit {
  * Processes deposit requests.
  */
 export class DepositProcessor {
-  public static process(state: ExchangeState, block: BlockContext, txData: Bitstream) {
+  public static process(
+    state: ExchangeState,
+    block: BlockContext,
+    txData: Bitstream
+  ) {
     const deposit = this.extractData(txData);
 
-    const account = state.getAccount(deposit.accountID);
-    account.owner = deposit.owner;
+    const account = state.getAccount(deposit.toAccountID);
+    account.owner = deposit.to;
 
     const balance = account.getBalance(deposit.tokenID);
     balance.balance.iadd(deposit.amount);
@@ -31,9 +35,9 @@ export class DepositProcessor {
     let offset = 1;
 
     // Read in the deposit data
-    deposit.owner = data.extractAddress(offset);
+    deposit.to = data.extractAddress(offset);
     offset += 20;
-    deposit.accountID = data.extractUint32(offset);
+    deposit.toAccountID = data.extractUint32(offset);
     offset += 4;
     deposit.tokenID = data.extractUint16(offset);
     offset += 2;

--- a/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
+++ b/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
@@ -6,8 +6,8 @@ import { BlockContext, ExchangeState } from "../types";
 
 interface Withdrawal {
   type?: number;
-  owner?: string;
-  accountID?: number;
+  from?: string;
+  fromAccountID?: number;
   tokenID?: number;
   amount?: BN;
   feeTokenID?: number;
@@ -30,7 +30,7 @@ export class WithdrawalProcessor {
   ) {
     const withdrawal = this.extractData(txData);
 
-    const account = state.getAccount(withdrawal.accountID);
+    const account = state.getAccount(withdrawal.fromAccountID);
     let amount = withdrawal.amount;
     if (withdrawal.type === 2) {
       amount = account.getBalance(withdrawal.tokenID).balance;
@@ -62,9 +62,9 @@ export class WithdrawalProcessor {
 
     withdrawal.type = data.extractUint8(offset);
     offset += 1;
-    withdrawal.owner = data.extractAddress(offset);
+    withdrawal.from = data.extractAddress(offset);
     offset += 20;
-    withdrawal.accountID = data.extractUint32(offset);
+    withdrawal.fromAccountID = data.extractUint32(offset);
     offset += 4;
     withdrawal.tokenID = data.extractUint16(offset);
     offset += 2;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -48,8 +48,8 @@ library AmmExitProcess
 
         require(
             withdrawal.withdrawalType == 1 &&
-            withdrawal.owner == address(this) &&
-            withdrawal.accountID == S.accountID &&
+            withdrawal.from == address(this) &&
+            withdrawal.fromAccountID == S.accountID &&
             withdrawal.tokenID == token.tokenID &&
             withdrawal.amount == amount && //No rounding errors because we put in the complete uint96 in the DA.
             withdrawal.feeTokenID == 0 &&

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -44,8 +44,8 @@ library AmmJoinProcess
         ctx.numTransactionsConsumed++;
 
         require(
-            deposit.owner == address(this) &&
-            deposit.accountID == S.accountID &&
+            deposit.to == address(this) &&
+            deposit.toAccountID == S.accountID &&
             deposit.tokenID == token.tokenID &&
             deposit.amount == amount,
             "INVALID_TX_DATA"
@@ -64,8 +64,8 @@ library AmmJoinProcess
         }
 
         ctx.exchange.deposit{value: ethValue}(
-            deposit.owner,
-            deposit.owner,
+            deposit.to,
+            deposit.to,
             token.addr,
             deposit.amount,
             new bytes(0)

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -87,15 +87,14 @@ abstract contract IExchangeV3 is IExchange
 
     // events from libraries
     /*event DepositProcessed(
-        address owner,
-        uint32  accountId,
+        address to,
+        uint32  toAccountId,
         uint16  token,
-        uint    amount,
-        uint    index
+        uint    amount
     );*/
 
     /*event ForcedWithdrawalProcessed(
-        uint32 accountID,
+        uint32 fromAccountID,
         uint16 tokenID,
         uint   amount
     );*/

--- a/packages/loopring_v3/contracts/test/AmmPool.sol
+++ b/packages/loopring_v3/contracts/test/AmmPool.sol
@@ -848,8 +848,8 @@ contract AmmPool is LPERC20, IBlockReceiver, IAgent {
     {
         // Check that the deposit in the block matches the expected deposit
         DepositTransaction.Deposit memory _deposit = ctx._block.readDeposit(ctx.txIdx++);
-        require(_deposit.owner == address(this), "INVALID_TX_DATA");
-        require(_deposit.accountID == accountID, "INVALID_TX_DATA");
+        require(_deposit.to == address(this), "INVALID_TX_DATA");
+        require(_deposit.toAccountID == accountID, "INVALID_TX_DATA");
         require(_deposit.tokenID == token.tokenID, "INVALID_TX_DATA");
         require(_deposit.amount == amount, "INVALID_TX_DATA");
 
@@ -866,8 +866,8 @@ contract AmmPool is LPERC20, IBlockReceiver, IAgent {
             }
         }
         exchange.deposit{value: ethValue}(
-            _deposit.owner,
-            _deposit.owner,
+            _deposit.to,
+            _deposit.to,
             token.addr,
             uint96(_deposit.amount),
             new bytes(0)
@@ -886,8 +886,8 @@ contract AmmPool is LPERC20, IBlockReceiver, IAgent {
     {
         // Check that the withdrawal in the block matches the expected withdrawal
         WithdrawTransaction.Withdrawal memory withdrawal = ctx._block.readWithdrawal(ctx.txIdx++);
-        require(withdrawal.owner == address(this), "INVALID_TX_DATA");
-        require(withdrawal.accountID == accountID, "INVALID_TX_DATA");
+        require(withdrawal.from == address(this), "INVALID_TX_DATA");
+        require(withdrawal.fromAccountID == accountID, "INVALID_TX_DATA");
         require(withdrawal.tokenID == token.tokenID, "INVALID_TX_DATA");
         require(withdrawal.amount == amount, "INVALID_TX_DATA");
         require(withdrawal.feeTokenID == withdrawal.tokenID, "INVALID_TX_DATA");


### PR DESCRIPTION
Only renamed variables that don't impact any offchain processes (signatures, circuits). Not sure if this would be a problem at this point.