### PR TITLE
[AMM] Mint/Burn directly on L2

### DIFF
--- a/packages/loopring_v3/contracts/amm/PoolToken.sol
+++ b/packages/loopring_v3/contracts/amm/PoolToken.sol
@@ -41,7 +41,7 @@ abstract contract PoolToken is ERC2612 {
         override
         returns (uint)
     {
-        return state.effectiveTotalSupply();
+        return state.totalSupply();
     }
 
     function balanceOf(address owner)

--- a/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
@@ -70,7 +70,7 @@ library AmmBlockReceiver
             poolTokenBase: AmmData.POOL_TOKEN_BASE(),
             poolTokenInitialSupply: AmmData.POOL_TOKEN_INITIAL_SUPPLY(),
             size: size,
-            layer2Balances: new uint96[](size),
+            balancesL2: new uint96[](size),
             totalMintedSupply: S.totalMintedSupply,
             poolBalanceL2: S.poolBalanceL2
         });

--- a/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
@@ -41,6 +41,10 @@ library AmmBlockReceiver
 
         S.approveAmmUpdates(ctx, false);
 
+        // Update state
+        S.totalSupply = ctx.totalSupply;
+        S.poolBalanceL2 = ctx.poolBalanceL2;
+
         return ctx.txIdx - txIdx;
     }
 
@@ -62,11 +66,13 @@ library AmmBlockReceiver
             domainSeparator: S.domainSeparator,
             accountID: S.accountID,
             tokens: S.tokens,
+            poolTokenID: S.poolTokenID,
             poolTokenBase: AmmData.POOL_TOKEN_BASE(),
             poolTokenInitialSupply: AmmData.POOL_TOKEN_INITIAL_SUPPLY(),
             size: size,
             layer2Balances: new uint96[](size),
-            effectiveTotalSupply: S.effectiveTotalSupply()
+            totalSupply: S.totalSupply,
+            poolBalanceL2: S.poolBalanceL2
         });
     }
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
@@ -42,7 +42,7 @@ library AmmBlockReceiver
         S.approveAmmUpdates(ctx, false);
 
         // Update state
-        S.totalSupply = ctx.totalSupply;
+        S.totalMintedSupply = ctx.totalMintedSupply;
         S.poolBalanceL2 = ctx.poolBalanceL2;
 
         return ctx.txIdx - txIdx;
@@ -71,7 +71,7 @@ library AmmBlockReceiver
             poolTokenInitialSupply: AmmData.POOL_TOKEN_INITIAL_SUPPLY(),
             size: size,
             layer2Balances: new uint96[](size),
-            totalSupply: S.totalSupply,
+            totalMintedSupply: S.totalMintedSupply,
             poolBalanceL2: S.poolBalanceL2
         });
     }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -79,6 +79,7 @@ library AmmData
         // AMM pool state variables
         bytes32 domainSeparator;
         uint32  accountID;
+        uint16  poolTokenID;
 
         Token[] tokens;
 
@@ -87,7 +88,8 @@ library AmmData
         uint    size; // == token.length;
 
         uint96[] layer2Balances;
-        uint     effectiveTotalSupply;
+        uint     totalSupply;
+        uint96   poolBalanceL2;
     }
 
     struct State {
@@ -95,7 +97,7 @@ library AmmData
         string poolName;
         string symbol;
         uint   totalSupply;
-        uint   poolSupplyToBurn;
+        uint96 poolBalanceL2;
 
         mapping(address => uint) balanceOf;
         mapping(address => mapping(address => uint)) allowance;
@@ -109,6 +111,7 @@ library AmmData
         uint8       feeBips;
         uint16      forcedExitCount;
         Token[]     tokens;
+        uint16      poolTokenID;
 
         // A map of approved transaction hashes to the timestamp it was created
         mapping (bytes32 => PoolExit) forcedExit;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -87,7 +87,7 @@ library AmmData
         uint    poolTokenInitialSupply;
         uint    size; // == token.length;
 
-        uint96[] layer2Balances;
+        uint96[] balancesL2;
         uint     totalMintedSupply;
         uint96   poolBalanceL2;
     }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -88,7 +88,7 @@ library AmmData
         uint    size; // == token.length;
 
         uint96[] layer2Balances;
-        uint     totalSupply;
+        uint     totalMintedSupply;
         uint96   poolBalanceL2;
     }
 
@@ -96,7 +96,7 @@ library AmmData
         // Pool token state variables
         string poolName;
         string symbol;
-        uint   totalSupply;
+        uint   totalMintedSupply;
         uint96 poolBalanceL2;
 
         mapping(address => uint) balanceOf;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -66,8 +66,8 @@ library AmmExitProcess
                 return;
             }
             S.burn(address(this), exit.burnAmount);
-            ctx.totalSupply = ctx.totalSupply.sub(exit.burnAmount);
-            assert(ctx.totalSupply == S.totalSupply);
+            ctx.totalMintedSupply = ctx.totalMintedSupply.sub(exit.burnAmount);
+            assert(ctx.totalMintedSupply == S.totalMintedSupply);
         } else {
             require(slippageOK, "EXIT_SLIPPAGE_INVALID");
             _burnL2(ctx, exit.burnAmount, exit.owner, exit.burnStorageID);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -125,7 +125,7 @@ library AmmExitProcess
 
         transfer.validUntil = 0xffffffff;
         bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
-        ctx.exchange.approveTransaction(address(this), hash);
+        ctx.exchange.approveTransaction(from, hash);
 
         // Update pool balance
         ctx.poolBalanceL2 = ctx.poolBalanceL2.add(transfer.amount);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -21,6 +21,7 @@ import "./AmmPoolToken.sol";
 library AmmExitProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using ERC20SafeTransfer for address;
     using MathUint          for uint;
@@ -65,11 +66,11 @@ library AmmExitProcess
                 return;
             }
             S.burn(address(this), exit.burnAmount);
+            ctx.totalSupply = ctx.totalSupply.sub(exit.burnAmount);
+            assert(ctx.totalSupply == S.totalSupply);
         } else {
             require(slippageOK, "EXIT_SLIPPAGE_INVALID");
-            S.poolSupplyToBurn = S.poolSupplyToBurn.add(exit.burnAmount);
-            // withdraw the pool token from the user to the pool account.
-            _approvePoolTokenWithdrawal(ctx, exit.burnAmount, exit.owner, exit.burnStorageID, signature);
+            _burnL2(ctx, exit.burnAmount, exit.owner, exit.burnStorageID);
         }
 
         // Handle liquidity tokens
@@ -99,48 +100,35 @@ library AmmExitProcess
         emit ExitProcessed(exit.owner, exit.burnAmount, amounts, isForcedExit);
     }
 
-    function _approvePoolTokenWithdrawal(
+    function _burnL2(
         AmmData.Context  memory  ctx,
-        uint                     amount,
+        uint96                   amount,
         address                  from,
-        uint32                   burnStorageID,
-        bytes            memory  signature
+        uint32                   burnStorageID
         )
         internal
     {
-        // Check that the withdrawal in the block matches the expected withdrawal
-        WithdrawTransaction.Withdrawal memory withdrawal = ctx._block.readWithdrawal(ctx.txIdx++);
-
-        // These fields are not read by readWithdrawal: to, extraData, minGas, validUntil
-        withdrawal.extraData = new bytes(0);
-        withdrawal.minGas = 0;
-        withdrawal.validUntil = 0xffffffff;
-
-        bytes32 expectedOnchainDataHash = WithdrawTransaction.hashOnchainData(
-            withdrawal.minGas,
-            withdrawal.to,
-            withdrawal.extraData
-        );
-
-        if (signature.length > 0) {
-            require(withdrawal.storageID == burnStorageID, "INVALID_STORAGE_ID_OR_REPLAY");
-        }
+        TransferTransaction.Transfer memory transfer = ctx._block.readTransfer(ctx.txIdx++);
 
         require(
-            withdrawal.withdrawalType == 1 &&
-            withdrawal.from == from &&
-            // withdrawal.fromAccountID == UNKNOWN &&
-            withdrawal.tokenID == ctx.tokens[ctx.size].tokenID &&
-            withdrawal.amount == amount && //No rounding errors because we put in the complete uint96 in the DA.
-            withdrawal.feeTokenID == 0 &&
-            withdrawal.fee == 0 &&
-            withdrawal.onchainDataHash == expectedOnchainDataHash,
+            // transfer.fromAccountID == UNKNOWN &&
+            transfer.toAccountID == ctx.accountID &&
+            transfer.from == from &&
+            transfer.to == address(this) &&
+            transfer.tokenID == ctx.poolTokenID &&
+            transfer.amount.isAlmostEqual(amount) &&
+            transfer.feeTokenID == 0 &&
+            transfer.fee == 0 &&
+            transfer.storageID == burnStorageID,
             "INVALID_TX_DATA"
         );
 
-        // Now approve this withdrawal
-        bytes32 hash = WithdrawTransaction.hashTx(ctx.exchangeDomainSeparator, withdrawal);
-        ctx.exchange.approveTransaction(from, hash);
+        transfer.validUntil = 0xffffffff;
+        bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
+        ctx.exchange.approveTransaction(address(this), hash);
+
+        // Update pool balance
+        ctx.poolBalanceL2 = ctx.poolBalanceL2.add(transfer.amount);
     }
 
     function _calculateExitAmounts(
@@ -162,7 +150,7 @@ library AmmExitProcess
         }
 
         // Calculate how much will be withdrawn
-        uint ratio = ctx.poolTokenBase.mul(exit.burnAmount) / ctx.effectiveTotalSupply;
+        uint ratio = ctx.poolTokenBase.mul(exit.burnAmount) / ctx.effectiveTotalSupply();
 
         for (uint i = 0; i < ctx.size; i++) {
             amounts[i] = (ratio.mul(ctx.layer2Balances[i]) / ctx.poolTokenBase).toUint96();

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -94,7 +94,7 @@ library AmmExitProcess
             bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
             ctx.exchange.approveTransaction(address(this), hash);
 
-            ctx.layer2Balances[i] = ctx.layer2Balances[i].sub(transfer.amount);
+            ctx.balancesL2[i] = ctx.balancesL2[i].sub(transfer.amount);
         }
 
         emit ExitProcessed(exit.owner, exit.burnAmount, amounts, isForcedExit);
@@ -153,7 +153,7 @@ library AmmExitProcess
         uint ratio = ctx.poolTokenBase.mul(exit.burnAmount) / ctx.effectiveTotalSupply();
 
         for (uint i = 0; i < ctx.size; i++) {
-            amounts[i] = (ratio.mul(ctx.layer2Balances[i]) / ctx.poolTokenBase).toUint96();
+            amounts[i] = (ratio.mul(ctx.balancesL2[i]) / ctx.poolTokenBase).toUint96();
             if (amounts[i] < exit.exitMinAmounts[i]) {
                 return (false, amounts);
             }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -20,6 +20,7 @@ import "./AmmUtil.sol";
 library AmmJoinProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using MathUint          for uint;
     using MathUint96        for uint96;
@@ -30,7 +31,7 @@ library AmmJoinProcess
     event JoinProcessed(address owner, uint96 mintAmount, uint96[] amounts);
 
     function processJoin(
-        AmmData.State    storage S,
+        AmmData.State    storage /*S*/,
         AmmData.Context  memory  ctx,
         AmmData.PoolJoin memory  join,
         bytes            memory  signature
@@ -68,42 +69,39 @@ library AmmJoinProcess
             ctx.layer2Balances[i] = ctx.layer2Balances[i].add(transfer.amount);
         }
 
-        // Handle pool tokens
-        S.mint(address(this), mintAmount);
-
-        _approvePoolTokenDeposit(ctx, mintAmount, join.owner);
+        _mintL2(ctx, mintAmount, join.owner);
 
         emit JoinProcessed(join.owner, mintAmount, amounts);
     }
 
-    function _approvePoolTokenDeposit(
+    function _mintL2(
         AmmData.Context  memory  ctx,
         uint96                   amount,
         address                  to
         )
         private
     {
-        require(amount > 0, "INVALID_DEPOSIT_AMOUNT");
-
-        // Check that the deposit in the block matches the expected deposit
-        DepositTransaction.Deposit memory deposit = ctx._block.readDeposit(ctx.txIdx++);
-
-        AmmData.Token memory poolToken = ctx.tokens[ctx.size];
+        TransferTransaction.Transfer memory transfer = ctx._block.readTransfer(ctx.txIdx++);
 
         require(
-            deposit.to == to &&
-            deposit.tokenID == poolToken.tokenID &&
-            deposit.amount == amount,
+            transfer.fromAccountID == ctx.accountID &&
+            // transfer.toAccountID == UNKNOWN &&
+            transfer.from == address(this) &&
+            transfer.to == to &&
+            transfer.tokenID == ctx.poolTokenID &&
+            transfer.amount.isAlmostEqual(amount) &&
+            transfer.feeTokenID == 0 &&
+            transfer.fee == 0,
+            // transfer.storageID == UNKNOWN &&
             "INVALID_TX_DATA"
         );
 
-        ctx.exchange.deposit{value: 0}(
-            address(this), // from
-            to,
-            poolToken.addr,
-            amount,
-            new bytes(0)
-        );
+        transfer.validUntil = 0xffffffff;
+        bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
+        ctx.exchange.approveTransaction(address(this), hash);
+
+        // Update pool balance
+        ctx.poolBalanceL2 = ctx.poolBalanceL2.sub(transfer.amount);
     }
 
     function _calculateJoinAmounts(
@@ -125,7 +123,7 @@ library AmmJoinProcess
             return (false, 0, amounts);
         }
 
-        if (ctx.effectiveTotalSupply == 0) {
+        if (ctx.effectiveTotalSupply() == 0) {
             return(true, ctx.poolTokenInitialSupply.toUint96(), join.joinAmounts);
         }
 
@@ -134,7 +132,7 @@ library AmmJoinProcess
         for (uint i = 0; i < ctx.size; i++) {
             if (ctx.layer2Balances[i] > 0) {
                 uint amountOut = uint(join.joinAmounts[i])
-                    .mul(ctx.effectiveTotalSupply) / uint(ctx.layer2Balances[i]);
+                    .mul(ctx.effectiveTotalSupply()) / uint(ctx.layer2Balances[i]);
 
                 if (!initialized) {
                     initialized = true;
@@ -150,7 +148,7 @@ library AmmJoinProcess
         }
 
         // Calculate the amounts to deposit
-        uint ratio = ctx.poolTokenBase.mul(mintAmount) / ctx.effectiveTotalSupply;
+        uint ratio = ctx.poolTokenBase.mul(mintAmount) / ctx.effectiveTotalSupply();
 
         for (uint i = 0; i < ctx.size; i++) {
             amounts[i] = ratio.mul(ctx.layer2Balances[i] / ctx.poolTokenBase).toUint96();

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -66,7 +66,7 @@ library AmmJoinProcess
             bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
             ctx.exchange.approveTransaction(join.owner, hash);
 
-            ctx.layer2Balances[i] = ctx.layer2Balances[i].add(transfer.amount);
+            ctx.balancesL2[i] = ctx.balancesL2[i].add(transfer.amount);
         }
 
         _mintL2(ctx, mintAmount, join.owner);
@@ -130,9 +130,9 @@ library AmmJoinProcess
         // Calculate the amount of pool tokens that should be minted
         bool initialized = false;
         for (uint i = 0; i < ctx.size; i++) {
-            if (ctx.layer2Balances[i] > 0) {
+            if (ctx.balancesL2[i] > 0) {
                 uint amountOut = uint(join.joinAmounts[i])
-                    .mul(ctx.effectiveTotalSupply()) / uint(ctx.layer2Balances[i]);
+                    .mul(ctx.effectiveTotalSupply()) / uint(ctx.balancesL2[i]);
 
                 if (!initialized) {
                     initialized = true;
@@ -151,7 +151,7 @@ library AmmJoinProcess
         uint ratio = ctx.poolTokenBase.mul(mintAmount) / ctx.effectiveTotalSupply();
 
         for (uint i = 0; i < ctx.size; i++) {
-            amounts[i] = ratio.mul(ctx.layer2Balances[i] / ctx.poolTokenBase).toUint96();
+            amounts[i] = ratio.mul(ctx.balancesL2[i] / ctx.poolTokenBase).toUint96();
         }
 
         slippageOK = (mintAmount >= join.mintMinAmount);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
@@ -27,7 +27,7 @@ library AmmPoolToken
         view
         returns (uint)
     {
-        return S.totalSupply.sub(S.poolSupplyToBurn);
+        return S.totalSupply.sub(S.poolBalanceL2);
     }
 
     function approve(

--- a/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
@@ -20,14 +20,14 @@ library AmmPoolToken
 
     bytes32 public constant PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    function effectiveTotalSupply(
+    function totalSupply(
         AmmData.State storage S
         )
         internal
         view
         returns (uint)
     {
-        return S.totalSupply.sub(S.poolBalanceL2);
+        return S.totalMintedSupply.sub(S.poolBalanceL2);
     }
 
     function approve(
@@ -108,7 +108,7 @@ library AmmPoolToken
         )
         internal
     {
-        S.totalSupply = S.totalSupply.add(value);
+        S.totalMintedSupply = S.totalMintedSupply.add(value);
         S.balanceOf[to] = S.balanceOf[to].add(value);
         emit Transfer(address(0), to, value);
     }
@@ -121,7 +121,7 @@ library AmmPoolToken
         internal
     {
         S.balanceOf[from] = S.balanceOf[from].sub(value);
-        S.totalSupply = S.totalSupply.sub(value);
+        S.totalMintedSupply = S.totalMintedSupply.sub(value);
         emit Transfer(from, address(0), value);
     }
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -66,6 +66,19 @@ library AmmStatus
                 weight: config.weights[i]
             }));
         }
+
+        S.poolTokenID = exchange.getTokenID(address(this));
+
+        // Mint all liquidity tokens to the pool account on L2
+        S.poolBalanceL2 = uint96(-1);
+        S.mint(address(this), S.poolBalanceL2);
+        exchange.deposit{value: 0}(
+            address(this), // from
+            address(this), // to
+            address(this), // token
+            uint96(S.poolBalanceL2),
+            new bytes(0)
+        );
     }
 
     // Anyone is able to shut down the pool when requests aren't being processed any more.
@@ -77,11 +90,6 @@ library AmmStatus
     {
         uint64 validUntil = S.forcedExit[exitHash].validUntil;
         require(validUntil > 0 && validUntil < block.timestamp, "INVALID_CHALLANGE");
-
-        if (S.poolSupplyToBurn > 0) {
-            S.burn(address(this), S.poolSupplyToBurn);
-            S.poolSupplyToBurn = 0;
-        }
 
         uint size = S.tokens.length;
         if (!S.exchange.isInWithdrawalMode()) {

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUpdateProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUpdateProcess.sol
@@ -36,9 +36,9 @@ library AmmUpdateProcess
             ctx.exchange.approveTransaction(address(this), txHash);
 
             if (opening) {
-                ctx.layer2Balances[i] = update.balance;
+                ctx.balancesL2[i] = update.balance;
             } else {
-                require(ctx.layer2Balances[i] == update.balance, "UNEXPECTED_AMM_BALANCE");
+                require(ctx.balancesL2[i] == update.balance, "UNEXPECTED_AMM_BALANCE");
             }
         }
     }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
@@ -5,6 +5,8 @@ pragma experimental ABIEncoderV2;
 
 import "../../lib/AddressUtil.sol";
 import "../../lib/ERC20SafeTransfer.sol";
+import "../../lib/MathUint.sol";
+import "./AmmData.sol";
 
 
 /// @title AmmUtil
@@ -12,6 +14,17 @@ library AmmUtil
 {
     using AddressUtil       for address;
     using ERC20SafeTransfer for address;
+    using MathUint          for uint;
+
+    function effectiveTotalSupply(
+        AmmData.Context  memory  ctx
+        )
+        internal
+        pure
+        returns (uint)
+    {
+        return ctx.totalSupply.sub(ctx.poolBalanceL2);
+    }
 
     function isAlmostEqual(
         uint96 amount,

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
@@ -23,7 +23,7 @@ library AmmUtil
         pure
         returns (uint)
     {
-        return ctx.totalSupply.sub(ctx.poolBalanceL2);
+        return ctx.totalMintedSupply.sub(ctx.poolBalanceL2);
     }
 
     function isAlmostEqual(

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawal.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawal.sol
@@ -57,7 +57,7 @@ library AmmWithdrawal
                 ERC20(token).balanceOf(address(this));
 
             // Withdraw the part owned by the pool
-            uint amount = balance.mul(burnAmount) / S.effectiveTotalSupply();
+            uint amount = balance.mul(burnAmount) / S.totalSupply();
             AmmUtil.transferOut(token, amount, msg.sender);
         }
 


### PR DESCRIPTION
Changes how minting/burning works in #1816. This mints all liquidity tokens that will ever exist to the pool account on L2 so we can mint/burn doing simple transfers on L2. Liquidity tokens can still be burned onchain like usual where we need to.

 I think this makes things cheaper/easier because the only thing we now use are transfers, deposits/withdrawals are never needed any more. 