### PR TITLE
use abi.encode instead o abi.encodePacked.

### DIFF
--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitRequest.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitRequest.sol
@@ -70,7 +70,7 @@ library AmmExitRequest
                     exit.owner,
                     exit.burnAmount,
                     exit.burnStorageID,
-                    keccak256(abi.encodePacked(exit.exitMinAmounts)),
+                    keccak256(abi.encode(exit.exitMinAmounts)),
                     exit.validUntil
                 )
             )

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinRequest.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinRequest.sol
@@ -28,9 +28,9 @@ library AmmJoinRequest
                 abi.encode(
                     POOLJOIN_TYPEHASH,
                     join.owner,
-                    keccak256(abi.encodePacked(join.joinAmounts)),
-                    keccak256(abi.encodePacked(join.joinFees)),
-                    keccak256(abi.encodePacked(join.joinStorageIDs)),
+                    keccak256(abi.encode(join.joinAmounts)),
+                    keccak256(abi.encode(join.joinFees)),
+                    keccak256(abi.encode(join.joinStorageIDs)),
                     join.mintMinAmount,
                     join.validUntil
                 )


### PR DESCRIPTION
Refer to https://github.com/ethereum/EIPs/blob/master/EIPS/eip-712.md

> The array values are encoded as the keccak256 hash of the concatenated encodeData of their contents (i.e. the encoding of SomeType[5] is identical to that of a struct containing five members of type SomeType).

I think the spec may not force us using abi.encode, and encodePacked can be another proposal, but so far gateway and 3rd-party python lib(for MM) can easily support the type-encoded data array rather then encodePacked. So switch back to abi.encode just like Hebao does for address[] can save some many dev efforts.

Signed-off-by: yue.wang <yue.wang@loopring>