### PR TITLE
[protocol 3.6] Support max fee in all authorization methods

### DIFF
--- a/packages/loopring_v3/DESIGN.md
+++ b/packages/loopring_v3/DESIGN.md
@@ -374,7 +374,7 @@ A transfer can also be approved using an on-chain signature or by approving the 
 
 ```
 bytes32 constant public TRANSFER_TYPEHASH = keccak256(
-    "Transfer(address from,address to,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,uint32 validUntil,uint32 storageID)"
+    "Transfer(address from,address to,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 maxFee,uint32 validUntil,uint32 storageID)"
 );
 ```
 
@@ -469,7 +469,7 @@ A withdrawal can also be approved using an on-chain signature or by approving th
 
 ```
 bytes32 constant public WITHDRAWAL_TYPEHASH = keccak256(
-  "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes extraData,uint minGas,uint32 validUntil,uint32 nonce)"
+  "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 maxFee,address to,bytes extraData,uint minGas,uint32 validUntil,uint32 nonce)"
 );
 ```
 
@@ -519,7 +519,7 @@ An account update can also be approved using an on-chain signature or by approvi
 
 ```
 bytes32 constant public ACCOUNTUPDATE_TYPEHASH = keccak256(
-    "AccountUpdate(address owner,uint32 accountID,uint16 feeTokenID,uint256 fee,uint256 publicKey,uint32 validUntil,uint32 nonce)"
+    "AccountUpdate(address owner,uint32 accountID,uint16 feeTokenID,uint256 maxFee,uint256 publicKey,uint32 validUntil,uint32 nonce)"
 );
 ```
 

--- a/packages/loopring_v3/DESIGN.md
+++ b/packages/loopring_v3/DESIGN.md
@@ -370,7 +370,7 @@ It is also possible to sign a transfer to an unspecified `to` address. This is d
 
 Transfers (like orders) use the storage tree instead of the account nonce for replay protection. This allows for more flexibility by e.g., allowing transfers to be executed out-of-order. We do this by requiring the storage slot data to be 0 for the transfer, and after the transaction is executed, the storage slot is set to 1, so the transfer cannot be executed a second time.
 
-A transfer can also be approved using an on-chain signature or by approving the hash of the transaction using `approveTransaction` or the helper function `approveOffchainTransfer`.
+A transfer can also be approved using an on-chain signature or by approving the hash of the transaction using `approveTransaction`.
 
 ```
 bytes32 constant public TRANSFER_TYPEHASH = keccak256(

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
@@ -24,6 +24,7 @@ library AmmUtil
         internal
     {
         transfer.validUntil = 0xffffffff;
+        transfer.maxFee = transfer.fee;
         bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
         ctx.exchange.approveTransaction(transfer.from, hash);
     }

--- a/packages/loopring_v3/contracts/aux/agents/OpenGSN2Agent.sol
+++ b/packages/loopring_v3/contracts/aux/agents/OpenGSN2Agent.sol
@@ -82,21 +82,6 @@ contract OpenGSN2Agent is BaseRelayRecipient, IKnowForwarderAddress
         forwardCall();
     }
 
-    function approveOffchainTransfer(
-        address from,
-        address /* to */,
-        address /* token */,
-        uint96  /* amount */,
-        address /* feeToken */,
-        uint96  /* fee */,
-        uint32  /* nonce */
-        )
-        external
-        onlyFrom(from)
-    {
-        forwardCall();
-    }
-
     function onchainTransferFrom(
         address from,
         address /* to */,

--- a/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/iface/IExchangeV3.sol
@@ -551,32 +551,6 @@ abstract contract IExchangeV3 is IExchange
         external
         virtual;
 
-    /// @dev Approves an offchain transfer. Helper function around `approveTransaction`.
-    ///      Important! This is just an approval, the owner has full control
-    ///      whether the transfer will actally be done!
-    ///
-    ///      This function can only be called by an agent.
-    ///
-    /// @param from The address of the account that sends the tokens.
-    /// @param to The address to which 'amount' tokens are transferred.
-    /// @param token The address of the token to transfer ('0x0' for ETH).
-    /// @param amount The amount of tokens to be transferred.
-    /// @param feeToken The address of the token used for the fee ('0x0' for ETH).
-    /// @param fee The fee for the transfer.
-    /// @param storageID The storageID.
-    function approveOffchainTransfer(
-        address from,
-        address to,
-        address token,
-        uint96  amount,
-        address feeToken,
-        uint96  fee,
-        uint32  validUntil,
-        uint32  storageID
-        )
-        external
-        virtual;
-
     /// @dev Allows a withdrawal to be done to an adddresss that is different
     ///      than initialy specified in the withdrawal request. This can be used to
     ///      implement functionality like fast withdrawals.

--- a/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
+++ b/packages/loopring_v3/contracts/core/impl/ExchangeV3.sol
@@ -517,40 +517,6 @@ contract ExchangeV3 is IExchangeV3
         emit WithdrawalModeActivated(state.withdrawalModeStartTime);
     }
 
-    function approveOffchainTransfer(
-        address from,
-        address to,
-        address token,
-        uint96  amount,
-        address feeToken,
-        uint96  fee,
-        uint32  validUntil,
-        uint32  storageID
-        )
-        external
-        override
-        nonReentrant
-        onlyFromUserOrAgent(from)
-    {
-        uint16 tokenID = state.getTokenID(token);
-        uint16 feeTokenID = state.getTokenID(feeToken);
-        TransferTransaction.Transfer memory transfer = TransferTransaction.Transfer({
-            from: from,
-            to: to,
-            tokenID: tokenID,
-            amount: amount,
-            feeTokenID: feeTokenID,
-            fee: fee,
-            validUntil: validUntil,
-            storageID: storageID,
-            fromAccountID: 0,       // Not used in hash
-            toAccountID: 0          // Not used in hash
-        });
-        bytes32 txHash = TransferTransaction.hashTx(state.DOMAIN_SEPARATOR, transfer);
-        state.approvedTx[transfer.from][txHash] = true;
-        emit TransactionApproved(transfer.from, txHash);
-    }
-
     function setWithdrawalRecipient(
         address from,
         address to,

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/TransferTransaction.sol
@@ -21,7 +21,7 @@ library TransferTransaction
     using ExchangeSignatures   for ExchangeData.State;
 
     bytes32 constant public TRANSFER_TYPEHASH = keccak256(
-        "Transfer(address from,address to,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,uint32 validUntil,uint32 storageID)"
+        "Transfer(address from,address to,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 maxFee,uint32 validUntil,uint32 storageID)"
     );
 
     struct Transfer
@@ -33,6 +33,7 @@ library TransferTransaction
         uint16  tokenID;
         uint96  amount;
         uint16  feeTokenID;
+        uint96  maxFee;
         uint96  fee;
         uint32  validUntil;
         uint32  storageID;
@@ -42,6 +43,7 @@ library TransferTransaction
     struct TransferAuxiliaryData
     {
         bytes  signature;
+        uint96 maxFee;
         uint32 validUntil;
     }
 
@@ -65,9 +67,12 @@ library TransferTransaction
         Transfer memory transfer = readTx(data, offset);
         TransferAuxiliaryData memory auxData = abi.decode(auxiliaryData, (TransferAuxiliaryData));
 
-        // Check validUntil
-        require(ctx.timestamp < auxData.validUntil, "TRANSFER_EXPIRED");
+        // Fill in withdrawal data missing from DA
         transfer.validUntil = auxData.validUntil;
+        transfer.maxFee = auxData.maxFee;
+        // Validate
+        require(ctx.timestamp < transfer.validUntil, "TRANSFER_EXPIRED");
+        require(transfer.fee <= transfer.maxFee, "TRANSFER_FEE_TOO_HIGH");
 
         // Calculate the tx hash
         bytes32 txHash = hashTx(ctx.DOMAIN_SEPARATOR, transfer);
@@ -132,7 +137,7 @@ library TransferTransaction
                     transfer.tokenID,
                     transfer.amount,
                     transfer.feeTokenID,
-                    transfer.fee,
+                    transfer.maxFee,
                     transfer.validUntil,
                     transfer.storageID
                 )

--- a/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/WithdrawTransaction.sol
@@ -33,7 +33,7 @@ library WithdrawTransaction
     using ExchangeWithdrawals  for ExchangeData.State;
 
     bytes32 constant public WITHDRAWAL_TYPEHASH = keccak256(
-        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 fee,address to,bytes extraData,uint256 minGas,uint32 validUntil,uint32 storageID)"
+        "Withdrawal(address owner,uint32 accountID,uint16 tokenID,uint256 amount,uint16 feeTokenID,uint256 maxFee,address to,bytes extraData,uint256 minGas,uint32 validUntil,uint32 storageID)"
     );
 
     struct Withdrawal
@@ -44,6 +44,7 @@ library WithdrawTransaction
         uint16  tokenID;
         uint96  amount;
         uint16  feeTokenID;
+        uint96  maxFee;
         uint96  fee;
         address to;
         bytes   extraData;
@@ -63,6 +64,7 @@ library WithdrawTransaction
         uint    minGas;
         address to;
         bytes   extraData;
+        uint96  maxFee;
         uint32  validUntil;
     }
 
@@ -98,13 +100,16 @@ library WithdrawTransaction
         withdrawal.to = auxData.to;
         withdrawal.minGas = auxData.minGas;
         withdrawal.extraData = auxData.extraData;
+        withdrawal.maxFee = auxData.maxFee;
         withdrawal.validUntil = auxData.validUntil;
 
         if (withdrawal.withdrawalType == 0) {
             // Signature checked offchain, nothing to do
         } else if (withdrawal.withdrawalType == 1) {
-            // Check validUntil
+            // Validate
             require(ctx.timestamp < withdrawal.validUntil, "WITHDRAWAL_EXPIRED");
+            require(withdrawal.fee <= withdrawal.maxFee, "WITHDRAWAL_FEE_TOO_HIGH");
+
             // Check appproval onchain
             // Calculate the tx hash
             bytes32 txHash = hashTx(ctx.DOMAIN_SEPARATOR, withdrawal);
@@ -238,7 +243,7 @@ library WithdrawTransaction
                     withdrawal.tokenID,
                     withdrawal.amount,
                     withdrawal.feeTokenID,
-                    withdrawal.fee,
+                    withdrawal.maxFee,
                     withdrawal.to,
                     keccak256(withdrawal.extraData),
                     withdrawal.minGas,

--- a/packages/loopring_v3/test/testExchangeAgents.ts
+++ b/packages/loopring_v3/test/testExchangeAgents.ts
@@ -188,23 +188,6 @@ contract("Exchange", (accounts: string[]) => {
       );
 
       await expectThrow(
-        exchange.approveOffchainTransfer(
-          ownerA,
-          ownerB,
-          token,
-          new BN(0),
-          token,
-          new BN(0),
-          0xffffffff,
-          new BN(1),
-          {
-            from: agent
-          }
-        ),
-        "UNAUTHORIZED"
-      );
-
-      await expectThrow(
         exchange.setWithdrawalRecipient(
           ownerA,
           ownerB,
@@ -238,20 +221,6 @@ contract("Exchange", (accounts: string[]) => {
       await exchange.approveTransaction(ownerA, Buffer.from("FF"), {
         from: agent
       });
-
-      await exchange.approveOffchainTransfer(
-        ownerA,
-        ownerB,
-        token,
-        new BN(0),
-        token,
-        new BN(0),
-        0xfffffff,
-        new BN(1),
-        {
-          from: agent
-        }
-      );
 
       await exchange.setWithdrawalRecipient(
         ownerA,

--- a/packages/loopring_v3/test/testExchangeDepositWithdraw.ts
+++ b/packages/loopring_v3/test/testExchangeDepositWithdraw.ts
@@ -381,7 +381,10 @@ contract("Exchange", (accounts: string[]) => {
           deposit.amount,
           feeToken,
           feeDeposits[i].amount,
-          { authMethod: authMethods[i] }
+          {
+            authMethod: authMethods[i],
+            maxFee: feeDeposits[i].amount.mul(new BN(2))
+          }
         );
       }
 
@@ -763,27 +766,41 @@ contract("Exchange", (accounts: string[]) => {
       await submitWithdrawalBlockChecked([expectedResult]);
     });
 
-    it("Withdrawal (fee > maxFee)", async () => {
-      await createExchange();
+    [AuthMethod.EDDSA, AuthMethod.ECDSA].forEach(function(authMethod) {
+      it("Withdrawal (fee > maxFee) (" + authMethod + ")", async () => {
+        await createExchange();
 
-      const owner = exchangeTestUtil.testContext.orderOwners[0];
-      const balance = new BN(web3.utils.toWei("4", "ether"));
-      const toWithdraw = new BN(web3.utils.toWei("2", "ether"));
-      const token = "ETH";
-      const feeToken = "ETH";
-      const fee = new BN(web3.utils.toWei("1.5", "ether"));
+        const owner = exchangeTestUtil.testContext.orderOwners[0];
+        const balance = new BN(web3.utils.toWei("4", "ether"));
+        const toWithdraw = new BN(web3.utils.toWei("2", "ether"));
+        const token = "ETH";
+        const feeToken = "ETH";
+        const fee = new BN(web3.utils.toWei("1.5", "ether"));
 
-      await exchangeTestUtil.deposit(owner, owner, token, balance);
-      await exchangeTestUtil.requestWithdrawal(
-        owner,
-        token,
-        toWithdraw,
-        feeToken,
-        fee,
-        { maxFee: fee.div(new BN(3)) }
-      );
+        await exchangeTestUtil.deposit(owner, owner, token, balance);
+        await exchangeTestUtil.requestWithdrawal(
+          owner,
+          token,
+          toWithdraw,
+          feeToken,
+          fee,
+          { maxFee: fee.div(new BN(3)), authMethod }
+        );
 
-      await expectThrow(exchangeTestUtil.submitTransactions(), "invalid block");
+        // Commit the transfers
+        if (authMethod === AuthMethod.EDDSA) {
+          await expectThrow(
+            exchangeTestUtil.submitTransactions(),
+            "invalid block"
+          );
+        } else {
+          await exchangeTestUtil.submitTransactions();
+          await expectThrow(
+            exchangeTestUtil.submitPendingBlocks(),
+            "WITHDRAWAL_FEE_TOO_HIGH"
+          );
+        }
+      });
     });
 
     it("Withdraw (protocol fees)", async () => {

--- a/packages/loopring_v3/test/types.ts
+++ b/packages/loopring_v3/test/types.ts
@@ -97,6 +97,7 @@ export interface AccountUpdate {
   feeTokenID: number;
   fee: BN;
   maxFee: BN;
+  originalMaxFee?: BN;
 
   signature?: Signature;
   onchainSignature?: any;
@@ -117,6 +118,7 @@ export class Transfer {
   feeTokenID: number;
   fee: BN;
   maxFee: BN;
+  originalMaxFee?: BN;
 
   from: string;
   to: string;
@@ -156,6 +158,7 @@ export interface WithdrawalRequest {
   feeTokenID?: number;
   fee?: BN;
   maxFee: BN;
+  originalMaxFee?: BN;
 
   storeRecipient: boolean;
 


### PR DESCRIPTION
#1847 

Also removed `approveOffchainTransfer` because we're not even using this ourselves, and easy to use libraries for this are now available.