### PR TITLE
[hebao] Deploy optimizations

### DIFF
--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -80,8 +80,9 @@ contract WalletFactory is MetaTxAware
         external
         txAwareHashNotAllowed()
     {
+        address _walletImplementation = walletImplementation;
         for (uint i = 0; i < salts.length; i++) {
-            createBlank_(walletImplementation, modules, salts[i]);
+            createBlank_(_walletImplementation, modules, salts[i]);
         }
     }
 

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -80,9 +80,8 @@ contract WalletFactory is MetaTxAware
         external
         txAwareHashNotAllowed()
     {
-        address _walletImplementation = walletImplementation;
         for (uint i = 0; i < salts.length; i++) {
-            createBlank_(_walletImplementation, modules, salts[i]);
+            createBlank_(walletImplementation, modules, salts[i]);
         }
     }
 
@@ -205,7 +204,7 @@ contract WalletFactory is MetaTxAware
         return computeAddress_(address(0), salt);
     }
 
-    function getProxyCreationCode()
+    function getWalletCreationCode()
         public
         view
         returns (bytes memory)

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -7,12 +7,12 @@ import "../../base/BaseWallet.sol";
 import "../../iface/Module.sol";
 import "../../iface/Wallet.sol";
 import "../../lib/OwnerManagable.sol";
-import "../../lib/SimpleProxy.sol";
 import "../../lib/AddressUtil.sol";
 import "../../lib/EIP712.sol";
 import "../../thirdparty/Create2.sol";
 import "../../thirdparty/ens/BaseENSManager.sol";
 import "../../thirdparty/ens/ENS.sol";
+import "../../thirdparty/proxy/CloneFactory.sol";
 import "../base/MetaTxAware.sol";
 import "../ControllerImpl.sol";
 
@@ -80,8 +80,9 @@ contract WalletFactory is MetaTxAware
         external
         txAwareHashNotAllowed()
     {
+        address _walletImplementation = walletImplementation;
         for (uint i = 0; i < salts.length; i++) {
-            createBlank_(modules, salts[i]);
+            createBlank_(_walletImplementation, modules, salts[i]);
         }
     }
 
@@ -204,12 +205,12 @@ contract WalletFactory is MetaTxAware
         return computeAddress_(address(0), salt);
     }
 
-    function getSimpleProxyCreationCode()
+    function getProxyCreationCode()
         public
-        pure
+        view
         returns (bytes memory)
     {
-        return type(SimpleProxy).creationCode;
+        return CloneFactory.getByteCode(walletImplementation);
     }
 
     // ---- internal functions ---
@@ -229,13 +230,14 @@ contract WalletFactory is MetaTxAware
     }
 
     function createBlank_(
+        address   _walletImplementation,
         address[] calldata modules,
         uint      salt
         )
         internal
         returns (address blank)
     {
-        blank = deploy_(modules, address(0), salt);
+        blank = deploy_(_walletImplementation, modules, address(0), salt);
         bytes32 version = keccak256(abi.encode(modules));
         blanks[blank] = version;
 
@@ -250,10 +252,11 @@ contract WalletFactory is MetaTxAware
         internal
         returns (address wallet)
     {
-        return deploy_(modules, owner, salt);
+        return deploy_(walletImplementation, modules, owner, salt);
     }
 
     function deploy_(
+        address            _walletImplementation,
         address[] calldata modules,
         address            owner,
         uint               salt
@@ -263,17 +266,10 @@ contract WalletFactory is MetaTxAware
     {
         wallet = Create2.deploy(
             keccak256(abi.encodePacked(WALLET_CREATION, owner, salt)),
-            type(SimpleProxy).creationCode
+            CloneFactory.getByteCode(_walletImplementation)
         );
 
-        SimpleProxy proxy = SimpleProxy(wallet);
-        proxy.setImplementation(walletImplementation);
-
-        BaseWallet w = BaseWallet(wallet);
-        w.initController(controller);
-        for (uint i = 0; i < modules.length; i++) {
-            w.addModule(modules[i]);
-        }
+        BaseWallet(wallet).init(controller, modules);
     }
 
     function validateRequest_(
@@ -341,7 +337,7 @@ contract WalletFactory is MetaTxAware
     {
         return Create2.computeAddress(
             keccak256(abi.encodePacked(WALLET_CREATION, owner, salt)),
-            type(SimpleProxy).creationCode
+            CloneFactory.getByteCode(walletImplementation)
         );
     }
 

--- a/packages/hebao_v1/contracts/thirdparty/proxy/CloneFactory.sol
+++ b/packages/hebao_v1/contracts/thirdparty/proxy/CloneFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// This code is taken from https://eips.ethereum.org/EIPS/eip-1167
+// Modified to a library and generalized to support create/create2.
+pragma solidity ^0.7.0;
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2018 Murray Software, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//solhint-disable max-line-length
+//solhint-disable no-inline-assembly
+
+library CloneFactory {
+  function getByteCode(address target) internal pure returns (bytes memory byteCode) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      byteCode := mload(0x40)
+      mstore(byteCode, 0x37)
+
+      let clone := add(byteCode, 0x20)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+
+      mstore(0x40, add(byteCode, 0x60))
+    }
+  }
+}

--- a/packages/hebao_v1/test/testWalletCreation.ts
+++ b/packages/hebao_v1/test/testWalletCreation.ts
@@ -429,10 +429,15 @@ contract("WalletFactory", () => {
         .keccak(web3.eth.abi.encodeParameters(["address[]"], [modules]))
         .toString("hex");
 
-    await ctx.walletFactory.createBlanks(
+    const tx = await ctx.walletFactory.createBlanks(
       modules,
       [...Array(10).keys()], // [0, ..., 9]
       { from: sender }
+    );
+
+    console.log(
+      "\x1b[46m%s\x1b[0m",
+      "[executeMetaTx] Gas used: " + tx.receipt.gasUsed
     );
 
     await assertEventsEmitted(


### PR DESCRIPTION
- Uses the optimized proxy code from https://eips.ethereum.org/EIPS/eip-1167. Like SimpleProxy it doesn't allow the wallet to be upgraded. Etherscan should also detect this as a proxy contract and should show the proxy interface, though I did not test this.
- Wallet `init` function now also can set modules directly instead of needing multiple calls on the wallet

When running the "anyone should be able to create a group of blank wallets" test which creates 10 wallets, with the 3 common modules initialized, the deployment cost is reduced from 3,649,674 gas to 2,103,030 gas, a 42% reduction. 35% of that 42% reduction is because of the much smaller deployment cost of the proxy contract.

This also reduces the cost of using the wallet because the implementation address is baked into the proxy code, instead of having to SLOAD the implementation address each time for each call. Because of that, transfers are now also 3,000 to 4,000 gas cheaper (~3%).