### PR TITLE
[protocol 3.6] Better optimizer settings

### DIFF
--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -36,7 +36,7 @@ library AmmStatus
         AmmData.State      storage  S,
         AmmData.PoolConfig calldata config
         )
-        internal
+        public
     {
         require(
             bytes(config.poolName).length > 0 && bytes(config.tokenSymbol).length > 0,
@@ -90,7 +90,7 @@ library AmmStatus
         AmmData.State storage S,
         address               exitOwner
         )
-        internal
+        public
     {
         // If the exchange is in withdrawal mode allow the pool to be shutdown immediately
         if (!S.exchange.isInWithdrawalMode()) {
@@ -113,7 +113,7 @@ library AmmStatus
 
     // Anyone is able to update the cached exchange owner to the current owner.
     function updateExchangeOwner(AmmData.State storage S)
-        internal
+        public
     {
         S.exchangeOwner = S.exchange.owner();
     }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawal.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawal.sol
@@ -21,7 +21,7 @@ library AmmWithdrawal
     function withdrawWhenOffline(
         AmmData.State storage S
         )
-        internal
+        public
     {
         _checkWithdrawalConditionInShutdown(S);
 

--- a/packages/loopring_v3/migrations/7_deploy_amm.js
+++ b/packages/loopring_v3/migrations/7_deploy_amm.js
@@ -5,18 +5,26 @@ const LoopringAmmPoolCopy = artifacts.require("LoopringAmmPoolCopy");
 const LoopringAmmSharedConfig = artifacts.require("LoopringAmmSharedConfig");
 const AmmJoinRequest = artifacts.require("AmmJoinRequest");
 const AmmExitRequest = artifacts.require("AmmExitRequest");
+const AmmStatus = artifacts.require("AmmStatus");
+const AmmWithdrawal = artifacts.require("AmmWithdrawal");
 
 module.exports = function(deployer, network, accounts) {
   if (network != "live" && network != "live-fork") {
     deployer.then(async () => {
       await deployer.deploy(AmmJoinRequest);
       await deployer.deploy(AmmExitRequest);
+      await deployer.deploy(AmmStatus);
+      await deployer.deploy(AmmWithdrawal);
       await deployer.link(AmmJoinRequest, LoopringAmmPool);
       await deployer.link(AmmExitRequest, LoopringAmmPool);
+      await deployer.link(AmmStatus, LoopringAmmPool);
+      await deployer.link(AmmWithdrawal, LoopringAmmPool);
       await deployer.deploy(LoopringAmmPool);
 
       await deployer.link(AmmJoinRequest, LoopringAmmPoolCopy);
       await deployer.link(AmmExitRequest, LoopringAmmPoolCopy);
+      await deployer.link(AmmStatus, LoopringAmmPoolCopy);
+      await deployer.link(AmmWithdrawal, LoopringAmmPoolCopy);
       await deployer.deploy(LoopringAmmPoolCopy);
       await deployer.deploy(LoopringAmmSharedConfig);
 

--- a/packages/loopring_v3/truffle.js
+++ b/packages/loopring_v3/truffle.js
@@ -47,7 +47,7 @@ module.exports = {
       settings: {
         optimizer: {
           enabled: true,
-          runs: 200
+          runs: 1000000
         }
       },
       version: "0.7.0"


### PR DESCRIPTION
Just increases the `runs` parameter of the optimizer so it optimizes more for runtime efficiency than contract size. Saves ~1% gas on the operations I checked (deposits, AMM joins).

@kongliangzhong Is there a reason there is a `LoopringAmmPoolCopy`? Not possible to just call `LoopringAmmPool.new()` to create another copy?