### PR TITLE
prevent transacting on Modules directly from wallets

### DIFF
--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -59,7 +59,7 @@ abstract contract BaseModule is Module
 
     modifier notDirectlyFromWallet(address wallet)
     {
-        require(msg.sender != wallet, "TRANSACTION_FROM_WALLET_DISALLOWED");
+        require(msg.sender != wallet, "WALLET_TO_MODULE_TX_DISALLOWED");
         _;
     }
 

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -57,6 +57,12 @@ abstract contract BaseModule is Module
         _;
     }
 
+    modifier notDirectlyFromWallet(address wallet)
+    {
+        require(msg.sender != wallet, "TRANSACTION_FROM_WALLET_DISALLOWED");
+        _;
+    }
+
     modifier notWalletOwner(address wallet, address addr)
         virtual
     {

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -122,6 +122,7 @@ abstract contract ForwarderModule is BaseModule
         bytes   calldata signature
         )
         external
+        notDirectlyFromWallet(from)
         returns (
             bool         success
         )

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -50,6 +50,7 @@ abstract contract GuardianModule is SecurityModule
         uint    group
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         notWalletOwner(wallet, guardian)
@@ -73,6 +74,7 @@ abstract contract GuardianModule is SecurityModule
         address guardian
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
@@ -85,6 +87,7 @@ abstract contract GuardianModule is SecurityModule
         address guardian
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         onlyWalletGuardian(wallet, guardian)
@@ -98,6 +101,7 @@ abstract contract GuardianModule is SecurityModule
         address guardian
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
@@ -107,6 +111,7 @@ abstract contract GuardianModule is SecurityModule
 
     function lock(address wallet)
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
         onlyHaveEnoughGuardians(wallet)
@@ -116,6 +121,7 @@ abstract contract GuardianModule is SecurityModule
 
     function unlock(address wallet)
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
     {

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -47,6 +47,7 @@ abstract contract InheritanceModule is SecurityModule
         address newOwner
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         eligibleWalletOwner(newOwner)
         notWalletOwner(wallet, newOwner)
@@ -71,6 +72,7 @@ abstract contract InheritanceModule is SecurityModule
         address _inheritor
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {

--- a/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
+++ b/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
@@ -34,7 +34,7 @@ library SignedRequest {
         )
         public
     {
-        require(msg.sender != request.wallet, "SENDER_CANNOT_BE_WALLET");
+        require(msg.sender != request.wallet, "WALLET_TO_MODULE_TX_DISALLOWED");
         require(block.timestamp <= request.validUntil, "EXPIRED_SIGNED_REQUEST");
 
         bytes32 _txAwareHash = EIP712.hashPacked(domainSeperator, encodedRequest);

--- a/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
+++ b/packages/hebao_v1/contracts/modules/security/SignedRequest.sol
@@ -34,6 +34,7 @@ library SignedRequest {
         )
         public
     {
+        require(msg.sender != request.wallet, "SENDER_CANNOT_BE_WALLET");
         require(block.timestamp <= request.validUntil, "EXPIRED_SIGNED_REQUEST");
 
         bytes32 _txAwareHash = EIP712.hashPacked(domainSeperator, encodedRequest);

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -38,10 +38,15 @@ abstract contract WhitelistModule is SecurityModule
         address addr
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        controllerCache.whitelistStore.addToWhitelist(wallet, addr, block.timestamp.add(whitelistDelayPeriod));
+        controllerCache.whitelistStore.addToWhitelist(
+            wallet,
+            addr,
+            block.timestamp.add(whitelistDelayPeriod)
+        );
     }
 
     function addToWhitelistImmediately(
@@ -72,6 +77,7 @@ abstract contract WhitelistModule is SecurityModule
         address addr
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -56,6 +56,7 @@ abstract contract TransferModule is BaseTransferModule
         uint    newQuota
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
@@ -101,6 +102,7 @@ abstract contract TransferModule is BaseTransferModule
         bytes calldata logdata
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
@@ -118,6 +120,7 @@ abstract contract TransferModule is BaseTransferModule
         bytes     calldata data
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
@@ -136,6 +139,7 @@ abstract contract TransferModule is BaseTransferModule
         uint    amount
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
@@ -155,6 +159,7 @@ abstract contract TransferModule is BaseTransferModule
         bytes calldata data
         )
         external
+        notDirectlyFromWallet(wallet)
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)

--- a/packages/hebao_v1/test/helpers/Artifacts.ts
+++ b/packages/hebao_v1/test/helpers/Artifacts.ts
@@ -28,7 +28,6 @@ export class Artifacts {
   public WhitelistStore: any;
   public QuotaStore: any;
   public PriceCacheStore: any;
-  public NonceStore: any;
 
   constructor(artifacts: any) {
     this.MockContract = artifacts.require("thirdparty/MockContract.sol");
@@ -64,6 +63,5 @@ export class Artifacts {
     this.SecurityStore = artifacts.require("SecurityStore");
     this.WhitelistStore = artifacts.require("WhitelistStore");
     this.QuotaStore = artifacts.require("QuotaStore");
-    this.NonceStore = artifacts.require("NonceStore");
   }
 }


### PR DESCRIPTION
I believe it is very important not to allow a wallet to transact directly on its modules.