### PR TITLE
[hebao 1.2] #2 lock permanently and unlock with approval

### DIFF
--- a/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
+++ b/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
@@ -47,8 +47,7 @@ abstract contract ERC1271Module is ERC1271, BaseModule
         returns (bytes4 magicValue)
     {
         address wallet = msg.sender;
-        (uint _lock,) = controllerCache.securityStore.getLock(wallet);
-        if (_lock > block.timestamp) { // wallet locked
+        if (controllerCache.securityStore.isLocked(wallet)) {
             return 0;
         }
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -26,7 +26,7 @@ abstract contract ForwarderModule is BaseModule
     uint    public constant MAX_REIMBURSTMENT_OVERHEAD = 165000;
     bytes32 public FORWARDER_DOMAIN_SEPARATOR;
 
-    bytes32 constant public META_TX_TYPEHASH = keccak256(
+    bytes32 public constant META_TX_TYPEHASH = keccak256(
         "MetaTx(address from,address to,uint256 nonce,bytes32 txAwareHash,address gasToken,uint256 gasPrice,uint256 gasLimit,bytes data)"
     );
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -104,8 +104,7 @@ abstract contract ForwarderModule is BaseModule
         // Instead of always taking the expensive path through ER1271,
         // skip directly to the wallet owner here (which could still be another contract).
         //require(metaTxHash.verifySignature(from, signature), "INVALID_SIGNATURE");
-        (uint _lock,) = controllerCache.securityStore.getLock(from);
-        require(_lock <= block.timestamp, "WALLET_LOCKED");
+        require(!controllerCache.securityStore.isLocked(from), "WALLET_LOCKED");
         require(metaTxHash.verifySignature(Wallet(from).owner(), signature), "INVALID_SIGNATURE");
     }
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -156,7 +156,7 @@ abstract contract ForwarderModule is BaseModule
             metaTx.to,
             metaTx.nonce,
             metaTx.txAwareHash,
-            metaTx.gasToken,
+            met taTx.gasToken,
             metaTx.gasPrice,
             metaTx.gasLimit,
             data,

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -34,7 +34,7 @@ contract WalletFactory is MetaTxAware
     event BlankConsumed (address blank);
     event WalletCreated (address wallet, string ensLabel, address owner, bool blankUsed);
 
-    string constant public WALLET_CREATION = "WALLET_CREATION";
+    string public constant WALLET_CREATION = "WALLET_CREATION";
 
     bytes32 public constant CREATE_WALLET_TYPEHASH = keccak256(
         "createWallet(address owner,uint256 salt,address blankAddress,string ensLabel,bool ensRegisterReverse,address[] modules)"

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -156,7 +156,15 @@ abstract contract GuardianModule is SecurityModule
         _lockWallet(wallet, true);
     }
 
-    function unlock(
+    function unlock(address wallet)
+        external
+        txAwareHashNotAllowed()
+        onlyFromGuardian(wallet)
+    {
+        _lockWallet(wallet, false);
+    }
+
+    function unlockWA(
         SignedRequest.Request calldata request
         )
         external

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -18,7 +18,7 @@ abstract contract GuardianModule is SecurityModule
 
     bytes32 public GUARDIAN_DOMAIN_SEPERATOR;
 
-    uint constant public MAX_GUARDIANS = 20;
+    uint public constant MAX_GUARDIANS = 20;
     uint public constant GUARDIAN_PENDING_PERIOD = 3 days;
 
     bytes32 public constant ADD_GUARDIAN_TYPEHASH = keccak256(

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -152,7 +152,7 @@ abstract contract GuardianModule is SecurityModule
         onlyFromGuardian(wallet)
         onlyHaveEnoughGuardians(wallet)
     {
-        lockWallet(wallet);
+        lockWallet(wallet, true);
     }
 
     function unlock(address wallet)
@@ -160,7 +160,7 @@ abstract contract GuardianModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
     {
-        unlockWallet(wallet, false);
+        lockWallet(wallet, false);
     }
 
     /// @dev Recover a wallet by setting a new owner.
@@ -196,20 +196,10 @@ abstract contract GuardianModule is SecurityModule
         Wallet(request.wallet).setOwner(newOwner);
 
         // solium-disable-next-line
-        unlockWallet(request.wallet, true /*force*/);
+        lockWallet(request.wallet, false);
 
         emit Recovered(request.wallet, newOwner);
     }
-
-    function getLock(address wallet)
-        public
-        view
-        returns (uint _lock, address _lockedBy)
-    {
-        return getWalletLock(wallet);
-    }
-
-    // ---- internal functions ---
 
     function isLocked(address wallet)
         public
@@ -218,6 +208,8 @@ abstract contract GuardianModule is SecurityModule
     {
         return isWalletLocked(wallet);
     }
+
+    // ---- internal functions ---
 
     function _addGuardian(
         address wallet,

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -147,19 +147,21 @@ abstract contract GuardianModule is SecurityModule
     function lock(address wallet)
         external
         txAwareHashNotAllowed()
-        onlyFromGuardian(wallet)
+        onlyFromWalletOrOwnerOrGuardianon(wallet)
     {
         _lockWallet(wallet, msg.sender, true);
     }
 
+    // TODO(daniel): remove this function
     function unlock(address wallet)
         external
         txAwareHashNotAllowed()
-        onlyFromGuardian(wallet)
+        onlyFromWalletOrOwnerOrGuardianon(wallet)
     {
         _lockWallet(wallet, msg.sender, false);
     }
 
+    // TODO(daniel): rename to unlock
     function unlockWA(
         SignedRequest.Request calldata request
         )

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -18,8 +18,8 @@ abstract contract GuardianModule is SecurityModule
 
     bytes32 public GUARDIAN_DOMAIN_SEPERATOR;
 
-    uint public constant MAX_GUARDIANS = 20;
-    uint public constant GUARDIAN_PENDING_PERIOD = 3 days;
+    uint public constant MAX_GUARDIANS           = 10;
+    uint public constant GUARDIAN_PENDING_PERIOD = 7 days;
 
     bytes32 public constant ADD_GUARDIAN_TYPEHASH = keccak256(
         "addGuardian(address wallet,uint256 validUntil,address guardian,uint256 group)"
@@ -149,7 +149,7 @@ abstract contract GuardianModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
     {
-        _lockWallet(wallet, true);
+        _lockWallet(wallet, msg.sender, true);
     }
 
     function unlock(address wallet)
@@ -157,7 +157,7 @@ abstract contract GuardianModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromGuardian(wallet)
     {
-        _lockWallet(wallet, false);
+        _lockWallet(wallet, msg.sender, false);
     }
 
     function unlockWA(
@@ -173,7 +173,7 @@ abstract contract GuardianModule is SecurityModule
             abi.encode(UNLOCK_TYPEHASH)
         );
 
-        _lockWallet(request.wallet, false);
+        _lockWallet(request.wallet, address(this), false);
     }
 
     /// @dev Recover a wallet by setting a new owner.
@@ -206,7 +206,7 @@ abstract contract GuardianModule is SecurityModule
         }
 
         Wallet(request.wallet).setOwner(newOwner);
-        _lockWallet(request.wallet, false);
+        _lockWallet(request.wallet, address(this), false);
 
         emit Recovered(request.wallet, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -144,18 +144,6 @@ abstract contract GuardianModule is SecurityModule
         emit GuardianRemovalCancelled(wallet, guardian);
     }
 
-        modifier onlyFromWalletOrOwnerOrGuardianon(address wallet)
-    {
-        address payable _logicalSender = logicalSender();
-        require(
-            _logicalSender == wallet ||
-            _logicalSender == Wallet(wallet).owner() ||
-            controllerCache.securityStore.isGuardian(wallet, _logicalSender),
-            "NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN"
-        );
-        _;
-    }
-
     function lock(address wallet)
         external
         txAwareHashNotAllowed()

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -194,8 +194,6 @@ abstract contract GuardianModule is SecurityModule
         }
 
         Wallet(request.wallet).setOwner(newOwner);
-
-        // solium-disable-next-line
         lockWallet(request.wallet, false);
 
         emit Recovered(request.wallet, newOwner);

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -157,20 +157,10 @@ abstract contract GuardianModule is SecurityModule
         _lockWallet(wallet, true);
     }
 
-    function unlock(address wallet)
-        external
-        txAwareHashNotAllowed()
-        onlyFromGuardian(wallet)
-    {
-        _lockWallet(wallet, false);
-    }
-
-    // TODO(daniel): test this method after initial review
     function unlock(
         SignedRequest.Request calldata request
         )
         external
-        onlyHaveEnoughGuardians(request.wallet)
     {
         controller().verifyRequest(
             GUARDIAN_DOMAIN_SEPERATOR,

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -38,11 +38,7 @@ abstract contract GuardianModule is SecurityModule
     event GuardianAdditionCancelled (address indexed wallet, address guardian);
     event GuardianRemoved           (address indexed wallet, address guardian, uint removalEffectiveTime);
     event GuardianRemovalCancelled  (address indexed wallet, address guardian);
-
-    event Recovered(
-        address indexed wallet,
-        address         newOwner
-    );
+    event Recovered                 (address indexed wallet, address newOwner);
 
     constructor()
     {

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -10,7 +10,7 @@ import "../../iface/Wallet.sol";
 /// @author Brecht Devos - <brecht@loopring.org>
 library GuardianUtils
 {
-    uint constant public MAX_NUM_GROUPS = 16;
+    uint public constant MAX_NUM_GROUPS = 16;
 
     enum SigRequirement
     {

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -53,7 +53,7 @@ abstract contract InheritanceModule is SecurityModule
         controllerCache.securityStore.setInheritor(wallet, address(0));
         Wallet(wallet).setOwner(newOwner);
 
-        lockWallet(wallet, false);
+        _lockWallet(wallet, false);
 
         emit Inherited(wallet, _inheritor, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -53,8 +53,7 @@ abstract contract InheritanceModule is SecurityModule
         controllerCache.securityStore.setInheritor(wallet, address(0));
         Wallet(wallet).setOwner(newOwner);
 
-        // solium-disable-next-line
-        unlockWallet(wallet, true /*force*/);
+        lockWallet(wallet, false);
 
         emit Inherited(wallet, _inheritor, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -54,7 +54,6 @@ abstract contract InheritanceModule is SecurityModule
         Wallet(wallet).setOwner(newOwner);
 
         lockWallet(wallet, false);
-        // TODO(daniel): cancel all pending security operations.
 
         emit Inherited(wallet, _inheritor, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -53,7 +53,7 @@ abstract contract InheritanceModule is SecurityModule
         controllerCache.securityStore.setInheritor(wallet, address(0));
         Wallet(wallet).setOwner(newOwner);
 
-        _lockWallet(wallet, false);
+        _lockWallet(wallet, address(this), false);
 
         emit Inherited(wallet, _inheritor, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -54,6 +54,7 @@ abstract contract InheritanceModule is SecurityModule
         Wallet(wallet).setOwner(newOwner);
 
         lockWallet(wallet, false);
+        // TODO(daniel): cancel all pending security operations.
 
         emit Inherited(wallet, _inheritor, newOwner);
     }

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -45,18 +45,6 @@ abstract contract SecurityModule is MetaTxModule
         _;
     }
 
-    modifier onlyWhenWalletLocked(address wallet)
-    {
-        require(_isWalletLocked(wallet), "NOT_LOCKED");
-        _;
-    }
-
-    modifier onlyWhenWalletUnlocked(address wallet)
-    {
-        require(!_isWalletLocked(wallet), "LOCKED");
-        _;
-    }
-
     modifier onlyWalletGuardian(address wallet, address guardian)
     {
         require(controllerCache.securityStore.isGuardian(wallet, guardian), "NOT_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -19,7 +19,7 @@ abstract contract SecurityModule is MetaTxModule
     using SignedRequest for ControllerImpl;
 
     // The minimal number of guardians for recovery and locking.
-    uint constant public TOUCH_GRACE_PERIOD   = 30 days;
+    uint public constant TOUCH_GRACE_PERIOD   = 30 days;
 
     event WalletLock(
         address indexed wallet,

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -45,11 +45,14 @@ abstract contract SecurityModule is MetaTxModule
         _;
     }
 
-    modifier onlyFromGuardian(address wallet)
+    modifier onlyFromWalletOrOwnerOrGuardianon(address wallet)
     {
+        address payable _logicalSender = logicalSender();
         require(
-            controllerCache.securityStore.isGuardian(wallet, logicalSender()),
-            "NOT_FROM_GUARDIAN"
+            _logicalSender == wallet ||
+            _logicalSender == Wallet(wallet).owner() ||
+            controllerCache.securityStore.isGuardian(wallet, _logicalSender),
+            "NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN"
         );
         _;
     }

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -45,18 +45,6 @@ abstract contract SecurityModule is MetaTxModule
         _;
     }
 
-    modifier onlyFromWalletOrOwnerOrGuardianon(address wallet)
-    {
-        address payable _logicalSender = logicalSender();
-        require(
-            _logicalSender == wallet ||
-            _logicalSender == Wallet(wallet).owner() ||
-            controllerCache.securityStore.isGuardian(wallet, _logicalSender),
-            "NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN"
-        );
-        _;
-    }
-
     modifier onlyWhenWalletLocked(address wallet)
     {
         require(_isWalletLocked(wallet), "NOT_LOCKED");

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -22,6 +22,7 @@ abstract contract WhitelistModule is SecurityModule
     bytes32 public constant ADD_TO_WHITELIST_TYPEHASH = keccak256(
         "addToWhitelist(address wallet,uint256 validUntil,address addr)"
     );
+
     bytes32 public constant REMOVE_FROM_WHITELIST_TYPEHASH = keccak256(
         "removeFromWhitelist(address wallet,uint256 validUntil,address addr)"
     );
@@ -41,10 +42,13 @@ abstract contract WhitelistModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        controllerCache.whitelistStore.addToWhitelist(wallet, addr, block.timestamp.add(WHITELIST_PENDING_PERIOD));
+        controllerCache.whitelistStore.addToWhitelist(
+            wallet,
+            addr,
+            block.timestamp.add(WHITELIST_PENDING_PERIOD)
+        );
     }
 
-    // TODO(daniel): test this method after initial review
     function addToWhitelistWA(
         SignedRequest.Request calldata request,
         address addr
@@ -64,7 +68,11 @@ abstract contract WhitelistModule is SecurityModule
             )
         );
 
-        controllerCache.whitelistStore.addToWhitelist(request.wallet, addr, block.timestamp);
+        controllerCache.whitelistStore.addToWhitelist(
+            request.wallet,
+            addr,
+            block.timestamp
+        );
     }
 
     function removeFromWhitelist(
@@ -78,7 +86,6 @@ abstract contract WhitelistModule is SecurityModule
         controllerCache.whitelistStore.removeFromWhitelist(wallet, addr);
     }
 
-    // TODO(daniel): test this method after initial review
     function removeFromWhitelistWA(
         SignedRequest.Request calldata request,
         address addr

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -44,6 +44,7 @@ abstract contract WhitelistModule is SecurityModule
         controllerCache.whitelistStore.addToWhitelist(wallet, addr, block.timestamp.add(WHITELIST_PENDING_PERIOD));
     }
 
+    // TODO(daniel): test this method after initial review
     function addToWhitelistImmediately(
         SignedRequest.Request calldata request,
         address addr
@@ -67,6 +68,7 @@ abstract contract WhitelistModule is SecurityModule
         controllerCache.whitelistStore.addToWhitelist(request.wallet, addr, block.timestamp);
     }
 
+    // TODO(daniel): test this method after initial review
     function removeFromWhitelistImmediately(
         SignedRequest.Request calldata request,
         address addr

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -22,7 +22,6 @@ abstract contract WhitelistModule is SecurityModule
     bytes32 public constant ADD_TO_WHITELIST_TYPEHASH = keccak256(
         "addToWhitelist(address wallet,uint256 validUntil,address addr)"
     );
-
     bytes32 public constant REMOVE_FROM_WHITELIST_TYPEHASH = keccak256(
         "removeFromWhitelist(address wallet,uint256 validUntil,address addr)"
     );

--- a/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
@@ -14,25 +14,9 @@ abstract contract BaseTransferModule is SecurityModule
 {
     using MathUint      for uint;
 
-    event Transfered(
-        address wallet,
-        address token,
-        address to,
-        uint    amount,
-        bytes   logdata
-    );
-    event Approved(
-        address wallet,
-        address token,
-        address spender,
-        uint    amount
-    );
-    event ContractCalled(
-        address wallet,
-        address to,
-        uint    value,
-        bytes   data
-    );
+    event Transfered    (address wallet, address token, address to,      uint amount, bytes logdata);
+    event Approved      (address wallet, address token, address spender, uint amount);
+    event ContractCalled(address wallet, address to,    uint    value,   bytes data);
 
     function transferInternal(
         address wallet,

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -102,7 +102,7 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
         if (amount > 0 && !isTargetWhitelisted(wallet, to)) {
-            updateQuota(wallet, token, amount);
+            _updateQuota(wallet, token, amount);
         }
 
         transferInternal(wallet, token, to, amount, logdata);
@@ -120,7 +120,7 @@ abstract contract TransferModule is BaseTransferModule
         returns (bytes memory returnData)
     {
         if (value > 0 && !isTargetWhitelisted(wallet, to)) {
-            updateQuota(wallet, address(0), value);
+            _updateQuota(wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);
@@ -139,7 +139,7 @@ abstract contract TransferModule is BaseTransferModule
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
         if (additionalAllowance > 0 && !isTargetWhitelisted(wallet, to)) {
-            updateQuota(wallet, token, additionalAllowance);
+            _updateQuota(wallet, token, additionalAllowance);
         }
     }
 
@@ -159,8 +159,8 @@ abstract contract TransferModule is BaseTransferModule
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
         if ((additionalAllowance > 0 || value > 0) && !isTargetWhitelisted(wallet, to)) {
-            updateQuota(wallet, token, additionalAllowance);
-            updateQuota(wallet, address(0), value);
+            _updateQuota(wallet, token, additionalAllowance);
+            _updateQuota(wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -24,19 +24,15 @@ abstract contract TransferModule is BaseTransferModule
     bytes32 public constant CHANGE_DAILY_QUOTE_TYPEHASH = keccak256(
         "changeDailyQuota(address wallet,uint256 validUntil,uint256 newQuota)"
     );
-
     bytes32 public constant TRANSFER_TOKEN_TYPEHASH = keccak256(
         "transferToken(address wallet,uint256 validUntil,address token,address to,uint256 amount,bytes logdata)"
     );
-
     bytes32 public constant APPROVE_TOKEN_TYPEHASH = keccak256(
         "approveToken(address wallet,uint256 validUntil,address token,address to,uint256 amount)"
     );
-
     bytes32 public constant CALL_CONTRACT_TYPEHASH = keccak256(
         "callContract(address wallet,uint256 validUntil,address to,uint256 value,bytes data)"
     );
-
     bytes32 public constant APPROVE_THEN_CALL_CONTRACT_TYPEHASH = keccak256(
         "approveThenCallContract(address wallet,uint256 validUntil,address token,address to,uint256 amount,uint256 value,bytes data)"
     );

--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -92,7 +92,7 @@ contract UpgraderModule is BaseModule {
 
         (address inheritor,) = oldSecurityStore.inheritor(wallet);
         if (inheritor != address(0)) {
-            newSecurityStore.setInheritor(wallet, inheritor);
+            newSecurityStore.setInheritor(wallet, inheritor, 365 days);
         }
     }
 

--- a/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
@@ -16,7 +16,7 @@ contract ENSConsumer {
     using strings for *;
 
     // namehash('addr.reverse')
-    bytes32 constant public ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
+    bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
     // the address of the ENS registry
     address ensRegistry;

--- a/packages/hebao_v1/deployment/deployer-goerli.js
+++ b/packages/hebao_v1/deployment/deployer-goerli.js
@@ -136,7 +136,6 @@ async function deployController() {
   const { abi, bin } = getAbiAndBin(releaseDir, contractName);
 
   const moduleRegistryImplAddr = "";
-  const lockPeriod = "";
   const collectTo = "";
   const ensManager = "";
   const priceOracle = "";
@@ -145,7 +144,6 @@ async function deployController() {
     abi,
     bin,
     moduleRegistryImplAddr,
-    lockPeriod,
     collectTo,
     ensManager,
     priceOracle,

--- a/packages/hebao_v1/legacy/version1.0/contracts/security/SecurityModule.sol
+++ b/packages/hebao_v1/legacy/version1.0/contracts/security/SecurityModule.sol
@@ -20,7 +20,7 @@ abstract contract SecurityModule is MetaTxModule
 
     event WalletLock(
         address indexed wallet,
-        uint            lock
+        bool            locked
     );
 
     constructor(ControllerImpl _controller)

--- a/packages/hebao_v1/test/testERC1271Module.ts
+++ b/packages/hebao_v1/test/testERC1271Module.ts
@@ -50,10 +50,6 @@ contract("ERC1271Module", () => {
       const hash = ethUtil.keccak("1234");
       const sig = sign(owner, hash);
 
-      const lockPeriod = (
-        await ctx.finalSecurityModule.LOCK_PERIOD()
-      ).toNumber();
-
       const walletContract = await ctx.contracts.FinalCoreModule.at(wallet);
 
       // lock wallet:
@@ -74,15 +70,6 @@ contract("ERC1271Module", () => {
         isValidBefore,
         "verification should be failed, but succeeded."
       );
-
-      // unlock
-      await advanceTimeAndBlockAsync(lockPeriod);
-
-      // verify agian:
-      const isValidAfter = await walletContract.contract.methods[
-        "isValidSignature(bytes32,bytes)"
-      ](hash, sig).call();
-      assert.equal(MAGICVALUE_B32, isValidAfter, "signature verify failed.");
     });
   });
 });

--- a/packages/hebao_v1/test/testLock.ts
+++ b/packages/hebao_v1/test/testLock.ts
@@ -58,17 +58,9 @@ contract("GuardianModule - Lock", (accounts: string[]) => {
       }
     );
 
-    const getWalletLock = await ctx.finalSecurityModule.getLock(wallet);
     const blockTime = await getBlockTime(tx.blockNumber);
 
     assert(await isLocked(wallet), "wallet needs to be locked");
-    // Check the lock data
-    const lockData = await ctx.finalSecurityModule.getLock(wallet);
-    assert.equal(
-      lockData._lockedBy,
-      ctx.finalSecurityModule.address,
-      "wallet locker unexpected"
-    );
   };
 
   const unlockChecked = async (
@@ -97,7 +89,7 @@ contract("GuardianModule - Lock", (accounts: string[]) => {
         finalSecurityModule,
         "WalletLock",
         (event: any) => {
-          return event.wallet == wallet && event.lock == 0;
+          return event.wallet == wallet && event.locked == false;
         }
       );
     }

--- a/packages/hebao_v1/test/testLock.ts
+++ b/packages/hebao_v1/test/testLock.ts
@@ -17,8 +17,6 @@ contract("GuardianModule - Lock", (accounts: string[]) => {
   let ctx: Context;
   let finalSecurityModule2: any;
 
-  let lockPeriod: number;
-
   let useMetaTx: boolean = false;
   let wallet: any;
   let guardians: any;
@@ -144,8 +142,6 @@ contract("GuardianModule - Lock", (accounts: string[]) => {
       wallet = _wallet.wallet;
       guardians = _wallet.guardians;
     }
-
-    lockPeriod = (await ctx.finalSecurityModule.LOCK_PERIOD()).toNumber();
   });
 
   [false, true].forEach(function(metaTx) {
@@ -194,25 +190,6 @@ contract("GuardianModule - Lock", (accounts: string[]) => {
         await unlockChecked(wallet, guardians[1], undefined, guardianWallet2);
         // Try to unlock the wallet again (should not throw)
         await unlockChecked(wallet, guardians[0], undefined, guardianWallet1);
-      }
-    );
-
-    it(
-      description("wallet lock should automatically expire after `lockPeriod`"),
-      async () => {
-        const owner = ctx.owners[0];
-        // Lock the wallet
-        await lockChecked(wallet, guardians[0], undefined, guardianWallet1);
-        // Skip forward `lockPeriod` / 2 seconds
-        await advanceTimeAndBlockAsync(lockPeriod / 2);
-        // Check if the wallet is still locked
-        assert(await isLocked(wallet), "wallet still needs to be locked");
-        // Skip forward the complete `lockPeriod`
-        await advanceTimeAndBlockAsync(lockPeriod / 2);
-        // Check if the wallet is now unlocked
-        assert(!(await isLocked(wallet)), "wallet needs to be unlocked");
-        // Lock the wallet again
-        await lockChecked(wallet, guardians[0], undefined, guardianWallet1);
       }
     );
 


### PR DESCRIPTION
- We remove the `onlyHaveEnoughGuardians` modifier so make sure `requireMajority` will check the number of active guardians is not empty.
- the first two guardians still don't have to wait a pending period
- If a function `doSomething` as a version that supports multi-sig authorization, I name it `doSomethingWA` where *WA* means *WithApproval*. I also make sure these two functions are next to each other. If a function only supports multisig, *WA* will be dropped from the function name
- Add default impl for `bindableMethods` in BaseModule
- Allow owner to lock his own wallet (regardless of the current lock status)
- Disable automatic unlock after 1 day. Do not track who locked the wallet.
- Lock and unlock does not check the previous status and will always succeed.
- Change the max number of guardians from 20 to 10, change guardian waiting period from 1 day to 7 days
- Disable unlock by one single guardian and only allow unlock with a majority (owner signature required)  【not tested】
- Event `WalletLock` now tracks which guardian locked a wallet and which module unlocked a wallet.
- Allow wallet owner to specify the inheritance waiting period (2 months to 10 years) 【not tested】