### PR TITLE
[protocol36] Allow arbitrary storageID for forced withdrawals

### DIFF
--- a/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
+++ b/packages/loopring_v3.js/src/request_processors/withdrawal_processor.ts
@@ -31,14 +31,10 @@ export class WithdrawalProcessor {
     const withdrawal = this.extractData(txData);
 
     const account = state.getAccount(withdrawal.fromAccountID);
-    let amount = withdrawal.amount;
     if (withdrawal.type === 2) {
-      amount = account.getBalance(withdrawal.tokenID).balance;
       account.getBalance(withdrawal.tokenID).weightAMM = new BN(0);
-    } else if (withdrawal.type === 3) {
-      amount = new BN(0);
     }
-    account.getBalance(withdrawal.tokenID).balance.isub(amount);
+    account.getBalance(withdrawal.tokenID).balance.isub(withdrawal.amount);
     account.getBalance(withdrawal.feeTokenID).balance.isub(withdrawal.fee);
 
     const operator = state.getAccount(block.operatorAccountID);

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1269,7 +1269,6 @@ export class ExchangeTestUtil {
       } else {
         type = 3;
       }
-      storageID = 0;
     }
 
     if (!token.startsWith("0x")) {
@@ -1284,12 +1283,16 @@ export class ExchangeTestUtil {
     if (authMethod === AuthMethod.FORCE && !skipForcedAuthentication) {
       const withdrawalFee = await this.loopringV3.forcedWithdrawalFee();
       if (owner != Constants.zeroAddress) {
-        const numAvailableSlotsBefore = (await this.exchange.getNumAvailableForcedSlots()).toNumber();
+        const numAvailableSlotsBefore = (
+          await this.exchange.getNumAvailableForcedSlots()
+        ).toNumber();
         await this.exchange.forceWithdraw(signer, token, accountID, {
           from: signer,
           value: withdrawalFee
         });
-        const numAvailableSlotsAfter = (await this.exchange.getNumAvailableForcedSlots()).toNumber();
+        const numAvailableSlotsAfter = (
+          await this.exchange.getNumAvailableForcedSlots()
+        ).toNumber();
         assert.equal(
           numAvailableSlotsAfter,
           numAvailableSlotsBefore - 1,
@@ -1948,10 +1951,14 @@ export class ExchangeTestUtil {
       testCallback(onchainBlocks, blocks);
     }
 
-    const numBlocksSubmittedBefore = (await this.exchange.getBlockHeight()).toNumber();
+    const numBlocksSubmittedBefore = (
+      await this.exchange.getBlockHeight()
+    ).toNumber();
 
     // Forced requests
-    const numAvailableSlotsBefore = (await this.exchange.getNumAvailableForcedSlots()).toNumber();
+    const numAvailableSlotsBefore = (
+      await this.exchange.getNumAvailableForcedSlots()
+    ).toNumber();
 
     // SubmitBlocks raw tx data
     const txData = this.getSubmitCallbackData(onchainBlocks);
@@ -2002,7 +2009,9 @@ export class ExchangeTestUtil {
     const ethBlock = await web3.eth.getBlock(tx.receipt.blockNumber);
 
     // Check number of blocks submitted
-    const numBlocksSubmittedAfter = (await this.exchange.getBlockHeight()).toNumber();
+    const numBlocksSubmittedAfter = (
+      await this.exchange.getBlockHeight()
+    ).toNumber();
     assert.equal(
       numBlocksSubmittedAfter,
       numBlocksSubmittedBefore + blocks.length,
@@ -2066,7 +2075,9 @@ export class ExchangeTestUtil {
     }
 
     // Forced requests
-    const numAvailableSlotsAfter = (await this.exchange.getNumAvailableForcedSlots()).toNumber();
+    const numAvailableSlotsAfter = (
+      await this.exchange.getNumAvailableForcedSlots()
+    ).toNumber();
     let numForcedRequestsProcessed = 0;
     for (const block of blocks) {
       for (const tx of block.internalBlock.transactions) {
@@ -2790,14 +2801,14 @@ export class ExchangeTestUtil {
   }
 
   public async advanceBlockTimestamp(seconds: number) {
-    const previousTimestamp = (await web3.eth.getBlock(
-      await web3.eth.getBlockNumber()
-    )).timestamp;
+    const previousTimestamp = (
+      await web3.eth.getBlock(await web3.eth.getBlockNumber())
+    ).timestamp;
     await this.evmIncreaseTime(seconds);
     await this.evmMine();
-    const currentTimestamp = (await web3.eth.getBlock(
-      await web3.eth.getBlockNumber()
-    )).timestamp;
+    const currentTimestamp = (
+      await web3.eth.getBlock(await web3.eth.getBlockNumber())
+    ).timestamp;
     assert(
       Math.abs(currentTimestamp - (previousTimestamp + seconds)) < 60,
       "Timestamp should have been increased by roughly the expected value"
@@ -3360,19 +3371,27 @@ export class ExchangeTestUtil {
     const tokenAddrDecimalsMap = new Map<string, number>();
     const tokenAddrInstanceMap = new Map<string, any>();
 
-    const [eth, weth, lrc, gto, rdn, rep, inda, indb, test] = await Promise.all(
-      [
-        null,
-        this.contracts.WETHToken.deployed(),
-        this.contracts.LRCToken.deployed(),
-        this.contracts.GTOToken.deployed(),
-        this.contracts.RDNToken.deployed(),
-        this.contracts.REPToken.deployed(),
-        this.contracts.INDAToken.deployed(),
-        this.contracts.INDBToken.deployed(),
-        this.contracts.TESTToken.deployed()
-      ]
-    );
+    const [
+      eth,
+      weth,
+      lrc,
+      gto,
+      rdn,
+      rep,
+      inda,
+      indb,
+      test
+    ] = await Promise.all([
+      null,
+      this.contracts.WETHToken.deployed(),
+      this.contracts.LRCToken.deployed(),
+      this.contracts.GTOToken.deployed(),
+      this.contracts.RDNToken.deployed(),
+      this.contracts.REPToken.deployed(),
+      this.contracts.INDAToken.deployed(),
+      this.contracts.INDBToken.deployed(),
+      this.contracts.TESTToken.deployed()
+    ]);
 
     const allTokens = [eth, weth, lrc, gto, rdn, rep, inda, indb, test];
 


### PR DESCRIPTION
#1942

Before: 
- For forced withdrawals `storageID` needed to be valid for use with a nonce, but also required the value to be exactly the same as the one stored in the storage tree. This could be a problem (and the tests only picked the easy case by setting the value to `0` to make setting up the tests easier under these constraints).
After:
- Any `storageID` can be used for forced withdrawals, the value only matters for the witness, nothing else.
