### PR TITLE
rename trustedForwarder to metaTxForwarder

### DIFF
--- a/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
+++ b/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
@@ -21,11 +21,11 @@ abstract contract MetaTxAware
     using AddressUtil for address;
     using BytesUtil   for bytes;
 
-    address public trustedForwarder;
+    address public metaTxForwarder;
 
-    constructor(address _trustedForwarder)
+    constructor(address _metaTxForwarder)
     {
-        trustedForwarder = _trustedForwarder;
+        metaTxForwarder = _metaTxForwarder;
     }
 
     modifier txAwareHashNotAllowed()
@@ -41,7 +41,7 @@ abstract contract MetaTxAware
         view
         returns (address payable)
     {
-        if (msg.data.length >= 56 && msg.sender == trustedForwarder) {
+        if (msg.data.length >= 56 && msg.sender == metaTxForwarder) {
             return msg.data.toAddress(msg.data.length - 52).toPayable();
         } else {
             return msg.sender;
@@ -53,7 +53,7 @@ abstract contract MetaTxAware
         view
         returns (bytes32)
     {
-        if (msg.data.length >= 56 && msg.sender == trustedForwarder) {
+        if (msg.data.length >= 56 && msg.sender == metaTxForwarder) {
             return msg.data.toBytes32(msg.data.length - 32);
         } else {
             return 0;

--- a/packages/hebao_v1/contracts/modules/base/MetaTxModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/MetaTxModule.sol
@@ -20,8 +20,8 @@ abstract contract MetaTxModule is MetaTxAware, BaseModule
 {
     using SignatureUtil for bytes32;
 
-    constructor(address _trustedForwarder)
-        MetaTxAware(_trustedForwarder)
+    constructor(address _metaTxForwarder)
+        MetaTxAware(_metaTxForwarder)
     {
     }
 

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -72,12 +72,12 @@ contract WalletFactory is MetaTxAware
         allowEmptyENS = _allowEmptyENS;
     }
 
-    function initTrustedForwarder(address _trustedForwarder)
+    function initTrustedForwarder(address _metaTxForwarder)
         external
     {
-        require(trustedForwarder == address(0), "INITIALIZED_ALREADY");
-        require(_trustedForwarder != address(0), "INVALID_ADDRESS");
-        trustedForwarder = _trustedForwarder;
+        require(metaTxForwarder == address(0), "INITIALIZED_ALREADY");
+        require(_metaTxForwarder != address(0), "INVALID_ADDRESS");
+        metaTxForwarder = _metaTxForwarder;
     }
 
     /// @dev Create a set of new wallet blanks to be used in the future.

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -72,7 +72,7 @@ contract WalletFactory is MetaTxAware
         allowEmptyENS = _allowEmptyENS;
     }
 
-    function initTrustedForwarder(address _metaTxForwarder)
+    function initMetaTxForwarder(address _metaTxForwarder)
         external
     {
         require(metaTxForwarder == address(0), "INITIALIZED_ALREADY");

--- a/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
@@ -21,9 +21,9 @@ contract FinalSecurityModule is
 
     constructor(
         ControllerImpl _controller,
-        address        _trustedForwarder
+        address        _metaTxForwarder
         )
-        SecurityModule(_trustedForwarder)
+        SecurityModule(_metaTxForwarder)
         GuardianModule()
         InheritanceModule()
         WhitelistModule()

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -27,8 +27,8 @@ abstract contract SecurityModule is MetaTxModule
         bool            locked
     );
 
-    constructor(address _trustedForwarder)
-        MetaTxModule(_trustedForwarder)
+    constructor(address _metaTxForwarder)
+        MetaTxModule(_metaTxForwarder)
     {
     }
 

--- a/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
@@ -16,9 +16,9 @@ contract FinalTransferModule is TransferModule
 
     constructor(
         ControllerImpl _controller,
-        address        _trustedForwarder
+        address        _metaTxForwarder
         )
-        SecurityModule(_trustedForwarder)
+        SecurityModule(_metaTxForwarder)
         TransferModule()
     {
         controller_ = _controller;

--- a/packages/hebao_v1/test/helpers/TestUtils.ts
+++ b/packages/hebao_v1/test/helpers/TestUtils.ts
@@ -77,7 +77,7 @@ export async function createContext(context?: Context) {
     true
   );
 
-  await walletFactory.initTrustedForwarder(context.finalCoreModule.address);
+  await walletFactory.initMetaTxForwarder(context.finalCoreModule.address);
   await context.baseENSManager.addManager(walletFactory.address);
   await context.controllerImpl.initWalletFactory(walletFactory.address);
   context.walletFactory = walletFactory;


### PR DESCRIPTION
At the request of GSN2 folks to reduce confusion.