### PR TITLE
[hebao] batch call

### DIFF
--- a/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
+++ b/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
@@ -8,14 +8,14 @@ import "../../lib/AddressUtil.sol";
 import "../../lib/ERC1271.sol";
 import "../../lib/SignatureUtil.sol";
 import "../../thirdparty/BytesUtil.sol";
-import "../base/BaseModule.sol";
+import "../security/SecurityModule.sol";
 
 
 /// @title ERC1271Module
 /// @dev This module enables our smart wallets to message signers.
 /// @author Brecht Devos - <brecht@loopring.org>
 /// @author Daniel Wang - <daniel@loopring.org>
-abstract contract ERC1271Module is ERC1271, BaseModule
+abstract contract ERC1271Module is ERC1271, SecurityModule
 {
     using SignatureUtil for bytes;
     using SignatureUtil for bytes32;

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -71,6 +71,11 @@ abstract contract ForwarderModule is SecurityModule
         view
     {
         verifyTo(to, from, data);
+        require(
+            msg.sender != address(this) ||
+            data.toBytes4(0) == ForwarderModule.batchCall.selector,
+            "INVALID_TARGET"
+        );
 
         require(
             nonce == 0 && txAwareHash != 0 ||
@@ -227,6 +232,7 @@ abstract contract ForwarderModule is SecurityModule
         require(to.length == data.length, "INVALID_DATA");
 
         for (uint i = 0; i < to.length; i++) {
+            require(to[i] != address(this), "INVALID_TARGET");
             verifyTo(to[i], wallet, data[i]);
             // The trick is to append the really logical message sender and the
             // transaction-aware hash to the end of the call data.
@@ -256,7 +262,7 @@ abstract contract ForwarderModule is SecurityModule
     function verifyTo(
         address to,
         address wallet,
-        bytes memory data
+        bytes   memory data
         )
         internal
         view


### PR DESCRIPTION
I'm back with batched call support. :)

Allow meta-txs or the wallet owner to do batched calls. I think also very important for efficiency (add multiple guardians, do multiple token transfers, whitelist multiple address,... or a combination of all of the above in multiple modules which isn't even possible with a module specific batch implementation)  with only the overhead of a single Ethereum tx/meta tx, which can be very significant (especially with reimbursement).


I think technically possible to support `txAwareHash` for batched calls, but I don't really see much use for that so kept things as simple as possible.

**Untested!**
