### PR TITLE
[hebao] add `lockWA` that does not use nonce

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -116,6 +116,21 @@ abstract contract GuardianModule is SecurityModule
         _removeGuardian(request.wallet, guardian, 0, true);
     }
 
+    function lock(address wallet)
+        external
+        txAwareHashNotAllowed()
+    {
+        address payable _logicalSender = logicalSender();
+        require(
+            _logicalSender == wallet ||
+            _logicalSender == Wallet(wallet).owner() ||
+            controllerCache.securityStore.isGuardian(wallet, _logicalSender, false),
+            "NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN"
+        );
+
+        _lockWallet(wallet, _logicalSender, true);
+    }
+
     function lock(
         SignedRequest.Request calldata request
         )

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -131,7 +131,7 @@ abstract contract GuardianModule is SecurityModule
         _lockWallet(wallet, _logicalSender, true);
     }
 
-    function lock(
+    function lock2(
         SignedRequest.Request calldata request
         )
         external

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -131,7 +131,7 @@ abstract contract GuardianModule is SecurityModule
         _lockWallet(wallet, _logicalSender, true);
     }
 
-    function lock2(
+    function lockWA(
         SignedRequest.Request calldata request
         )
         external

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -30,6 +30,9 @@ abstract contract GuardianModule is SecurityModule
     bytes32 public constant RECOVER_TYPEHASH = keccak256(
         "recover(address wallet,uint256 validUntil,address newOwner)"
     );
+    bytes32 public constant LOCK_TYPEHASH = keccak256(
+        "lock(address wallet,uint256 validUntil)"
+    );
     bytes32 public constant UNLOCK_TYPEHASH = keccak256(
         "unlock(address wallet,uint256 validUntil)"
     );
@@ -66,7 +69,7 @@ abstract contract GuardianModule is SecurityModule
         controller().verifyRequest(
             GUARDIAN_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 ADD_GUARDIAN_TYPEHASH,
@@ -100,7 +103,7 @@ abstract contract GuardianModule is SecurityModule
         controller().verifyRequest(
             GUARDIAN_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 REMOVE_GUARDIAN_TYPEHASH,
@@ -113,19 +116,24 @@ abstract contract GuardianModule is SecurityModule
         _removeGuardian(request.wallet, guardian, 0, true);
     }
 
-    function lock(address wallet)
+    function lock(
+        SignedRequest.Request calldata request
+        )
         external
-        txAwareHashNotAllowed()
     {
-        address payable _logicalSender = logicalSender();
-        if (_logicalSender == wallet ||
-            _logicalSender == Wallet(wallet).owner()) {
-            _lockWallet(wallet, address(0), true);
-        } else if (controllerCache.securityStore.isGuardian(wallet, _logicalSender, false)) {
-            _lockWallet(wallet, _logicalSender, true);
-        } else {
-            revert("NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN");
-        }
+        controller().verifyRequest(
+            GUARDIAN_DOMAIN_SEPERATOR,
+            txAwareHash(),
+            GuardianUtils.SigRequirement.OWNER_OR_ANY_GUARDIAN,
+            request,
+            abi.encode(
+                LOCK_TYPEHASH,
+                request.wallet,
+                request.validUntil
+            )
+        );
+
+        _lockWallet(request.wallet, request.signers[0], true);
     }
 
     function unlock(
@@ -136,7 +144,7 @@ abstract contract GuardianModule is SecurityModule
         controller().verifyRequest(
             GUARDIAN_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 UNLOCK_TYPEHASH,
@@ -163,7 +171,7 @@ abstract contract GuardianModule is SecurityModule
         controller().verifyRequest(
             GUARDIAN_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerNotAllowed,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_NOT_ALLOWED,
             request,
             abi.encode(
                 RECOVER_TYPEHASH,

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -46,7 +46,7 @@ library GuardianUtils
             require(signers[i] > lastSigner, "INVALID_SIGNERS_ORDER");
             lastSigner = signers[i];
 
-            if (signers[i] == owner) {
+            if (signers[i] == owner || signers[i] == wallet) {
                 walletOwnerSigned = true;
             } else {
                 require(isWalletGuardian(allGuardians, signers[i]), "SIGNER_NOT_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -12,9 +12,10 @@ library GuardianUtils
 {
     enum SigRequirement
     {
-        OwnerNotAllowed,
-        OwnerAllowed,
-        OwnerRequired
+        MAJORITY_OWNER_NOT_ALLOWED,
+        MAJORITY_OWNER_ALLOWED,
+        MAJORITY_OWNER_REQUIRED,
+        OWNER_OR_ANY_GUARDIAN
     }
 
     function requireMajority(
@@ -51,10 +52,14 @@ library GuardianUtils
             }
         }
 
+        if (requirement == SigRequirement.OWNER_OR_ANY_GUARDIAN) {
+            return signers.length == 1;
+        }
+
         // Check owner requirements
-        if (requirement == SigRequirement.OwnerRequired) {
+        if (requirement == SigRequirement.MAJORITY_OWNER_REQUIRED) {
             require(walletOwnerSigned, "WALLET_OWNER_SIGNATURE_REQUIRED");
-        } else if (requirement == SigRequirement.OwnerNotAllowed) {
+        } else if (requirement == SigRequirement.MAJORITY_OWNER_NOT_ALLOWED) {
             require(!walletOwnerSigned, "WALLET_OWNER_SIGNATURE_NOT_ALLOWED");
         }
 

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -47,6 +47,7 @@ library GuardianUtils
             lastSigner = signers[i];
 
             if (signers[i] == owner || signers[i] == wallet) {
+                require(!walletOwnerSigned, "OWNER_CANNOT_SIGN_TWICE");
                 walletOwnerSigned = true;
             } else {
                 require(isWalletGuardian(allGuardians, signers[i]), "SIGNER_NOT_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -46,8 +46,7 @@ library GuardianUtils
             require(signers[i] > lastSigner, "INVALID_SIGNERS_ORDER");
             lastSigner = signers[i];
 
-            if (signers[i] == owner || signers[i] == wallet) {
-                require(!walletOwnerSigned, "OWNER_CANNOT_SIGN_TWICE");
+            if (signers[i] == owner) {
                 walletOwnerSigned = true;
             } else {
                 require(isWalletGuardian(allGuardians, signers[i]), "SIGNER_NOT_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -46,7 +46,7 @@ library GuardianUtils
             require(signers[i] > lastSigner, "INVALID_SIGNERS_ORDER");
             lastSigner = signers[i];
 
-            if (signers[i] == owner || signers[i] == wallet) {
+            if (signers[i] == owner) {
                 walletOwnerSigned = true;
             } else {
                 require(isWalletGuardian(allGuardians, signers[i]), "SIGNER_NOT_GUARDIAN");

--- a/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianUtils.sol
@@ -15,7 +15,8 @@ library GuardianUtils
         MAJORITY_OWNER_NOT_ALLOWED,
         MAJORITY_OWNER_ALLOWED,
         MAJORITY_OWNER_REQUIRED,
-        OWNER_OR_ANY_GUARDIAN
+        OWNER_OR_ANY_GUARDIAN,
+        ANY_GUARDIAN
     }
 
     function requireMajority(
@@ -53,6 +54,9 @@ library GuardianUtils
         }
 
         if (requirement == SigRequirement.OWNER_OR_ANY_GUARDIAN) {
+            return signers.length == 1;
+        } else if (requirement == SigRequirement.ANY_GUARDIAN) {
+            require(!walletOwnerSigned, "WALLET_OWNER_SIGNATURE_NOT_ALLOWED");
             return signers.length == 1;
         }
 

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -57,7 +57,7 @@ abstract contract WhitelistModule is SecurityModule
         controller().verifyRequest(
             WHITELIST_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 ADD_TO_WHITELIST_TYPEHASH,
@@ -94,7 +94,7 @@ abstract contract WhitelistModule is SecurityModule
         controller().verifyRequest(
             WHITELIST_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 REMOVE_FROM_WHITELIST_TYPEHASH,

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -64,7 +64,7 @@ abstract contract TransferModule is BaseTransferModule
         controller().verifyRequest(
             TRANSFER_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 CHANGE_DAILY_QUOTE_TYPEHASH,
@@ -106,7 +106,7 @@ abstract contract TransferModule is BaseTransferModule
         controller().verifyRequest(
             TRANSFER_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 TRANSFER_TOKEN_TYPEHASH,
@@ -152,7 +152,7 @@ abstract contract TransferModule is BaseTransferModule
         controller().verifyRequest(
             TRANSFER_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 CALL_CONTRACT_TYPEHASH,
@@ -195,7 +195,7 @@ abstract contract TransferModule is BaseTransferModule
         controller().verifyRequest(
             TRANSFER_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             abi.encode(
                 APPROVE_TOKEN_TYPEHASH,
@@ -258,7 +258,7 @@ abstract contract TransferModule is BaseTransferModule
         controller().verifyRequest(
             TRANSFER_DOMAIN_SEPERATOR,
             txAwareHash(),
-            GuardianUtils.SigRequirement.OwnerRequired,
+            GuardianUtils.SigRequirement.MAJORITY_OWNER_REQUIRED,
             request,
             encoded
         );


### PR DESCRIPTION
Locking a wallet should be a really urgent operation and shall not wait for any previous transactions to finish due to nonce dependency.  