### PR TITLE
[hebao1.2] Allow unlimited quota

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -84,6 +84,7 @@ abstract contract SecurityModule is MetaTxModule
         QuotaStore qs = controllerCache.quotaStore;
         if (qs == QuotaStore(0)) return false;
         if (qs.currentQuota(wallet) == 0 /* max/disabled */) return false;
+        return true;
     }
 
     function _updateQuota(

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -72,7 +72,7 @@ abstract contract SecurityModule is MetaTxModule
         return controllerCache.securityStore.isLocked(wallet);
     }
 
-    function _needUpdateQuota(
+    function _needCheckQuota(
         address wallet,
         uint    amount
         )

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -73,24 +73,25 @@ abstract contract SecurityModule is MetaTxModule
     }
 
     function _needCheckQuota(
-        address wallet,
-        uint    amount
+        QuotaStore qs,
+        address    wallet,
+        uint       amount
         )
         internal
         view
         returns (bool)
     {
         if (amount == 0) return false;
-        QuotaStore qs = controllerCache.quotaStore;
         if (qs == QuotaStore(0)) return false;
         if (qs.currentQuota(wallet) == 0 /* max/disabled */) return false;
         return true;
     }
 
     function _updateQuota(
-        address wallet,
-        address token,
-        uint    amount
+        QuotaStore qs,
+        address    wallet,
+        address    token,
+        uint       amount
         )
         internal
     {
@@ -99,7 +100,7 @@ abstract contract SecurityModule is MetaTxModule
             controllerCache.priceOracle.tokenValue(token, amount);
 
         if (value > 0) {
-            controllerCache.quotaStore.checkAndAddToSpent(wallet, value);
+            qs.checkAndAddToSpent(wallet, value);
         }
     }
 }

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -87,7 +87,7 @@ abstract contract TransferModule is BaseTransferModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        if (amount > 0 && !isTargetWhitelisted(wallet, to)) {
+        if (_needUpdateQuota(wallet, amount) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, amount);
         }
 
@@ -133,7 +133,7 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
-        if (value > 0 && !isTargetWhitelisted(wallet, to)) {
+        if (_needUpdateQuota(wallet, value) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, address(0), value);
         }
 
@@ -179,7 +179,9 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (additionalAllowance > 0 && !isTargetWhitelisted(wallet, to)) {
+        if (additionalAllowance > 0 &&
+            _needUpdateQuota(wallet, amount) &&
+            !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
         }
     }
@@ -225,7 +227,9 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if ((additionalAllowance > 0 || value > 0) && !isTargetWhitelisted(wallet, to)) {
+        if ((additionalAllowance > 0 || value > 0) &&
+             _needUpdateQuota(wallet, amount) &&
+            !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
             _updateQuota(wallet, address(0), value);
         }

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -87,8 +87,9 @@ abstract contract TransferModule is BaseTransferModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        if (_needCheckQuota(wallet, amount) && !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, amount);
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, amount) && !isTargetWhitelisted(wallet, to)) {
+            _updateQuota(qs, wallet, token, amount);
         }
 
         transferInternal(wallet, token, to, amount, logdata);
@@ -133,8 +134,9 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
-        if (_needCheckQuota(wallet, value) && !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, address(0), value);
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, value) && !isTargetWhitelisted(wallet, to)) {
+            _updateQuota(qs, wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);
@@ -179,9 +181,10 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (_needCheckQuota(wallet, additionalAllowance) &&
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, additionalAllowance) &&
             !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, additionalAllowance);
+            _updateQuota(qs, wallet, token, additionalAllowance);
         }
     }
 
@@ -226,10 +229,11 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (_needCheckQuota(wallet, additionalAllowance.add(value)) &&
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, additionalAllowance.add(value)) &&
             !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, additionalAllowance);
-            _updateQuota(wallet, address(0), value);
+            _updateQuota(qs, wallet, token, additionalAllowance);
+            _updateQuota(qs, wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -179,8 +179,7 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (additionalAllowance > 0 &&
-            _needCheckQuota(wallet, amount) &&
+        if (_needCheckQuota(wallet, additionalAllowance) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
         }
@@ -227,8 +226,7 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if ((additionalAllowance > 0 || value > 0) &&
-             _needCheckQuota(wallet, amount) &&
+        if (_needCheckQuota(wallet, additionalAllowance.add(value)) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
             _updateQuota(wallet, address(0), value);

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -87,7 +87,7 @@ abstract contract TransferModule is BaseTransferModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        if (_needUpdateQuota(wallet, amount) && !isTargetWhitelisted(wallet, to)) {
+        if (_needCheckQuota(wallet, amount) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, amount);
         }
 
@@ -133,7 +133,7 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
-        if (_needUpdateQuota(wallet, value) && !isTargetWhitelisted(wallet, to)) {
+        if (_needCheckQuota(wallet, value) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, address(0), value);
         }
 
@@ -180,7 +180,7 @@ abstract contract TransferModule is BaseTransferModule
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
         if (additionalAllowance > 0 &&
-            _needUpdateQuota(wallet, amount) &&
+            _needCheckQuota(wallet, amount) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
         }
@@ -228,7 +228,7 @@ abstract contract TransferModule is BaseTransferModule
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
         if ((additionalAllowance > 0 || value > 0) &&
-             _needUpdateQuota(wallet, amount) &&
+             _needCheckQuota(wallet, amount) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(wallet, token, additionalAllowance);
             _updateQuota(wallet, address(0), value);

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -271,7 +271,7 @@ abstract contract TransferModule is BaseTransferModule
         public
         view
         returns (
-            uint total,
+            uint total, // 0 indicates quota is disabled
             uint spent,
             uint available
         )
@@ -289,13 +289,14 @@ abstract contract TransferModule is BaseTransferModule
         private
     {
         QuotaStore qs = controllerCache.quotaStore;
-        uint _newQuota = newQuota == 0 ? qs.defaultQuota(): newQuota;
         uint _currentQuota = qs.currentQuota(wallet);
+        require(_currentQuota != newQuota, "SAME_VALUE");
 
-        if (_newQuota < _currentQuota) {
-            qs.changeQuota(wallet, _newQuota, block.timestamp);
-        } else if (_newQuota > _currentQuota) {
-            qs.changeQuota(wallet, _newQuota, block.timestamp.add(pendingPeriod));
+        uint _pendingPeriod = pendingPeriod;
+        if (newQuota > 0 && newQuota < _currentQuota) {
+            _pendingPeriod = 0;
         }
+
+        qs.changeQuota(wallet, newQuota, block.timestamp.add(_pendingPeriod));
     }
 }

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -112,7 +112,7 @@ contract QuotaStore is DataStore
     }
 
     function spentQuota(address wallet)
-        external
+        public
         view
         returns (uint)
     {
@@ -141,7 +141,7 @@ contract QuotaStore is DataStore
     // Internal
 
     function _currentQuota(Quota memory q)
-        internal
+        private
         view
         returns (uint)
     {
@@ -149,7 +149,7 @@ contract QuotaStore is DataStore
     }
 
     function _pendingQuota(Quota memory q)
-        internal
+        private
         view
         returns (
             uint __pendingQuota,
@@ -163,7 +163,7 @@ contract QuotaStore is DataStore
     }
 
     function _spentQuota(Quota memory q)
-        public
+        private
         view
         returns (uint)
     {
@@ -176,7 +176,7 @@ contract QuotaStore is DataStore
     }
 
     function _availableQuota(Quota memory q)
-        public
+        private
         view
         returns (uint)
     {
@@ -192,7 +192,7 @@ contract QuotaStore is DataStore
         Quota   memory q,
         uint    requiredAmount
         )
-        public
+        private
         view
         returns (bool)
     {
@@ -204,7 +204,7 @@ contract QuotaStore is DataStore
         Quota   memory q,
         uint    amount
         )
-        internal
+        private
     {
         Quota storage s = quotas[wallet];
         s.spentAmount = _spentQuota(q).add(amount).toUint128();

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 Loopring Technology Limited.
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "../base/DataStore.sol";
 import "../lib/MathUint.sol";
@@ -45,7 +46,7 @@ contract QuotaStore is DataStore
         uint    newQuota,
         uint    effectiveTime
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
         require(newQuota <= MAX_QUOTA, "INVALID_VALUE");
@@ -68,13 +69,14 @@ contract QuotaStore is DataStore
         address wallet,
         uint    amount
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
-        uint available = availableQuota(wallet);
+        Quota memory q = quotas[wallet];
+        uint available = _availableQuota(q);
         if (available != MAX_QUOTA) {
             require(available >= amount, "QUOTA_EXCEEDED");
-            addToSpent(wallet, amount);
+            _addToSpent(wallet, q, amount);
         }
     }
 
@@ -82,12 +84,10 @@ contract QuotaStore is DataStore
         address wallet,
         uint    amount
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
-        Quota storage q = quotas[wallet];
-        q.spentAmount = spentQuota(wallet).add(amount).toUint128();
-        q.spentTimestamp = uint64(block.timestamp);
+        _addToSpent(wallet, quotas[wallet], amount);
     }
 
     // Returns 0 to indiciate unlimited quota
@@ -96,8 +96,7 @@ contract QuotaStore is DataStore
         view
         returns (uint)
     {
-        Quota storage q = quotas[wallet];
-        return q.pendingUntil <= block.timestamp ? q.pendingQuota : q.currentQuota;
+        return _currentQuota(quotas[wallet]);
     }
 
     // Returns 0 to indiciate unlimited quota
@@ -105,15 +104,11 @@ contract QuotaStore is DataStore
         public
         view
         returns (
-            uint _pendingQuota,
-            uint _pendingUntil
+            uint __pendingQuota,
+            uint __pendingUntil
         )
     {
-        Quota storage q = quotas[wallet];
-        if (q.pendingUntil > 0 && q.pendingUntil > block.timestamp) {
-            _pendingQuota = q.pendingQuota;
-            _pendingUntil = q.pendingUntil;
-        }
+        return _pendingQuota(quotas[wallet]);
     }
 
     function spentQuota(address wallet)
@@ -121,13 +116,7 @@ contract QuotaStore is DataStore
         view
         returns (uint)
     {
-        Quota storage q = quotas[wallet];
-        uint timeSinceLastSpent = block.timestamp.sub(q.spentTimestamp);
-        if (timeSinceLastSpent < 1 days) {
-            return uint(q.spentAmount).sub(timeSinceLastSpent.mul(q.spentAmount) / 1 days);
-        } else {
-            return 0;
-        }
+        return _spentQuota(quotas[wallet]);
     }
 
     function availableQuota(address wallet)
@@ -135,12 +124,7 @@ contract QuotaStore is DataStore
         view
         returns (uint)
     {
-        uint quota = currentQuota(wallet);
-        if (quota == 0) {
-            return MAX_QUOTA;
-        }
-        uint spent = spentQuota(wallet);
-        return quota > spent ? quota - spent : 0;
+        return _availableQuota(quotas[wallet]);
     }
 
     function hasEnoughQuota(
@@ -151,6 +135,79 @@ contract QuotaStore is DataStore
         view
         returns (bool)
     {
-        return availableQuota(wallet) >= requiredAmount;
+        return _hasEnoughQuota(quotas[wallet], requiredAmount);
+    }
+
+    // Internal
+
+    function _currentQuota(Quota memory q)
+        internal
+        view
+        returns (uint)
+    {
+        return q.pendingUntil <= block.timestamp ? q.pendingQuota : q.currentQuota;
+    }
+
+    function _pendingQuota(Quota memory q)
+        internal
+        view
+        returns (
+            uint __pendingQuota,
+            uint __pendingUntil
+        )
+    {
+        if (q.pendingUntil > 0 && q.pendingUntil > block.timestamp) {
+            __pendingQuota = q.pendingQuota;
+            __pendingUntil = q.pendingUntil;
+        }
+    }
+
+    function _spentQuota(Quota memory q)
+        public
+        view
+        returns (uint)
+    {
+        uint timeSinceLastSpent = block.timestamp.sub(q.spentTimestamp);
+        if (timeSinceLastSpent < 1 days) {
+            return uint(q.spentAmount).sub(timeSinceLastSpent.mul(q.spentAmount) / 1 days);
+        } else {
+            return 0;
+        }
+    }
+
+    function _availableQuota(Quota memory q)
+        public
+        view
+        returns (uint)
+    {
+        uint quota = _currentQuota(q);
+        if (quota == 0) {
+            return MAX_QUOTA;
+        }
+        uint spent = _spentQuota(q);
+        return quota > spent ? quota - spent : 0;
+    }
+
+    function _hasEnoughQuota(
+        Quota   memory q,
+        uint    requiredAmount
+        )
+        public
+        view
+        returns (bool)
+    {
+        return _availableQuota(q) >= requiredAmount;
+    }
+
+    function _addToSpent(
+        address wallet,
+        Quota   memory q,
+        uint    amount
+        )
+        internal
+    {
+        Quota storage s = quotas[wallet];
+        s.spentAmount = _spentQuota(q).add(amount).toUint128();
+        s.spentTimestamp = uint64(block.timestamp);
     }
 }

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -83,7 +83,7 @@ contract QuotaStore is DataStore, Claimable
         address wallet,
         uint    amount
         )
-        internal
+        public
         onlyWalletModule(wallet)
     {
         Quota storage q = quotas[wallet];

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -4,13 +4,12 @@ pragma solidity ^0.7.0;
 
 import "../base/DataStore.sol";
 import "../lib/MathUint.sol";
-import "../lib/Claimable.sol";
 import "../thirdparty/SafeCast.sol";
 
 /// @title QuotaStore
 /// @dev This store maintains daily spending quota for each wallet.
 ///      A rolling daily limit is used.
-contract QuotaStore is DataStore, Claimable
+contract QuotaStore is DataStore
 {
     using MathUint for uint;
     using SafeCast for uint;

--- a/packages/hebao_v1/contracts/stores/SecurityStore.sol
+++ b/packages/hebao_v1/contracts/stores/SecurityStore.sol
@@ -39,7 +39,6 @@ contract SecurityStore is GuardianStore
         uint    minInternval
         )
         external
-        onlyWalletModule(wallet)
     {
         if (wallets[wallet].inheritor != address(0) &&
             block.timestamp > lastActive(wallet) + minInternval) {

--- a/packages/hebao_v1/contracts/stores/SecurityStore.sol
+++ b/packages/hebao_v1/contracts/stores/SecurityStore.sol
@@ -17,14 +17,6 @@ contract SecurityStore is GuardianStore
 
     constructor() GuardianStore() {}
 
-    function isLocked(address wallet)
-        public
-        view
-        returns (bool)
-    {
-        return wallets[wallet].locked;
-    }
-
     function setLock(
         address wallet,
         bool    locked
@@ -33,14 +25,6 @@ contract SecurityStore is GuardianStore
         onlyWalletModule(wallet)
     {
         wallets[wallet].locked = locked;
-    }
-
-    function lastActive(address wallet)
-        public
-        view
-        returns (uint)
-    {
-        return wallets[wallet].lastActive;
     }
 
     function touchLastActive(address wallet)
@@ -55,12 +39,42 @@ contract SecurityStore is GuardianStore
         uint    minInternval
         )
         external
+        onlyWalletModule(wallet)
     {
         if (wallets[wallet].inheritor != address(0) &&
             block.timestamp > lastActive(wallet) + minInternval) {
             requireWalletModule(wallet);
             wallets[wallet].lastActive = uint64(block.timestamp);
         }
+    }
+
+    function setInheritor(
+        address wallet,
+        address who,
+        uint32 _inheritWaitingPeriod
+        )
+        external
+        onlyWalletModule(wallet)
+    {
+        wallets[wallet].inheritor = who;
+        wallets[wallet].inheritWaitingPeriod = _inheritWaitingPeriod;
+        wallets[wallet].lastActive = uint64(block.timestamp);
+    }
+
+    function isLocked(address wallet)
+        public
+        view
+        returns (bool)
+    {
+        return wallets[wallet].locked;
+    }
+
+    function lastActive(address wallet)
+        public
+        view
+        returns (uint)
+    {
+        return wallets[wallet].lastActive;
     }
 
     function inheritor(address wallet)
@@ -89,18 +103,5 @@ contract SecurityStore is GuardianStore
 
         _who = _inheritor;
         _effectiveTimestamp = _lastActive + _inheritWaitingPeriod;
-    }
-
-    function setInheritor(
-        address wallet,
-        address who,
-        uint32 _inheritWaitingPeriod
-        )
-        external
-        onlyWalletModule(wallet)
-    {
-        wallets[wallet].inheritor = who;
-        wallets[wallet].inheritWaitingPeriod = _inheritWaitingPeriod;
-        wallets[wallet].lastActive = uint64(block.timestamp);
     }
 }

--- a/packages/hebao_v1/contracts/stores/WhitelistStore.sol
+++ b/packages/hebao_v1/contracts/stores/WhitelistStore.sol
@@ -56,6 +56,22 @@ contract WhitelistStore is DataStore, AddressSet, OwnerManagable
         emit Whitelisted(wallet, addr, false, 0);
     }
 
+    function addDapp(address addr)
+        external
+        onlyManager
+    {
+        addAddressToSet(DAPPS, addr, true);
+        emit DappWhitelisted(addr, true);
+    }
+
+    function removeDapp(address addr)
+        external
+        onlyManager
+    {
+        removeAddressFromSet(DAPPS, addr);
+        emit DappWhitelisted(addr, false);
+    }
+
     function whitelist(address wallet)
         public
         view
@@ -92,22 +108,6 @@ contract WhitelistStore is DataStore, AddressSet, OwnerManagable
         returns (uint)
     {
         return numAddressesInSet(_walletKey(wallet));
-    }
-
-    function addDapp(address addr)
-        external
-        onlyManager
-    {
-        addAddressToSet(DAPPS, addr, true);
-        emit DappWhitelisted(addr, true);
-    }
-
-    function removeDapp(address addr)
-        external
-        onlyManager
-    {
-        removeAddressFromSet(DAPPS, addr);
-        emit DappWhitelisted(addr, false);
     }
 
     function dapps()

--- a/packages/hebao_v1/contracts/thirdparty/SafeCast.sol
+++ b/packages/hebao_v1/contracts/thirdparty/SafeCast.sol
@@ -37,6 +37,21 @@ library SafeCast {
     }
 
     /**
+     * @dev Returns the downcasted uint96 from uint256, reverting on
+     * overflow (when the input is greater than largest uint96).
+     *
+     * Counterpart to Solidity's `uint96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toUint96(uint256 value) internal pure returns (uint96) {
+        require(value < 2**96, "SafeCast: value doesn\'t fit in 96 bits");
+        return uint96(value);
+    }
+
+    /**
      * @dev Returns the downcasted uint64 from uint256, reverting on
      * overflow (when the input is greater than largest uint64).
      *

--- a/packages/hebao_v1/migrations/6_stores.js
+++ b/packages/hebao_v1/migrations/6_stores.js
@@ -7,7 +7,7 @@ module.exports = function(deployer, network, accounts) {
   deployer.then(() => {
     return Promise.all([
       deployer.deploy(HashStore),
-      deployer.deploy(QuotaStore, "1" + "0".repeat(19)), // 1000 wei for unit test
+      deployer.deploy(QuotaStore),
       deployer.deploy(SecurityStore),
       deployer.deploy(WhitelistStore)
     ]);

--- a/packages/hebao_v1/migrations/9_modules.js
+++ b/packages/hebao_v1/migrations/9_modules.js
@@ -45,7 +45,6 @@ module.exports = function(deployer, network, accounts) {
       AddOfficialGuardianModule,
       ControllerImpl.address,
       OfficialGuardian.address,
-      11,
       { gas: 6700000 }
     );
 

--- a/packages/hebao_v1/test/helpers/TestUtils.ts
+++ b/packages/hebao_v1/test/helpers/TestUtils.ts
@@ -60,10 +60,7 @@ export async function getContext() {
     securityStore: await contracts.SecurityStore.deployed(),
     whitelistStore: await contracts.WhitelistStore.deployed(),
     quotaStore: await contracts.QuotaStore.deployed(),
-    priceCacheStore: await contracts.PriceCacheStore.new(
-      Constants.zeroAddress,
-      3600 * 240
-    )
+    priceCacheStore: await contracts.PriceCacheStore.new(Constants.zeroAddress)
   };
   return context;
 }


### PR DESCRIPTION
Now a wallet's quota by default is 0, and it means the quota is unlimited, consuming quota will not update the quota value in QuotaStore to reduce gas. Values other than 0 will behave as usual.

@Brechtpd I'm not sure if `uint128(-1)` is the right way to calculate the max number for uint128.