### PR TITLE
[hebao] QuotaStore optimizations

### DIFF
--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -73,24 +73,25 @@ abstract contract SecurityModule is MetaTxModule
     }
 
     function _needCheckQuota(
-        address wallet,
-        uint    amount
+        QuotaStore qs,
+        address    wallet,
+        uint       amount
         )
         internal
         view
         returns (bool)
     {
         if (amount == 0) return false;
-        QuotaStore qs = controllerCache.quotaStore;
         if (qs == QuotaStore(0)) return false;
         if (qs.currentQuota(wallet) == 0 /* max/disabled */) return false;
         return true;
     }
 
     function _updateQuota(
-        address wallet,
-        address token,
-        uint    amount
+        QuotaStore qs,
+        address    wallet,
+        address    token,
+        uint       amount
         )
         internal
     {
@@ -99,7 +100,7 @@ abstract contract SecurityModule is MetaTxModule
             controllerCache.priceOracle.tokenValue(token, amount);
 
         if (value > 0) {
-            controllerCache.quotaStore.checkAndAddToSpent(wallet, value);
+            qs.checkAndAddToSpent(wallet, value);
         }
     }
 }

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -87,8 +87,9 @@ abstract contract TransferModule is BaseTransferModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        if (_needCheckQuota(wallet, amount) && !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, amount);
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, amount) && !isTargetWhitelisted(wallet, to)) {
+            _updateQuota(qs, wallet, token, amount);
         }
 
         transferInternal(wallet, token, to, amount, logdata);
@@ -133,8 +134,9 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
-        if (_needCheckQuota(wallet, value) && !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, address(0), value);
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, value) && !isTargetWhitelisted(wallet, to)) {
+            _updateQuota(qs, wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);
@@ -179,9 +181,10 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (_needCheckQuota(wallet, additionalAllowance) &&
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, additionalAllowance) &&
             !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, additionalAllowance);
+            _updateQuota(qs, wallet, token, additionalAllowance);
         }
     }
 
@@ -226,10 +229,11 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        if (_needCheckQuota(wallet, additionalAllowance.add(value)) &&
+        QuotaStore qs = controllerCache.quotaStore;
+        if (_needCheckQuota(qs, wallet, additionalAllowance.add(value)) &&
             !isTargetWhitelisted(wallet, to)) {
-            _updateQuota(wallet, token, additionalAllowance);
-            _updateQuota(wallet, address(0), value);
+            _updateQuota(qs, wallet, token, additionalAllowance);
+            _updateQuota(qs, wallet, address(0), value);
         }
 
         return callContractInternal(wallet, to, value, data);

--- a/packages/hebao_v1/contracts/stores/QuotaStore.sol
+++ b/packages/hebao_v1/contracts/stores/QuotaStore.sol
@@ -46,7 +46,7 @@ contract QuotaStore is DataStore
         uint    newQuota,
         uint    effectiveTime
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
         require(newQuota <= MAX_QUOTA, "INVALID_VALUE");
@@ -69,7 +69,7 @@ contract QuotaStore is DataStore
         address wallet,
         uint    amount
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
         Quota memory q = quotas[wallet];
@@ -84,7 +84,7 @@ contract QuotaStore is DataStore
         address wallet,
         uint    amount
         )
-        public
+        external
         onlyWalletModule(wallet)
     {
         _addToSpent(wallet, quotas[wallet], amount);

--- a/packages/hebao_v1/contracts/test/PriceCacheStore.sol
+++ b/packages/hebao_v1/contracts/test/PriceCacheStore.sol
@@ -4,16 +4,18 @@ pragma solidity ^0.7.0;
 
 import "../lib/MathUint.sol";
 import "../lib/OwnerManagable.sol";
+import "../thirdparty/SafeCast.sol";
 
 import "../iface/PriceOracle.sol";
 
-import "../base/DataStore.sol";
-
 
 /// @title PriceCacheStore
-contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
+contract PriceCacheStore is PriceOracle, OwnerManagable
 {
     using MathUint for uint;
+    using SafeCast for uint;
+
+    uint public constant EXPIRY_PERIOD = 14 days;
 
     PriceOracle oracle;
     uint expiry;
@@ -25,23 +27,19 @@ contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
         uint    timestamp
     );
 
+    // Optimized to fit into 32 bytes (1 slot)
     struct TokenPrice
     {
-        uint amount;
-        uint value;
-        uint timestamp;
+        uint128 amount;
+        uint96  value;
+        uint32  timestamp;
     }
 
     mapping (address => TokenPrice) prices;
 
-    constructor(
-        PriceOracle _oracle,
-        uint        _expiry
-        )
-        DataStore()
+    constructor(PriceOracle _oracle)
     {
         oracle = _oracle;
-        expiry = _expiry;
     }
 
     function tokenValue(address token, uint amount)
@@ -50,9 +48,9 @@ contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
         override
         returns (uint)
     {
-        TokenPrice storage tp = prices[token];
-        if (tp.timestamp > 0 && block.timestamp < tp.timestamp + expiry) {
-            return tp.value.mul(amount) / tp.amount;
+        TokenPrice memory tp = prices[token];
+        if (tp.timestamp > 0 && block.timestamp < tp.timestamp + EXPIRY_PERIOD) {
+            return uint(tp.value).mul(amount) / tp.amount;
         } else {
             return 0;
         }
@@ -63,7 +61,6 @@ contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
         uint    amount
         )
         external
-        onlyManager
     {
         uint value = oracle.tokenValue(token, amount);
         if (value > 0) {
@@ -77,14 +74,14 @@ contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
         uint    value
         )
         external
-        onlyManager
+        onlyOwnerOrManager
     {
         cacheTokenPrice(token, amount, value);
     }
 
     function setOracle(PriceOracle _oracle)
         external
-        onlyManager
+        onlyOwnerOrManager
     {
         oracle = _oracle;
     }
@@ -96,9 +93,9 @@ contract PriceCacheStore is DataStore, PriceOracle, OwnerManagable
         )
         internal
     {
-        prices[token].amount = amount;
-        prices[token].value = value;
-        prices[token].timestamp = block.timestamp;
+        prices[token].amount = amount.toUint128();
+        prices[token].value = value.toUint96();
+        prices[token].timestamp = block.timestamp.toUint32();
         emit PriceCached(token, amount, value, block.timestamp);
     }
 }

--- a/packages/hebao_v1/contracts/test/PriceCacheStore.sol
+++ b/packages/hebao_v1/contracts/test/PriceCacheStore.sol
@@ -15,7 +15,7 @@ contract PriceCacheStore is PriceOracle, OwnerManagable
     using MathUint for uint;
     using SafeCast for uint;
 
-    uint public constant EXPIRY_PERIOD = 14 days;
+    uint public constant EXPIRY_PERIOD = 7 days;
 
     PriceOracle oracle;
     uint expiry;
@@ -74,14 +74,14 @@ contract PriceCacheStore is PriceOracle, OwnerManagable
         uint    value
         )
         external
-        onlyOwnerOrManager
+        onlyManager
     {
         cacheTokenPrice(token, amount, value);
     }
 
     function setOracle(PriceOracle _oracle)
         external
-        onlyOwnerOrManager
+        onlyManager
     {
         oracle = _oracle;
     }

--- a/packages/hebao_v1/contracts/thirdparty/SafeCast.sol
+++ b/packages/hebao_v1/contracts/thirdparty/SafeCast.sol
@@ -37,6 +37,21 @@ library SafeCast {
     }
 
     /**
+     * @dev Returns the downcasted uint96 from uint256, reverting on
+     * overflow (when the input is greater than largest uint96).
+     *
+     * Counterpart to Solidity's `uint96` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 96 bits
+     */
+    function toUint96(uint256 value) internal pure returns (uint96) {
+        require(value < 2**96, "SafeCast: value doesn\'t fit in 96 bits");
+        return uint96(value);
+    }
+
+    /**
      * @dev Returns the downcasted uint64 from uint256, reverting on
      * overflow (when the input is greater than largest uint64).
      *

--- a/packages/hebao_v1/migrations/9_modules.js
+++ b/packages/hebao_v1/migrations/9_modules.js
@@ -45,7 +45,6 @@ module.exports = function(deployer, network, accounts) {
       AddOfficialGuardianModule,
       ControllerImpl.address,
       OfficialGuardian.address,
-      11,
       { gas: 6700000 }
     );
 

--- a/packages/hebao_v1/test/helpers/TestUtils.ts
+++ b/packages/hebao_v1/test/helpers/TestUtils.ts
@@ -60,10 +60,7 @@ export async function getContext() {
     securityStore: await contracts.SecurityStore.deployed(),
     whitelistStore: await contracts.WhitelistStore.deployed(),
     quotaStore: await contracts.QuotaStore.deployed(),
-    priceCacheStore: await contracts.PriceCacheStore.new(
-      Constants.zeroAddress,
-      3600 * 240
-    )
+    priceCacheStore: await contracts.PriceCacheStore.new(Constants.zeroAddress)
   };
   return context;
 }

--- a/packages/hebao_v1/test/testQuotaTransfers.ts
+++ b/packages/hebao_v1/test/testQuotaTransfers.ts
@@ -35,7 +35,7 @@ contract("TransferModule - approvedTransfer", (accounts: string[]) => {
 
   let priceOracleMock: any;
   let targetContract: any;
-  let defaultQuota: BN;
+  let maxQuota: BN;
   let quotaPeriod: number; // 24 * 3600; // 1 day
 
   let useMetaTx: boolean = false;
@@ -155,7 +155,10 @@ contract("TransferModule - approvedTransfer", (accounts: string[]) => {
     const newAvailableQuota = await ctx.quotaStore.availableQuota(wallet);
     const newSpentQuota = await ctx.quotaStore.spentQuota(wallet);
 
-    const quotaDelta = isWhitelisted || approved ? new BN(0) : assetValue;
+    const quotaDelta =
+      isWhitelisted || approved || oldAvailableQuota.eq(maxQuota)
+        ? new BN(0)
+        : assetValue;
     equalWithPrecision(
       oldAvailableQuota,
       newAvailableQuota.add(quotaDelta),
@@ -853,68 +856,88 @@ contract("TransferModule - approvedTransfer", (accounts: string[]) => {
   beforeEach(async () => {
     ctx = await createContext(defaultCtx);
     targetContract = await TestTargetContract.new();
-    quotaPeriod = (await ctx.finalTransferModule.QUOTA_PENDING_PERIOD()).toNumber();
-    defaultQuota = await ctx.quotaStore.defaultQuota();
+    quotaPeriod = (
+      await ctx.finalTransferModule.QUOTA_PENDING_PERIOD()
+    ).toNumber();
+    maxQuota = await ctx.quotaStore.MAX_QUOTA();
 
     await defaultCtx.controllerImpl.setPriceOracle(priceOracleMock.address);
     await updateControllerCache(defaultCtx);
   });
 
-  [true].forEach(function(metaTx) {
-    describe(description("Benchmark TransferToken", metaTx), () => {
-      it(description("benchmark", metaTx), async () => {
-        useMetaTx = metaTx;
-        const owner = ctx.owners[0];
-        const to = ctx.miscAddresses[0];
-        const { wallet } = await createWallet(ctx, owner);
+  describe.only("Benchmark", () => {
+    [false, true].forEach(function(withQuota) {
+      it(
+        "Token transfer " + (withQuota ? "(with quota)" : "(without quota)"),
+        async () => {
+          useMetaTx = true;
+          const owner = ctx.owners[0];
+          const to = ctx.miscAddresses[withQuota ? 0 : 1];
+          const { wallet } = await createWallet(ctx, owner);
 
-        const quota = await ctx.quotaStore.currentQuota(wallet);
+          if (withQuota) {
+            const targetQuota = new BN(10);
+            await ctx.finalTransferModule.changeDailyQuota(
+              wallet,
+              targetQuota.toString(10),
+              { from: owner }
+            );
+            // Skip forward `quotaPeriod`
+            await advanceTimeAndBlockAsync(quotaPeriod);
+          }
 
-        const TestPriceOracle = artifacts.require("TestPriceOracle");
-        const testPriceOracle = await TestPriceOracle.new();
-        await defaultCtx.controllerImpl.setPriceOracle(testPriceOracle.address);
-        await updateControllerCache(defaultCtx);
+          const quota = await ctx.quotaStore.currentQuota(wallet);
 
-        // Use up the quota in multiple transfers
-        const transferValue = quota.div(new BN(7));
-        await transferTokenChecked(
-          owner,
-          wallet,
-          "ETH",
-          to,
-          transferValue,
-          "0x"
-        );
+          const TestPriceOracle = artifacts.require("TestPriceOracle");
+          const testPriceOracle = await TestPriceOracle.new();
+          await defaultCtx.controllerImpl.setPriceOracle(
+            testPriceOracle.address
+          );
+          await updateControllerCache(defaultCtx);
 
-        await transferTokenChecked(
-          owner,
-          wallet,
-          "ETH",
-          to,
-          transferValue,
-          "0x"
-        );
+          // Use up the quota in multiple transfers
+          const transferValue = withQuota
+            ? quota.div(new BN(7))
+            : toAmount("1");
+          await transferTokenChecked(
+            owner,
+            wallet,
+            "ETH",
+            to,
+            transferValue,
+            "0x"
+          );
 
-        await transferTokenChecked(
-          owner,
-          wallet,
-          "LRC",
-          to,
-          transferValue,
-          "0x",
-          { assetValue: transferValue }
-        );
+          await transferTokenChecked(
+            owner,
+            wallet,
+            "ETH",
+            to,
+            transferValue,
+            "0x"
+          );
 
-        await transferTokenChecked(
-          owner,
-          wallet,
-          "LRC",
-          to,
-          transferValue,
-          "0x",
-          { assetValue: transferValue }
-        );
-      });
+          await transferTokenChecked(
+            owner,
+            wallet,
+            "LRC",
+            to,
+            transferValue,
+            "0x",
+            { assetValue: transferValue }
+          );
+
+          await transferTokenChecked(
+            owner,
+            wallet,
+            "LRC",
+            to,
+            transferValue,
+            "0x",
+            { assetValue: transferValue }
+          );
+        }
+      );
     });
   });
 


### PR DESCRIPTION
Reverted back to internal functions + caching `Quota`. A bit more functions and bloat, but caching `Quota` saves a nice 4,000 gas so seems worth it.

There's a ~3,000 gas overhead by having to call `currentQuota` to check if the quota is enabled, and so if the quota is enabled this is just extra cost. (in some cases `currentQuota` only needs to do 1 SLOAD in some cases when `pendingUntil` and either `currentQuota` or `pendingQuota` or stared in the same slot, but this would only work sometimes and I haven't found a clean way to do that yet).

But the if the quota is disabled there are of course savings, and this ends up being ~25,000 gas in the benchmark (~5,000 gas saved by being able to skip the whitelist check, ~5,000 gas saved by not having to get the token value from the price oracle, and the remaining ~15,000 gas by not having to call `checkAndAddToSpent`). The benchmark now also uses `PriceCacheStore` to read cached prices from an oracle. So when using e.g. the uniswap price oracle direclty without caching the savings would be a bit larger.

Benchmark now tests both with and without quota enabled.