### PR TITLE
[hebao 1.2] Start using immutable

### DIFF
--- a/packages/hebao_v1/contracts/base/Controller.sol
+++ b/packages/hebao_v1/contracts/base/Controller.sol
@@ -10,6 +10,15 @@ import "../iface/ModuleRegistry.sol";
 /// @author Daniel Wang - <daniel@loopring.org>
 abstract contract Controller
 {
-    ModuleRegistry public moduleRegistry;
-    address        public walletFactory;
+    function moduleRegistry()
+        external
+        view
+        virtual
+        returns (ModuleRegistry);
+
+    function walletFactory()
+        external
+        view
+        virtual
+        returns (address);
 }

--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -18,13 +18,15 @@ import "../thirdparty/ens/BaseENSManager.sol";
 /// @author Daniel Wang - <daniel@loopring.org>
 contract ControllerImpl is Claimable, Controller
 {
+    HashStore           public immutable hashStore;
+    QuotaStore          public immutable quotaStore;
+    SecurityStore       public immutable securityStore;
+    WhitelistStore      public immutable whitelistStore;
+    ModuleRegistry      public immutable override moduleRegistry;
+    address             public override  walletFactory;
     address             public collectTo;
     BaseENSManager      public immutable ensManager;
     PriceOracle         public priceOracle;
-    HashStore           public hashStore;
-    QuotaStore          public quotaStore;
-    SecurityStore       public securityStore;
-    WhitelistStore      public whitelistStore;
 
     // Make sure this value if false in production env.
     // Ideally we can use chainid(), but there is a bug in truffle so testing is buggy:
@@ -37,6 +39,10 @@ contract ControllerImpl is Claimable, Controller
     );
 
     constructor(
+        HashStore         _hashStore,
+        QuotaStore        _quotaStore,
+        SecurityStore     _securityStore,
+        WhitelistStore    _whitelistStore,
         ModuleRegistry    _moduleRegistry,
         address           _collectTo,
         BaseENSManager    _ensManager,
@@ -44,6 +50,10 @@ contract ControllerImpl is Claimable, Controller
         bool              _allowChangingWalletFactory
         )
     {
+        hashStore = _hashStore;
+        quotaStore = _quotaStore;
+        securityStore = _securityStore;
+        whitelistStore = _whitelistStore;
         moduleRegistry = _moduleRegistry;
 
         require(_collectTo != address(0), "ZERO_ADDRESS");
@@ -52,28 +62,6 @@ contract ControllerImpl is Claimable, Controller
         ensManager = _ensManager;
         priceOracle = _priceOracle;
         allowChangingWalletFactory = _allowChangingWalletFactory;
-    }
-
-    function initStores(
-        HashStore         _hashStore,
-        QuotaStore        _quotaStore,
-        SecurityStore     _securityStore,
-        WhitelistStore    _whitelistStore
-        )
-        external
-        onlyOwner
-    {
-        // Make sure this function can only invoked once.
-        require(
-            address(hashStore) == address(0) &&
-            address(_hashStore) != address(0),
-            "INVALID_INIT"
-        );
-
-        hashStore = _hashStore;
-        quotaStore = _quotaStore;
-        securityStore = _securityStore;
-        whitelistStore = _whitelistStore;
     }
 
     function initWalletFactory(address _walletFactory)

--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -19,7 +19,7 @@ import "../thirdparty/ens/BaseENSManager.sol";
 contract ControllerImpl is Claimable, Controller
 {
     address             public collectTo;
-    BaseENSManager      public ensManager;
+    BaseENSManager      public immutable ensManager;
     PriceOracle         public priceOracle;
     HashStore           public hashStore;
     QuotaStore          public quotaStore;
@@ -29,7 +29,7 @@ contract ControllerImpl is Claimable, Controller
     // Make sure this value if false in production env.
     // Ideally we can use chainid(), but there is a bug in truffle so testing is buggy:
     // https://github.com/trufflesuite/ganache/issues/1643
-    bool                public allowChangingWalletFactory;
+    bool                public immutable allowChangingWalletFactory;
 
     event AddressChanged(
         string   name,

--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -21,9 +21,9 @@ contract AddOfficialGuardianModule is BaseModule {
         ControllerImpl   _controller,
         address          _officialGuardian
         )
+        BaseModule(_controller)
     {
         controller_ = _controller;
-        _updateControllerCache(_controller);
         officialGuardian = _officialGuardian;
     }
 
@@ -42,7 +42,7 @@ contract AddOfficialGuardianModule is BaseModule {
     {
         address payable wallet = msg.sender;
 
-        SecurityStore ss = controllerCache.securityStore;
+        SecurityStore ss = securityStore;
         require(
             ss.numGuardians(wallet, true /* with pending */) == 0,
             "NOT_THE_FIRST_GUARDIAN"

--- a/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/aux/AddOfficialGuardianModule.sol
@@ -14,8 +14,8 @@ import "../base/BaseModule.sol";
 ///
 /// @author Daniel Wang - <daniel@loopring.org>
 contract AddOfficialGuardianModule is BaseModule {
-    ControllerImpl private controller_;
-    address        public  officialGuardian;
+    ControllerImpl private immutable controller_;
+    address        public  immutable officialGuardian;
 
     constructor(
         ControllerImpl   _controller,
@@ -23,7 +23,7 @@ contract AddOfficialGuardianModule is BaseModule {
         )
     {
         controller_ = _controller;
-        updateControllerCache();
+        _updateControllerCache(_controller);
         officialGuardian = _officialGuardian;
     }
 

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -27,17 +27,18 @@ abstract contract BaseModule is Module
 
     struct ControllerCache
     {
-        ModuleRegistry   moduleRegistry;
-        SecurityStore    securityStore;
-        WhitelistStore   whitelistStore;
-        QuotaStore       quotaStore;
-        HashStore        hashStore;
         PriceOracle      priceOracle;
-        address          walletFactory;
         address          collectTo;
     }
 
     ControllerCache public controllerCache;
+
+    ModuleRegistry public immutable moduleRegistry;
+    SecurityStore  public immutable securityStore;
+    WhitelistStore public immutable whitelistStore;
+    QuotaStore     public immutable quotaStore;
+    HashStore      public immutable hashStore;
+    address        public immutable walletFactory;
 
     function logicalSender()
         internal
@@ -66,6 +67,18 @@ abstract contract BaseModule is Module
     {
         require(addr != address(0) && !addr.isContract(), "INVALID_OWNER");
         _;
+    }
+
+    constructor(ControllerImpl _controller)
+    {
+        moduleRegistry = _controller.moduleRegistry();
+        securityStore = _controller.securityStore();
+        whitelistStore = _controller.whitelistStore();
+        quotaStore = _controller.quotaStore();
+        hashStore = _controller.hashStore();
+        walletFactory = _controller.walletFactory();
+
+        _updateControllerCache(_controller);
     }
 
     function controller()
@@ -120,13 +133,7 @@ abstract contract BaseModule is Module
     function _updateControllerCache(ControllerImpl _controller)
         internal
     {
-        controllerCache.moduleRegistry = _controller.moduleRegistry();
-        controllerCache.securityStore = _controller.securityStore();
-        controllerCache.whitelistStore = _controller.whitelistStore();
-        controllerCache.quotaStore = _controller.quotaStore();
-        controllerCache.hashStore = _controller.hashStore();
         controllerCache.priceOracle = _controller.priceOracle();
-        controllerCache.walletFactory = _controller.walletFactory();
         controllerCache.collectTo = _controller.collectTo();
     }
 
@@ -253,7 +260,7 @@ abstract contract BaseModule is Module
                 controllerCache.priceOracle.tokenValue(gasToken, gasCost);
 
             if (value > 0) {
-              controllerCache.quotaStore.checkAndAddToSpent(wallet, value);
+              quotaStore.checkAndAddToSpent(wallet, value);
             }
         }
 

--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -112,7 +112,14 @@ abstract contract BaseModule is Module
     function updateControllerCache()
         public
     {
-        ControllerImpl _controller = controller();
+        _updateControllerCache(controller());
+    }
+
+    // ===== internal & private methods =====
+
+    function _updateControllerCache(ControllerImpl _controller)
+        internal
+    {
         controllerCache.moduleRegistry = _controller.moduleRegistry();
         controllerCache.securityStore = _controller.securityStore();
         controllerCache.whitelistStore = _controller.whitelistStore();
@@ -122,8 +129,6 @@ abstract contract BaseModule is Module
         controllerCache.walletFactory = _controller.walletFactory();
         controllerCache.collectTo = _controller.collectTo();
     }
-
-    // ===== internal & private methods =====
 
     /// @dev Binds all methods to the given wallet.
     function bindMethods(address wallet)

--- a/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
+++ b/packages/hebao_v1/contracts/modules/base/MetaTxAware.sol
@@ -21,7 +21,7 @@ abstract contract MetaTxAware
     using AddressUtil for address;
     using BytesUtil   for bytes;
 
-    address public metaTxForwarder;
+    address public immutable metaTxForwarder;
 
     constructor(address _metaTxForwarder)
     {

--- a/packages/hebao_v1/contracts/modules/base/MetaTxModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/MetaTxModule.sol
@@ -20,8 +20,11 @@ abstract contract MetaTxModule is MetaTxAware, BaseModule
 {
     using SignatureUtil for bytes32;
 
-    constructor(address _metaTxForwarder)
+    constructor(
+        ControllerImpl _controller,
+        address        _metaTxForwarder)
         MetaTxAware(_metaTxForwarder)
+        BaseModule(_controller)
     {
     }
 

--- a/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
+++ b/packages/hebao_v1/contracts/modules/core/ERC1271Module.sol
@@ -47,7 +47,7 @@ abstract contract ERC1271Module is ERC1271, SecurityModule
         returns (bytes4 magicValue)
     {
         address wallet = msg.sender;
-        if (controllerCache.securityStore.isLocked(wallet)) {
+        if (securityStore.isLocked(wallet)) {
             return 0;
         }
 

--- a/packages/hebao_v1/contracts/modules/core/FinalCoreModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/FinalCoreModule.sol
@@ -18,9 +18,9 @@ contract FinalCoreModule is
     ControllerImpl private immutable controller_;
 
     constructor(ControllerImpl _controller)
+        ForwarderModule(_controller)
     {
         controller_ = _controller;
-        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/core/FinalCoreModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/FinalCoreModule.sol
@@ -15,16 +15,12 @@ contract FinalCoreModule is
     ERC1271Module,
     ForwarderModule
 {
-    ControllerImpl private controller_;
+    ControllerImpl private immutable controller_;
 
     constructor(ControllerImpl _controller)
     {
-        FORWARDER_DOMAIN_SEPARATOR = EIP712.hash(
-            EIP712.Domain("ForwarderModule", "1.2.0", address(this))
-        );
-
         controller_ = _controller;
-        updateControllerCache();
+        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -23,8 +23,8 @@ abstract contract ForwarderModule is SecurityModule
     using MathUint      for uint;
     using SignatureUtil for bytes32;
 
-    uint    public constant MAX_REIMBURSTMENT_OVERHEAD = 165000;
-    bytes32 public FORWARDER_DOMAIN_SEPARATOR;
+    uint    public constant  MAX_REIMBURSTMENT_OVERHEAD = 165000;
+    bytes32 public immutable FORWARDER_DOMAIN_SEPARATOR;
 
     bytes32 public constant META_TX_TYPEHASH = keccak256(
         "MetaTx(address from,address to,uint256 nonce,bytes32 txAwareHash,address gasToken,uint256 gasPrice,uint256 gasLimit,bytes data)"
@@ -54,6 +54,9 @@ abstract contract ForwarderModule is SecurityModule
     constructor()
         SecurityModule(address(this))
     {
+        FORWARDER_DOMAIN_SEPARATOR = EIP712.hash(
+            EIP712.Domain("ForwarderModule", "1.2.0", address(this))
+        );
     }
 
     function validateMetaTx(

--- a/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
@@ -17,7 +17,7 @@ contract FinalSecurityModule is
     InheritanceModule,
     WhitelistModule
 {
-    ControllerImpl private controller_;
+    ControllerImpl private immutable controller_;
 
     constructor(
         ControllerImpl _controller,
@@ -29,7 +29,7 @@ contract FinalSecurityModule is
         WhitelistModule()
     {
         controller_ = _controller;
-        updateControllerCache();
+        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/FinalSecurityModule.sol
@@ -23,13 +23,12 @@ contract FinalSecurityModule is
         ControllerImpl _controller,
         address        _metaTxForwarder
         )
-        SecurityModule(_metaTxForwarder)
+        SecurityModule(_controller, _metaTxForwarder)
         GuardianModule()
         InheritanceModule()
         WhitelistModule()
     {
         controller_ = _controller;
-        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -16,7 +16,7 @@ abstract contract GuardianModule is SecurityModule
     using AddressUtil   for address;
     using SignedRequest for ControllerImpl;
 
-    bytes32 public GUARDIAN_DOMAIN_SEPERATOR;
+    bytes32 public immutable GUARDIAN_DOMAIN_SEPERATOR;
 
     uint public constant MAX_GUARDIANS           = 10;
     uint public constant GUARDIAN_PENDING_PERIOD = 7 days;

--- a/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/GuardianModule.sol
@@ -124,7 +124,7 @@ abstract contract GuardianModule is SecurityModule
         require(
             _logicalSender == wallet ||
             _logicalSender == Wallet(wallet).owner() ||
-            controllerCache.securityStore.isGuardian(wallet, _logicalSender, false),
+            securityStore.isGuardian(wallet, _logicalSender, false),
             "NOT_FROM_WALLET_OR_OWNER_OR_GUARDIAN"
         );
 
@@ -196,7 +196,7 @@ abstract contract GuardianModule is SecurityModule
             )
         );
 
-        SecurityStore ss = controllerCache.securityStore;
+        SecurityStore ss = securityStore;
         if (ss.isGuardian(request.wallet, newOwner, true)) {
             ss.removeGuardian(request.wallet, newOwner, block.timestamp, true);
         }
@@ -229,7 +229,7 @@ abstract contract GuardianModule is SecurityModule
         require(guardian != wallet, "INVALID_ADDRESS");
         require(guardian != address(0), "ZERO_ADDRESS");
 
-        SecurityStore ss = controllerCache.securityStore;
+        SecurityStore ss = securityStore;
         uint numGuardians = ss.numGuardians(wallet, true);
         require(numGuardians < MAX_GUARDIANS, "TOO_MANY_GUARDIANS");
 
@@ -250,7 +250,7 @@ abstract contract GuardianModule is SecurityModule
         private
     {
         uint validUntil = block.timestamp + pendingPeriod;
-        SecurityStore ss = controllerCache.securityStore;
+        SecurityStore ss = securityStore;
         validUntil = ss.removeGuardian(wallet, guardian, validUntil, alwaysOverride);
         emit GuardianRemoved(wallet, guardian, validUntil);
     }

--- a/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/InheritanceModule.sol
@@ -33,7 +33,7 @@ abstract contract InheritanceModule is SecurityModule
         view
         returns (address _inheritor, uint _effectiveTimestamp)
     {
-        return controllerCache.securityStore.inheritor(wallet);
+        return securityStore.inheritor(wallet);
     }
 
     function inherit(
@@ -45,7 +45,7 @@ abstract contract InheritanceModule is SecurityModule
         eligibleWalletOwner(newOwner)
         notWalletOwner(wallet, newOwner)
     {
-        SecurityStore ss = controllerCache.securityStore;
+        SecurityStore ss = securityStore;
         (address _inheritor, uint _effectiveTimestamp) = ss.inheritor(wallet);
 
         require(_effectiveTimestamp != 0 && _inheritor != address(0), "NO_INHERITOR");
@@ -78,7 +78,7 @@ abstract contract InheritanceModule is SecurityModule
             "INVALID_INHERITOR_OR_WAITING_PERIOD"
         );
 
-        controllerCache.securityStore.setInheritor(wallet, _inheritor, _waitingPeriod);
+        securityStore.setInheritor(wallet, _inheritor, _waitingPeriod);
         emit InheritorChanged(wallet, _inheritor, _waitingPeriod);
     }
 }

--- a/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/SecurityModule.sol
@@ -25,8 +25,11 @@ abstract contract SecurityModule is MetaTxModule
         bool            locked
     );
 
-    constructor(address _metaTxForwarder)
-        MetaTxModule(_metaTxForwarder)
+    constructor(
+        ControllerImpl _controller,
+        address        _metaTxForwarder
+        )
+        MetaTxModule(_controller, _metaTxForwarder)
     {
     }
 
@@ -39,19 +42,19 @@ abstract contract SecurityModule is MetaTxModule
             (_logicalSender == Wallet(wallet).owner() && !_isWalletLocked(wallet)),
              "NOT_FROM_WALLET_OR_OWNER_OR_WALLET_LOCKED"
         );
-        controllerCache.securityStore.touchLastActiveWhenRequired(wallet, TOUCH_GRACE_PERIOD);
+        securityStore.touchLastActiveWhenRequired(wallet, TOUCH_GRACE_PERIOD);
         _;
     }
 
     modifier onlyWalletGuardian(address wallet, address guardian)
     {
-        require(controllerCache.securityStore.isGuardian(wallet, guardian, false), "NOT_GUARDIAN");
+        require(securityStore.isGuardian(wallet, guardian, false), "NOT_GUARDIAN");
         _;
     }
 
     modifier notWalletGuardian(address wallet, address guardian)
     {
-        require(!controllerCache.securityStore.isGuardian(wallet, guardian, false), "IS_GUARDIAN");
+        require(!securityStore.isGuardian(wallet, guardian, false), "IS_GUARDIAN");
         _;
     }
 
@@ -60,7 +63,7 @@ abstract contract SecurityModule is MetaTxModule
     function _lockWallet(address wallet, address by, bool locked)
         internal
     {
-        controllerCache.securityStore.setLock(wallet, locked);
+        securityStore.setLock(wallet, locked);
         emit WalletLocked(wallet, by, locked);
     }
 
@@ -69,7 +72,7 @@ abstract contract SecurityModule is MetaTxModule
         view
         returns (bool)
     {
-        return controllerCache.securityStore.isLocked(wallet);
+        return securityStore.isLocked(wallet);
     }
 
     function _needCheckQuota(

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -15,7 +15,7 @@ abstract contract WhitelistModule is SecurityModule
     using MathUint      for uint;
     using SignedRequest for ControllerImpl;
 
-    bytes32 public WHITELIST_DOMAIN_SEPERATOR;
+    bytes32 public immutable WHITELIST_DOMAIN_SEPERATOR;
 
     uint public constant WHITELIST_PENDING_PERIOD = 1 days;
 

--- a/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
+++ b/packages/hebao_v1/contracts/modules/security/WhitelistModule.sol
@@ -41,7 +41,7 @@ abstract contract WhitelistModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        controllerCache.whitelistStore.addToWhitelist(
+        whitelistStore.addToWhitelist(
             wallet,
             addr,
             block.timestamp.add(WHITELIST_PENDING_PERIOD)
@@ -67,7 +67,7 @@ abstract contract WhitelistModule is SecurityModule
             )
         );
 
-        controllerCache.whitelistStore.addToWhitelist(
+        whitelistStore.addToWhitelist(
             request.wallet,
             addr,
             block.timestamp
@@ -82,7 +82,7 @@ abstract contract WhitelistModule is SecurityModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        controllerCache.whitelistStore.removeFromWhitelist(wallet, addr);
+        whitelistStore.removeFromWhitelist(wallet, addr);
     }
 
     function removeFromWhitelistWA(
@@ -104,7 +104,7 @@ abstract contract WhitelistModule is SecurityModule
             )
         );
 
-        controllerCache.whitelistStore.removeFromWhitelist(request.wallet, addr);
+        whitelistStore.removeFromWhitelist(request.wallet, addr);
     }
 
     function getWhitelist(address wallet)
@@ -115,7 +115,7 @@ abstract contract WhitelistModule is SecurityModule
             uint[]    memory effectiveTimes
         )
     {
-        return controllerCache.whitelistStore.whitelist(wallet);
+        return whitelistStore.whitelist(wallet);
     }
 
     function isWhitelisted(
@@ -128,6 +128,6 @@ abstract contract WhitelistModule is SecurityModule
             uint effectiveTime
         )
     {
-        return controllerCache.whitelistStore.isWhitelisted(wallet, addr);
+        return whitelistStore.isWhitelisted(wallet, addr);
     }
 }

--- a/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/BaseTransferModule.sol
@@ -89,6 +89,6 @@ abstract contract BaseTransferModule is SecurityModule
         view
         returns (bool)
     {
-        return controllerCache.whitelistStore.isDappOrWhitelisted(wallet, to);
+        return whitelistStore.isDappOrWhitelisted(wallet, to);
     }
 }

--- a/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
@@ -12,7 +12,7 @@ import "./TransferModule.sol";
 ///      by wallet creation.
 contract FinalTransferModule is TransferModule
 {
-    ControllerImpl private controller_;
+    ControllerImpl private immutable controller_;
 
     constructor(
         ControllerImpl _controller,
@@ -22,7 +22,7 @@ contract FinalTransferModule is TransferModule
         TransferModule()
     {
         controller_ = _controller;
-        updateControllerCache();
+        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/FinalTransferModule.sol
@@ -18,11 +18,10 @@ contract FinalTransferModule is TransferModule
         ControllerImpl _controller,
         address        _metaTxForwarder
         )
-        SecurityModule(_metaTxForwarder)
+        SecurityModule(_controller, _metaTxForwarder)
         TransferModule()
     {
         controller_ = _controller;
-        _updateControllerCache(_controller);
     }
 
     function controller()

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -87,7 +87,7 @@ abstract contract TransferModule is BaseTransferModule
         txAwareHashNotAllowed()
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
     {
-        QuotaStore qs = controllerCache.quotaStore;
+        QuotaStore qs = quotaStore;
         if (_needCheckQuota(qs, wallet, amount) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(qs, wallet, token, amount);
         }
@@ -134,7 +134,7 @@ abstract contract TransferModule is BaseTransferModule
         onlyFromWalletOrOwnerWhenUnlocked(wallet)
         returns (bytes memory returnData)
     {
-        QuotaStore qs = controllerCache.quotaStore;
+        QuotaStore qs = quotaStore;
         if (_needCheckQuota(qs, wallet, value) && !isTargetWhitelisted(wallet, to)) {
             _updateQuota(qs, wallet, address(0), value);
         }
@@ -181,7 +181,7 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        QuotaStore qs = controllerCache.quotaStore;
+        QuotaStore qs = quotaStore;
         if (_needCheckQuota(qs, wallet, additionalAllowance) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(qs, wallet, token, additionalAllowance);
@@ -229,7 +229,7 @@ abstract contract TransferModule is BaseTransferModule
     {
         uint additionalAllowance = approveInternal(wallet, token, to, amount);
 
-        QuotaStore qs = controllerCache.quotaStore;
+        QuotaStore qs = quotaStore;
         if (_needCheckQuota(qs, wallet, additionalAllowance.add(value)) &&
             !isTargetWhitelisted(wallet, to)) {
             _updateQuota(qs, wallet, token, additionalAllowance);
@@ -282,9 +282,9 @@ abstract contract TransferModule is BaseTransferModule
             uint available
         )
     {
-        total = controllerCache.quotaStore.currentQuota(wallet);
-        spent = controllerCache.quotaStore.spentQuota(wallet);
-        available = controllerCache.quotaStore.availableQuota(wallet);
+        total = quotaStore.currentQuota(wallet);
+        spent = quotaStore.spentQuota(wallet);
+        available = quotaStore.availableQuota(wallet);
     }
 
     function _changeQuota(
@@ -294,7 +294,7 @@ abstract contract TransferModule is BaseTransferModule
         )
         private
     {
-        QuotaStore qs = controllerCache.quotaStore;
+        QuotaStore qs = quotaStore;
         uint _currentQuota = qs.currentQuota(wallet);
         require(_currentQuota != newQuota, "SAME_VALUE");
 

--- a/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
+++ b/packages/hebao_v1/contracts/modules/transfers/TransferModule.sol
@@ -17,7 +17,7 @@ abstract contract TransferModule is BaseTransferModule
     using MathUint      for uint;
     using SignedRequest for ControllerImpl;
 
-    bytes32 public TRANSFER_DOMAIN_SEPERATOR;
+    bytes32 public immutable TRANSFER_DOMAIN_SEPERATOR;
 
     uint public constant QUOTA_PENDING_PERIOD = 1 days;
 

--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -17,9 +17,9 @@ import "./SecurityStore_1_0_2.sol";
 /// @author Daniel Wang - <daniel@loopring.org>
 
 contract UpgraderModule is BaseModule {
-    ControllerImpl private controller_;
+    ControllerImpl private immutable controller_;
 
-    address    public walletImplementation;
+    address    public immutable walletImplementation;
     address[]  public modulesToRemove;
     address[]  public modulesToAdd;
 
@@ -36,7 +36,7 @@ contract UpgraderModule is BaseModule {
         )
     {
         controller_ = _controller;
-        updateControllerCache();
+        _updateControllerCache(_controller);
         walletImplementation = _walletImplementation;
         modulesToAdd = _modulesToAdd;
         modulesToRemove = _modulesToRemove;

--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -23,8 +23,8 @@ contract UpgraderModule is BaseModule {
     address[]  public modulesToRemove;
     address[]  public modulesToAdd;
 
-    SecurityStore_1_0_2 oldSecurityStore;
-    SecurityStore       newSecurityStore;
+    SecurityStore_1_0_2 immutable oldSecurityStore;
+    SecurityStore       immutable newSecurityStore;
 
     constructor(
         ControllerImpl   _controller,

--- a/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
+++ b/packages/hebao_v1/contracts/modules/upgrade/UpgraderModule.sol
@@ -34,9 +34,9 @@ contract UpgraderModule is BaseModule {
         address          _oldSecurityStore,
         address          _newSecurityStore
         )
+        BaseModule(_controller)
     {
         controller_ = _controller;
-        _updateControllerCache(_controller);
         walletImplementation = _walletImplementation;
         modulesToAdd = _modulesToAdd;
         modulesToRemove = _modulesToRemove;

--- a/packages/hebao_v1/contracts/price/KyberNetworkPriceOracle.sol
+++ b/packages/hebao_v1/contracts/price/KyberNetworkPriceOracle.sol
@@ -25,7 +25,7 @@ abstract contract KyberNetworkProxy {
 /// @dev Returns the value in Ether for any given ERC20 token.
 contract KyberNetworkPriceOracle is PriceOracle
 {
-    KyberNetworkProxy kyber;
+    KyberNetworkProxy immutable kyber;
     address constant private ethTokenInKyber = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
     constructor(KyberNetworkProxy _kyber)

--- a/packages/hebao_v1/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v1/contracts/price/UniswapV2PriceOracle.sol
@@ -14,8 +14,8 @@ contract UniswapV2PriceOracle is PriceOracle
 {
     using MathUint   for uint;
 
-    IUniswapV2Factory factory;
-    address wethAddress;
+    IUniswapV2Factory immutable factory;
+    address immutable wethAddress;
 
     constructor(
         IUniswapV2Factory _factory,

--- a/packages/hebao_v1/contracts/test/PriceCacheStore.sol
+++ b/packages/hebao_v1/contracts/test/PriceCacheStore.sol
@@ -17,8 +17,7 @@ contract PriceCacheStore is PriceOracle, OwnerManagable
 
     uint public constant EXPIRY_PERIOD = 7 days;
 
-    PriceOracle oracle;
-    uint expiry;
+    PriceOracle public oracle;
 
     event PriceCached (
         address token,

--- a/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/BaseENSManager.sol
@@ -44,7 +44,7 @@ contract BaseENSManager is IENSManager, OwnerManagable, ENSConsumer {
     // The managed root name
     string public rootName;
     // The managed root node
-    bytes32 public rootNode;
+    bytes32 public immutable rootNode;
     // The address of the ENS resolver
     address public ensResolver;
 

--- a/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/ENSConsumer.sol
@@ -19,7 +19,7 @@ contract ENSConsumer {
     bytes32 public constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
     // the address of the ENS registry
-    address ensRegistry;
+    address immutable ensRegistry;
 
     /**
     * @dev No address should be provided when deploying on Mainnet to avoid storage cost. The

--- a/packages/hebao_v1/contracts/thirdparty/ens/ENSReverseRegistrarImpl.sol
+++ b/packages/hebao_v1/contracts/thirdparty/ens/ENSReverseRegistrarImpl.sol
@@ -10,8 +10,8 @@ contract ENSReverseRegistrarImpl is ENSReverseRegistrar {
     // namehash('addr.reverse')
     bytes32 constant ADDR_REVERSE_NODE = 0x91d1777781884d03a6757a803996e38de2a42967fb37eeaca72729271025a9e2;
 
-    ENSRegistry public ens;
-    ENSResolver public defaultResolver;
+    ENSRegistry public immutable ens;
+    ENSResolver public immutable defaultResolver;
 
     /**
      * @dev Constructor

--- a/packages/hebao_v1/migrations/7_controller.js
+++ b/packages/hebao_v1/migrations/7_controller.js
@@ -22,21 +22,15 @@ module.exports = function(deployer, network, accounts) {
     await deployer.deploy(TestPriceOracle);
     await deployer.deploy(
       ControllerImpl,
+      HashStore.address,
+      QuotaStore.address,
+      SecurityStore.address,
+      WhitelistStore.address,
       ModuleRegistryImpl.address,
       collecTo,
       ensManagerAddr,
       TestPriceOracle.address,
       true
     );
-
-    const controllerImpl = await ControllerImpl.deployed();
-    return Promise.all([
-      controllerImpl.initStores(
-        HashStore.address,
-        QuotaStore.address,
-        SecurityStore.address,
-        WhitelistStore.address
-      )
-    ]);
   });
 };

--- a/packages/hebao_v1/test/helpers/TestUtils.ts
+++ b/packages/hebao_v1/test/helpers/TestUtils.ts
@@ -74,7 +74,6 @@ export async function createContext(context?: Context) {
     true
   );
 
-  await walletFactory.initMetaTxForwarder(context.finalCoreModule.address);
   await context.baseENSManager.addManager(walletFactory.address);
   await context.controllerImpl.initWalletFactory(walletFactory.address);
   context.walletFactory = walletFactory;


### PR DESCRIPTION
So I found `immutable` exists since solidity 0.7 while reading the solidity github:
- https://solidity.readthedocs.io/en/v0.7.4/contracts.html?highlight=immutable#constant-and-immutable-state-variables

Allows immutable simple data to be initialized in the constructor without using storage, so as cheap to read as constants most times. So we could pass in constant values in the constructor with this without loss of efficiency (after we stopped doing that until recently...).

Maybe some other cases it could be used as well. 

Does it make sense to just simply cache the store addresses in `immutable` vars in modules? Doesn't seem likely we can just update the stores used in the modules without any upgrading. @dong77 

Same for `WalletFactory`, easy to replace the contract when needed so not that important that those ENS contracts would be hard-coded I think.