### PR TITLE
[hebao 1.2] Fix skipQuota

### DIFF
--- a/packages/hebao_v1/contracts/modules/base/BaseModule.sol
+++ b/packages/hebao_v1/contracts/modules/base/BaseModule.sol
@@ -222,21 +222,18 @@ abstract contract BaseModule is Module
         address     recipient,
         address     gasToken,
         uint        gasPrice,
-        uint        gasAmount,
-        bool        skipQuota
+        uint        gasAmount
         )
         internal
     {
         uint gasCost = gasAmount.mul(gasPrice);
 
-        if (!skipQuota) {
-            quotaStore.checkAndAddToSpent(
-                wallet,
-                gasToken,
-                gasAmount,
-                priceOracle
-            );
-        }
+        quotaStore.checkAndAddToSpent(
+            wallet,
+            gasToken,
+            gasAmount,
+            priceOracle
+        );
 
         transactTokenTransfer(wallet, gasToken, recipient, gasCost);
     }

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -145,8 +145,7 @@ abstract contract ForwarderModule is SecurityModule
 
         // The trick is to append the really logical message sender and the
         // transaction-aware hash to the end of the call data.
-        bytes memory returnData;
-        (success, returnData) = metaTx.to.call{gas : metaTx.gasLimit, value : 0}(
+        (success, ) = metaTx.to.call{gas : metaTx.gasLimit, value : 0}(
             abi.encodePacked(data, metaTx.from, metaTx.txAwareHash)
         );
 

--- a/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
+++ b/packages/hebao_v1/contracts/modules/core/ForwarderModule.sol
@@ -181,18 +181,6 @@ abstract contract ForwarderModule is SecurityModule
                 MAX_REIMBURSTMENT_OVERHEAD + // near-worst case cost
                 2300; // 2*SLOAD+1*CALL = 2*800+1*700=2300
 
-            // Do not consume quota when the wallet is used to create itself successfully.
-            bool skipQuota = metaTx.to == walletFactory &&
-                (data.toBytes4(0) == WalletFactory.createWallet.selector ||
-                 data.toBytes4(0) == WalletFactory.createWallet2.selector) &&
-                abi.decode(returnData, (address)) == metaTx.from &&
-                success;
-
-            // MAX_REIMBURSTMENT_OVERHEAD covers an ERC20 transfer and a quota update.
-            if (skipQuota) {
-                gasUsed -= 48000;
-            }
-
             if (metaTx.gasToken == address(0)) {
                 gasUsed -= 15000; // diff between an regular ERC20 transfer and an ETH send
             }
@@ -204,8 +192,7 @@ abstract contract ForwarderModule is SecurityModule
                 feeCollector,
                 metaTx.gasToken,
                 metaTx.gasPrice,
-                gasToReimburse,
-                skipQuota
+                gasToReimburse
             );
         }
 

--- a/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
+++ b/packages/hebao_v1/contracts/modules/core/WalletFactory.sol
@@ -83,7 +83,6 @@ contract WalletFactory
     }
 
     /// @dev Create a new wallet by deploying a proxy.
-    ///      This function supports tx-aware hash.
     /// @param _owner The wallet's owner.
     /// @param _salt A salt to adjust address.
     /// @param _ensLabel The ENS subdomain to register, use "" to skip.
@@ -128,7 +127,6 @@ contract WalletFactory
     }
 
     /// @dev Create a new wallet by using a pre-deployed blank.
-    ///      This function supports tx-aware hash.
     /// @param _owner The wallet's owner.
     /// @param _blank The address of the blank to use.
     /// @param _ensLabel The ENS subdomain to register, use "" to skip.
@@ -276,9 +274,6 @@ contract WalletFactory
             _ensRegisterReverse,
             keccak256(abi.encode(_modules))
         );
-        // txAwareHash replay attack is impossible because the same wallet can only be created once.
-        // bytes32 txAwareHash_ = txAwareHash();
-        // require(txAwareHash_ == 0 || txAwareHash_ == signHash, "INVALID_TX_AWARE_HASH");
 
         bytes32 signHash = EIP712.hashPacked(DOMAIN_SEPERATOR, encodedRequest);
         require(signHash.verifySignature(_owner, _signature), "INVALID_SIGNATURE");


### PR DESCRIPTION
#1995

We also can't allow just any call to `createWallet`, otherwise the wallet can be used to create other wallets successfully just with the signature of the owner without quota.

I think we could also just remove `skipQuota` all together because by default the quota isn't used now, and this also doesn't save that much gas because of that.