### PR TITLE
[protocol 3.6] Circuit fixes

### DIFF
--- a/packages/loopring_v3/circuit/Circuits/AmmUpdateCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/AmmUpdateCircuit.h
@@ -107,7 +107,7 @@ class AmmUpdateCircuit : public BaseTransactionCircuit
         balance.generate_r1cs_constraints(true);
 
         // Increase the nonce
-        nonce_after.generate_r1cs_witness();
+        nonce_after.generate_r1cs_constraints();
         // Increase the number of conditional transactions
         numConditionalTransactionsAfter.generate_r1cs_constraints();
     }

--- a/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
@@ -384,15 +384,15 @@ class TransactionGadget : public GadgetT
             pb,
             protocolBalancesRoot,
             tx.getArrayOutput(TXV_BALANCE_A_S_ADDRESS),
-            {state.pool.balanceB.balance, constants._0, constants.emptyStorage},
-            {tx.getOutput(TXV_BALANCE_P_B_BALANCE), constants._0, constants.emptyStorage},
+            {state.pool.balanceB.balance, state.pool.balanceB.weightAMM, state.pool.balanceB.storageRoot},
+            {tx.getOutput(TXV_BALANCE_P_B_BALANCE), state.pool.balanceB.weightAMM, state.pool.balanceB.storageRoot},
             FMT(prefix, ".updateBalanceB_P")),
           updateBalanceA_P(
             pb,
             updateBalanceB_P.result(),
             tx.getArrayOutput(TXV_BALANCE_B_S_ADDRESS),
-            {state.pool.balanceA.balance, constants._0, constants.emptyStorage},
-            {tx.getOutput(TXV_BALANCE_P_A_BALANCE), constants._0, constants.emptyStorage},
+            {state.pool.balanceA.balance, state.pool.balanceA.weightAMM, state.pool.balanceA.storageRoot},
+            {tx.getOutput(TXV_BALANCE_P_A_BALANCE), state.pool.balanceA.weightAMM, state.pool.balanceA.storageRoot},
             FMT(prefix, ".updateBalanceA_P"))
 
     {

--- a/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
@@ -62,7 +62,7 @@ class SelectTransactionGadget : public BaseTransactionCircuit
             {
                 variables.push_back(transactions[i]->getOutput(uPair.first));
             }
-            uSelects.emplace_back(pb, selector, variables, FMT(annotation_prefix, ".uSelects"));
+            uSelects.emplace_back(pb, state.constants, selector, variables, FMT(annotation_prefix, ".uSelects"));
 
             // Set the output variable
             setOutput(uPair.first, uSelects.back().result());
@@ -77,7 +77,7 @@ class SelectTransactionGadget : public BaseTransactionCircuit
             {
                 variables.push_back(transactions[i]->getArrayOutput(aPair.first));
             }
-            aSelects.emplace_back(pb, selector, variables, FMT(annotation_prefix, ".aSelects"));
+            aSelects.emplace_back(pb, state.constants, selector, variables, FMT(annotation_prefix, ".aSelects"));
 
             // Set the output variable
             setArrayOutput(aPair.first, aSelects.back().result());
@@ -98,7 +98,7 @@ class SelectTransactionGadget : public BaseTransactionCircuit
                 variables.push_back(da);
                 // std::cout << "da size: " << variables.back().size() << std::endl;
             }
-            publicDataSelects.emplace_back(pb, selector, variables, FMT(annotation_prefix, ".publicDataSelects"));
+            publicDataSelects.emplace_back(pb, state.constants, selector, variables, FMT(annotation_prefix, ".publicDataSelects"));
         }
     }
 

--- a/packages/loopring_v3/circuit/Gadgets/AccountGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/AccountGadgets.h
@@ -309,10 +309,8 @@ class DynamicBalanceGadget : public DynamicVariableGadget
       ProtoboardT &pb,
       const VariableT &balance,
       const std::string &prefix)
-        : DynamicVariableGadget(pb, prefix)
+        : DynamicVariableGadget(pb, balance, prefix)
     {
-        add(balance);
-        allowGeneratingWitness = false;
     }
 
     DynamicBalanceGadget( //

--- a/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
@@ -1797,6 +1797,7 @@ class SelectGadget : public GadgetT
 
     SelectGadget(
       ProtoboardT &pb,
+      const Constants &_constants,
       const VariableArrayT &selector,
       const std::vector<VariableT> &values,
       const std::string &prefix)
@@ -1806,7 +1807,7 @@ class SelectGadget : public GadgetT
         for (unsigned int i = 0; i < values.size(); i++)
         {
             results.emplace_back(TernaryGadget(
-              pb, selector[i], values[i], (i == 0) ? values[0] : results.back().result(), FMT(prefix, ".results")));
+              pb, selector[i], values[i], (i == 0) ? _constants._0 : results.back().result(), FMT(prefix, ".results")));
         }
     }
 
@@ -1841,6 +1842,7 @@ class ArraySelectGadget : public GadgetT
 
     ArraySelectGadget(
       ProtoboardT &pb,
+      const Constants &_constants,
       const VariableArrayT &selector,
       const std::vector<VariableArrayT> &values,
       const std::string &prefix)
@@ -1849,8 +1851,8 @@ class ArraySelectGadget : public GadgetT
         assert(values.size() == selector.size());
         for (unsigned int i = 0; i < values.size(); i++)
         {
-            results.emplace_back(ArrayTernaryGadget(
-              pb, selector[i], values[i], (i == 0) ? values[0] : results.back().result(), FMT(prefix, ".results")));
+            results.emplace_back(
+              pb, selector[i], values[i], (i == 0) ? VariableArrayT(values[0].size(), _constants._0) : results.back().result(), FMT(prefix, ".results"));
         }
     }
 
@@ -2200,7 +2202,7 @@ class PowerGadget : public GadgetT
     UnsafeMulGadget t1;
     SignedAddGadget sum1;
 
-    std::vector<UnsafeAddGadget> bn;
+    std::vector<UnsafeMulGadget> bn;
     std::vector<SignedSubGadget> vn;
     std::vector<MulDivGadget> xn;
     std::vector<SignedMulDivGadget> cn;
@@ -2238,7 +2240,7 @@ class PowerGadget : public GadgetT
         for (unsigned int i = 2; i < iterations; i++)
         {
             bn.emplace_back(
-              pb, i > 2 ? bn.back().result() : constants.fixedBase, constants.fixedBase, FMT(prefix, ".bn"));
+              pb, constants.fixedBase, constants.values[i], FMT(prefix, ".bn"));
             vn.emplace_back(
               pb,
               constants,

--- a/packages/loopring_v3/circuit/main.cpp
+++ b/packages/loopring_v3/circuit/main.cpp
@@ -668,7 +668,7 @@ int main(int argc, char **argv)
         std::cerr << "-exportwitness <block.json> <witness.json>: Exports the "
                      "witness to json (circom)"
                   << std::endl;
-        std::cerr << "-createpk <block.json> <pk.json> <pk.raw>: Creates the "
+        std::cerr << "-createpk <pk.json> <pk.raw>: Creates the "
                      "proving key using a bellman pk"
                   << std::endl;
         std::cerr << "-pk_alt2mcl <pk_alt.raw> <pk_mcl.raw>: Converts the proving "

--- a/packages/loopring_v3/circuit/main.cpp
+++ b/packages/loopring_v3/circuit/main.cpp
@@ -857,7 +857,7 @@ int main(int argc, char **argv)
     Loopring::Circuit *circuit = createCircuit(blockType, blockSize, pb);
     if (config.swapAB)
     {
-        pb.constraint_system.swap_AB_if_beneficial();
+        //pb.constraint_system.swap_AB_if_beneficial();
     }
     pb.constraint_system.constraints.shrink_to_fit();
     pb.values.shrink_to_fit();

--- a/packages/loopring_v3/circuit/test/MathTests.cpp
+++ b/packages/loopring_v3/circuit/test/MathTests.cpp
@@ -1617,7 +1617,7 @@ TEST_CASE("Select", "[SelectGadget]")
         selectorGadget.generate_r1cs_constraints();
         selectorGadget.generate_r1cs_witness();
 
-        SelectGadget selectGadget(pb, selectorGadget.result(), values, "selectGadget");
+        SelectGadget selectGadget(pb, constants, selectorGadget.result(), values, "selectGadget");
         selectGadget.generate_r1cs_constraints();
         selectGadget.generate_r1cs_witness();
 
@@ -1675,7 +1675,7 @@ TEST_CASE("ArraySelect", "[ArraySelectGadget]")
         selectorGadget.generate_r1cs_constraints();
         selectorGadget.generate_r1cs_witness();
 
-        ArraySelectGadget arraySelectGadget(pb, selectorGadget.result(), values, "arraySelectGadget");
+        ArraySelectGadget arraySelectGadget(pb, constants, selectorGadget.result(), values, "arraySelectGadget");
         arraySelectGadget.generate_r1cs_constraints();
         arraySelectGadget.generate_r1cs_witness();
 


### PR DESCRIPTION
Fixed some issues/bugs found while running trusted setup scripts which does some additional checks.

These changes fix the "unconstrained variables" warnings (which isn't always a bug, sometimes just variables that aren't actually used).

Trusted setup scripts still don't work unfortunately because the proving key format was changed after the prover optimizations and my updated code to import the bellman proving key doesn't work yet. Working on that now.