### PR TITLE
[Protocol 3] Allow better processing of 0 deposits

### DIFF
--- a/packages/loopring_v3/contracts/core/impl/libtransactions/DepositTransaction.sol
+++ b/packages/loopring_v3/contracts/core/impl/libtransactions/DepositTransaction.sol
@@ -43,6 +43,9 @@ library DepositTransaction
     {
         // Read in the deposit
         Deposit memory deposit = readTx(data, offset);
+        if (deposit.amount == 0) {
+            return;
+        }
 
         // Process the deposit
         ExchangeData.Deposit memory pendingDeposit = S.pendingDeposits[deposit.to][deposit.tokenID];
@@ -52,11 +55,8 @@ library DepositTransaction
         // This is done to ensure the user can do multiple deposits after each other
         // without invalidating work done by the exchange owner for previous deposit amounts.
 
-        // Also note the original deposit.amount can be zero!
-        if (deposit.amount > 0) {
-            require(pendingDeposit.amount >= deposit.amount, "INVALID_AMOUNT");
-            pendingDeposit.amount = pendingDeposit.amount.sub(deposit.amount);
-        }
+        require(pendingDeposit.amount >= deposit.amount, "INVALID_AMOUNT");
+        pendingDeposit.amount = pendingDeposit.amount.sub(deposit.amount);
 
         // If the deposit was fully consumed, reset it so the storage is freed up
         // and the owner receives a gas refund.


### PR DESCRIPTION
There is small issue with the current code, if a user did two 0-deposits, after we process the first one,the second one is gone onchain so the processing of the second one will fail.