### PR TITLE
[AMM] Fix overflow in isAlmostEqual checks

### DIFF
--- a/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
@@ -55,7 +55,7 @@ library AmmUtil
             return amount == 0;
         } else {
             // Max rounding error for a float24 is 2/100000
-            uint ratio = (amount * 100000) / targetAmount;
+            uint ratio = (uint(amount) * 100000) / uint(targetAmount);
             return (100000 - 2) <= ratio && ratio <= (100000 + 2);
         }
     }
@@ -72,7 +72,7 @@ library AmmUtil
             return amount == 0;
         } else {
             // Max rounding error for a float16 is 5/1000
-            uint ratio = (amount * 1000) / targetAmount;
+            uint ratio = (uint(amount) * 1000) / uint(targetAmount);
             return (1000 - 5) <= ratio && ratio <= (1000 + 5);
         }
     }

--- a/packages/loopring_v3/test/testExchangeAMM.ts
+++ b/packages/loopring_v3/test/testExchangeAMM.ts
@@ -323,8 +323,8 @@ contract("Exchange", (accounts: string[]) => {
           tokenB: "WETH",
           amountS: new BN(web3.utils.toWei("98", "mwei")),
           amountB: new BN(web3.utils.toWei("200", "ether")),
-          balanceS: new BN(web3.utils.toWei("10000", "mwei")),
-          balanceB: new BN(web3.utils.toWei("20000", "ether")),
+          balanceS: new BN(web3.utils.toWei("10000000", "mwei")),
+          balanceB: new BN(web3.utils.toWei("20000000", "ether")),
           feeBips: 0,
           amm: true
         },
@@ -377,8 +377,8 @@ contract("Exchange", (accounts: string[]) => {
           tokenB: "INDA",
           amountS: new BN(web3.utils.toWei("98", "ether")),
           amountB: new BN(web3.utils.toWei("200", "mwei")),
-          balanceS: new BN(web3.utils.toWei("10000", "ether")),
-          balanceB: new BN(web3.utils.toWei("20000", "mwei")),
+          balanceS: new BN(web3.utils.toWei("10000000", "ether")),
+          balanceB: new BN(web3.utils.toWei("20000000", "mwei")),
           feeBips: 0,
           amm: true
         },


### PR DESCRIPTION
`amount` is an uit96, and for big amounts `amount * 100000` is of course bigger than `uint96`, but solidity keeps precision in uint96.