### PR TITLE
[protocol 3.6] Audit feedback

### DIFF
--- a/packages/loopring_v3/circuit/Circuits/AccountUpdateCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/AccountUpdateCircuit.h
@@ -33,7 +33,7 @@ class AccountUpdateCircuit : public BaseTransactionCircuit
     DualVariableGadget type;
 
     // Signature
-    Poseidon_gadget_T<9, 1, 6, 53, 8, 1> hash;
+    Poseidon_8 hash;
 
     // Validate
     OwnerValidGadget ownerValid;

--- a/packages/loopring_v3/circuit/Circuits/AccountUpdateCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/AccountUpdateCircuit.h
@@ -24,7 +24,7 @@ class AccountUpdateCircuit : public BaseTransactionCircuit
     DualVariableGadget owner;
     DualVariableGadget accountID;
     DualVariableGadget validUntil;
-    DualVariableGadget nonce;
+    ToBitsGadget nonce;
     VariableT publicKeyX;
     VariableT publicKeyY;
     DualVariableGadget feeTokenID;

--- a/packages/loopring_v3/circuit/Circuits/AmmUpdateCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/AmmUpdateCircuit.h
@@ -21,13 +21,13 @@ class AmmUpdateCircuit : public BaseTransactionCircuit
 {
   public:
     // Inputs
-    DualVariableGadget owner;
+    ToBitsGadget owner;
     DualVariableGadget accountID;
     DualVariableGadget tokenID;
     DualVariableGadget feeBips;
     DualVariableGadget tokenWeight;
-    DualVariableGadget nonce;
-    DualVariableGadget balance;
+    ToBitsGadget nonce;
+    ToBitsGadget balance;
 
     // Increase the nonce
     AddGadget nonce_after;
@@ -98,13 +98,13 @@ class AmmUpdateCircuit : public BaseTransactionCircuit
     void generate_r1cs_constraints()
     {
         // Inputs
-        owner.generate_r1cs_constraints(true);
+        owner.generate_r1cs_constraints();
         accountID.generate_r1cs_constraints(true);
         tokenID.generate_r1cs_constraints(true);
         feeBips.generate_r1cs_constraints(true);
         tokenWeight.generate_r1cs_constraints(true);
-        nonce.generate_r1cs_constraints(true);
-        balance.generate_r1cs_constraints(true);
+        nonce.generate_r1cs_constraints();
+        balance.generate_r1cs_constraints();
 
         // Increase the nonce
         nonce_after.generate_r1cs_constraints();

--- a/packages/loopring_v3/circuit/Circuits/SignatureVerificationCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/SignatureVerificationCircuit.h
@@ -21,7 +21,7 @@ class SignatureVerificationCircuit : public BaseTransactionCircuit
 {
   public:
     // Inputs
-    DualVariableGadget owner;
+    ToBitsGadget owner;
     DualVariableGadget accountID;
     DualVariableGadget data;
 

--- a/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
@@ -74,8 +74,8 @@ class TransferCircuit : public BaseTransactionCircuit
     TernaryGadget resolvedDualAuthorY;
 
     // Signature
-    Poseidon_gadget_T<13, 1, 6, 53, 12, 1> hashPayer;
-    Poseidon_gadget_T<13, 1, 6, 53, 12, 1> hashDual;
+    Poseidon_12 hashPayer;
+    Poseidon_12 hashDual;
 
     // Balances
     DynamicBalanceGadget balanceS_A;

--- a/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/TransferCircuit.h
@@ -44,7 +44,7 @@ class TransferCircuit : public BaseTransactionCircuit
     DualVariableGadget fee;
     DualVariableGadget validUntil;
     DualVariableGadget type;
-    DualVariableGadget from;
+    ToBitsGadget from;
     DualVariableGadget to;
     DualVariableGadget storageID;
     VariableT dualAuthorX;
@@ -431,7 +431,7 @@ class TransferCircuit : public BaseTransactionCircuit
         fee.generate_r1cs_constraints(true);
         validUntil.generate_r1cs_constraints(true);
         type.generate_r1cs_constraints(true);
-        from.generate_r1cs_constraints(true);
+        from.generate_r1cs_constraints();
         to.generate_r1cs_constraints(true);
         storageID.generate_r1cs_constraints(true);
         payer_toAccountID.generate_r1cs_constraints(true);

--- a/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
@@ -551,7 +551,7 @@ class UniversalCircuit : public Circuit
     AddGadget nonce_after;
 
     // Signature
-    Poseidon_gadget_T<3, 1, 6, 51, 2, 1> hash;
+    Poseidon_2 hash;
     SignatureVerifier signatureVerifier;
 
     // Transactions

--- a/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/UniversalCircuit.h
@@ -163,8 +163,8 @@ class TransactionGadget : public GadgetT
     SelectTransactionGadget tx;
 
     // General validation
-    DualVariableGadget accountA;
-    DualVariableGadget accountB;
+    FromBitsGadget accountA;
+    FromBitsGadget accountB;
     RequireNotZeroGadget validateAccountA;
     RequireNotZeroGadget validateAccountB;
 
@@ -544,7 +544,7 @@ class UniversalCircuit : public Circuit
     DualVariableGadget timestamp;
     DualVariableGadget protocolTakerFeeBips;
     DualVariableGadget protocolMakerFeeBips;
-    std::unique_ptr<libsnark::dual_variable_gadget<FieldT>> numConditionalTransactions;
+    std::unique_ptr<ToBitsGadget> numConditionalTransactions;
     DualVariableGadget operatorAccountID;
 
     // Increment the nonce of the Operator
@@ -685,9 +685,9 @@ class UniversalCircuit : public Circuit
         updateAccount_O->generate_r1cs_constraints();
 
         // Num conditional transactions
-        numConditionalTransactions.reset(new libsnark::dual_variable_gadget<FieldT>(
+        numConditionalTransactions.reset(new ToBitsGadget(
           pb, transactions.back().tx.getOutput(TXV_NUM_CONDITIONAL_TXS), 32, ".numConditionalTransactions"));
-        numConditionalTransactions->generate_r1cs_constraints(true);
+        numConditionalTransactions->generate_r1cs_constraints();
 
         // Public data
         publicData.add(exchange.bits);

--- a/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
@@ -47,7 +47,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
     ToBitsGadget owner;
 
     // Signature
-    Poseidon_gadget_T<10, 1, 6, 53, 9, 1> hash;
+    Poseidon_9 hash;
 
     // Validate
     RequireLtGadget requireValidUntil;

--- a/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/WithdrawCircuit.h
@@ -44,7 +44,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
     EqualGadget isWithdrawalTx;
     EqualGadget isProtocolFeeWithdrawal;
     TernaryGadget ownerValue;
-    DualVariableGadget owner;
+    ToBitsGadget owner;
 
     // Signature
     Poseidon_gadget_T<10, 1, 6, 53, 9, 1> hash;
@@ -397,7 +397,7 @@ class WithdrawCircuit : public BaseTransactionCircuit
         isWithdrawalTx.generate_r1cs_constraints();
         isProtocolFeeWithdrawal.generate_r1cs_constraints();
         ownerValue.generate_r1cs_constraints();
-        owner.generate_r1cs_constraints(true);
+        owner.generate_r1cs_constraints();
 
         // Signature
         hash.generate_r1cs_constraints();

--- a/packages/loopring_v3/circuit/Gadgets/MatchingGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MatchingGadgets.h
@@ -502,7 +502,7 @@ class SpotPriceAMMGadget : public GadgetT
     UnsafeMulGadget numer;
     UnsafeMulGadget denom;
     MulDivGadget ratio;
-    DualVariableGadget ratioRangeCheck;
+    RangeCheckGadget ratioRangeCheck;
     UnsafeSubGadget invFeeBips;
     MulDivGadget res;
 
@@ -588,7 +588,7 @@ class CalcOutGivenInAMMGadget : public GadgetT
     static const unsigned int numIterations = 4;
 
     MulDivGadget weightRatio;
-    DualVariableGadget weightRatioRangeCheck;
+    RangeCheckGadget weightRatioRangeCheck;
     MulDivGadget fee;
     UnsafeSubGadget amountInWithoutFee;
     AddGadget y_denom;

--- a/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
@@ -19,6 +19,18 @@ using namespace jubjub;
 namespace Loopring
 {
 
+// All Poseidon permutations used
+using Poseidon_2 = Poseidon_gadget_T<3, 1, 6, 51, 2, 1>;
+template <unsigned n_outputs>
+using Poseidon_4_ = Poseidon_gadget_T<5, 1, 6, 52, n_outputs, 1>;
+using Poseidon_4 = Poseidon_4_<4>;
+using Poseidon_5 = Poseidon_gadget_T<6, 1, 6, 52, 5, 1>;
+using Poseidon_6 = Poseidon_gadget_T<7, 1, 6, 52, 6, 1>;
+using Poseidon_8 = Poseidon_gadget_T<9, 1, 6, 53, 8, 1>;
+using Poseidon_9 = Poseidon_gadget_T<10, 1, 6, 53, 9, 1>;
+using Poseidon_11 = Poseidon_gadget_T<12, 1, 6, 53, 11, 1>;
+using Poseidon_12 = Poseidon_gadget_T<13, 1, 6, 53, 12, 1>;
+
 // require(A == B)
 static void requireEqual( //
   ProtoboardT &pb,

--- a/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
@@ -155,8 +155,6 @@ class Constants : public GadgetT
 class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
 {
   public:
-    bool fromPacked = false;
-    bool fromBits = false;
 
     DualVariableGadget( //
       ProtoboardT &pb,
@@ -166,42 +164,10 @@ class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
     {
     }
 
-    DualVariableGadget( //
-      ProtoboardT &pb,
-      const VariableT &value,
-      const size_t width,
-      const std::string &prefix)
-        : libsnark::dual_variable_gadget<FieldT>(pb, value, width, prefix)
-    {
-        fromPacked = true;
-    }
-
-    DualVariableGadget( //
-      ProtoboardT &pb,
-      const VariableArrayT &bits,
-      const std::string &prefix)
-        : libsnark::dual_variable_gadget<FieldT>(pb, bits, prefix)
-    {
-        fromBits = true;
-    }
-
-    void generate_r1cs_witness()
-    {
-        if (fromPacked)
-        {
-            generate_r1cs_witness_from_packed();
-        }
-        if (fromBits)
-        {
-            generate_r1cs_witness_from_bits();
-        }
-    }
-
     void generate_r1cs_witness( //
       ProtoboardT &pb,
       const FieldT &value)
     {
-        assert(!fromPacked && !fromBits);
         pb.val(packed) = value;
         generate_r1cs_witness_from_packed();
     }
@@ -210,7 +176,6 @@ class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
       ProtoboardT &pb,
       const LimbT &value)
     {
-        assert(!fromPacked && !fromBits);
         assert(value.max_bits() == 256);
         for (unsigned int i = 0; i < 256; i++)
         {
@@ -225,21 +190,62 @@ class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
     }
 };
 
+class ToBitsGadget : public libsnark::dual_variable_gadget<FieldT>
+{
+  public:
+
+    ToBitsGadget( //
+      ProtoboardT &pb,
+      const VariableT &value,
+      const size_t width,
+      const std::string &prefix)
+        : libsnark::dual_variable_gadget<FieldT>(pb, value, width, prefix)
+    {
+
+    }
+
+    void generate_r1cs_witness()
+    {
+        generate_r1cs_witness_from_packed();
+    }
+
+    void generate_r1cs_constraints()
+    {
+        libsnark::dual_variable_gadget<FieldT>::generate_r1cs_constraints(true);
+    }
+};
+
+typedef ToBitsGadget RangeCheckGadget;
+
+class FromBitsGadget : public libsnark::dual_variable_gadget<FieldT>
+{
+  public:
+
+    FromBitsGadget( //
+      ProtoboardT &pb,
+      const VariableArrayT &bits,
+      const std::string &prefix)
+        : libsnark::dual_variable_gadget<FieldT>(pb, bits, prefix)
+    {
+
+    }
+
+    void generate_r1cs_witness()
+    {
+        generate_r1cs_witness_from_bits();
+    }
+
+    void generate_r1cs_constraints(bool enforce = true)
+    {
+        libsnark::dual_variable_gadget<FieldT>::generate_r1cs_constraints(enforce);
+    }
+};
+
 // Helper function that contains the history of all the values of a variable
 class DynamicVariableGadget : public GadgetT
 {
   public:
     std::vector<VariableT> variables;
-    bool allowGeneratingWitness;
-
-    DynamicVariableGadget( //
-      ProtoboardT &pb,
-      const std::string &prefix)
-        : GadgetT(pb, prefix)
-    {
-        add(make_variable(pb, FMT(prefix, ".initialValue")));
-        allowGeneratingWitness = true;
-    }
 
     DynamicVariableGadget( //
       ProtoboardT &pb,
@@ -248,7 +254,6 @@ class DynamicVariableGadget : public GadgetT
         : GadgetT(pb, prefix)
     {
         add(initialValue);
-        allowGeneratingWitness = false;
     }
 
     const VariableT &front() const
@@ -264,12 +269,6 @@ class DynamicVariableGadget : public GadgetT
     void add(const VariableT &variable)
     {
         variables.push_back(variable);
-    }
-
-    void generate_r1cs_witness(ethsnarks::FieldT value)
-    {
-        assert(allowGeneratingWitness);
-        pb.val(variables.front()) = value;
     }
 };
 
@@ -408,7 +407,7 @@ class AddGadget : public GadgetT
 {
   public:
     UnsafeAddGadget unsafeAdd;
-    libsnark::dual_variable_gadget<FieldT> rangeCheck;
+    RangeCheckGadget rangeCheck;
 
     AddGadget( //
       ProtoboardT &pb,
@@ -427,13 +426,13 @@ class AddGadget : public GadgetT
     void generate_r1cs_witness()
     {
         unsafeAdd.generate_r1cs_witness();
-        rangeCheck.generate_r1cs_witness_from_packed();
+        rangeCheck.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
     {
         unsafeAdd.generate_r1cs_constraints();
-        rangeCheck.generate_r1cs_constraints(true);
+        rangeCheck.generate_r1cs_constraints();
     }
 
     const VariableT &result() const
@@ -447,7 +446,7 @@ class SubGadget : public GadgetT
 {
   public:
     UnsafeSubGadget unsafeSub;
-    libsnark::dual_variable_gadget<FieldT> rangeCheck;
+    RangeCheckGadget rangeCheck;
 
     SubGadget( //
       ProtoboardT &pb,
@@ -466,13 +465,13 @@ class SubGadget : public GadgetT
     void generate_r1cs_witness()
     {
         unsafeSub.generate_r1cs_witness();
-        rangeCheck.generate_r1cs_witness_from_packed();
+        rangeCheck.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
     {
         unsafeSub.generate_r1cs_constraints();
-        rangeCheck.generate_r1cs_constraints(true);
+        rangeCheck.generate_r1cs_constraints();
     }
 
     const VariableT &result() const
@@ -583,7 +582,7 @@ class ArrayTernaryGadget : public GadgetT
         results.reserve(x.size());
         for (unsigned int i = 0; i < x.size(); i++)
         {
-            results.emplace_back(TernaryGadget(pb, b, x[i], y[i], FMT(prefix, ".results")));
+            results.emplace_back(pb, b, x[i], y[i], FMT(prefix, ".results"));
             res.emplace_back(results.back().result());
         }
     }
@@ -1044,10 +1043,10 @@ class LtFieldGadget : public GadgetT
   public:
     field2bits_strict Abits;
     field2bits_strict Bbits;
-    DualVariableGadget Alo;
-    DualVariableGadget Ahi;
-    DualVariableGadget Blo;
-    DualVariableGadget Bhi;
+    FromBitsGadget Alo;
+    FromBitsGadget Ahi;
+    FromBitsGadget Blo;
+    FromBitsGadget Bhi;
     LeqGadget partLo;
     LeqGadget partHi;
     TernaryGadget res;
@@ -1363,7 +1362,7 @@ class MulDivGadget : public GadgetT
 
     RequireNotZeroGadget denominator_notZero;
     UnsafeMulGadget product;
-    libsnark::dual_variable_gadget<FieldT> remainder;
+    DualVariableGadget remainder;
     RequireLtGadget remainder_lt_denominator;
 
     MulDivGadget(
@@ -1412,8 +1411,7 @@ class MulDivGadget : public GadgetT
         {
             pb.val(quotient) = FieldT::zero();
         }
-        pb.val(remainder.packed) = pb.val(product.result()) - (pb.val(denominator) * pb.val(quotient));
-        remainder.generate_r1cs_witness_from_packed();
+        remainder.generate_r1cs_witness(pb, pb.val(product.result()) - (pb.val(denominator) * pb.val(quotient)));
         remainder_lt_denominator.generate_r1cs_witness();
     }
 
@@ -1530,7 +1528,7 @@ class PublicDataGadget : public GadgetT
     VariableArrayT publicDataBits;
 
     std::unique_ptr<sha256_many> hasher;
-    std::unique_ptr<libsnark::dual_variable_gadget<FieldT>> calculatedHash;
+    std::unique_ptr<FromBitsGadget> calculatedHash;
 
     PublicDataGadget( //
       ProtoboardT &pb,
@@ -1601,7 +1599,7 @@ class PublicDataGadget : public GadgetT
         hasher->generate_r1cs_constraints();
 
         // Check that the hash matches the public input
-        calculatedHash.reset(new libsnark::dual_variable_gadget<FieldT>(
+        calculatedHash.reset(new FromBitsGadget(
           pb, reverse(subArray(hasher->result().bits, 0, NUM_BITS_FIELD_CAPACITY)), ".packCalculatedHash"));
         calculatedHash->generate_r1cs_constraints(false);
         requireEqual(pb, calculatedHash->packed, publicInput, ".publicDataCheck");
@@ -1642,8 +1640,8 @@ class FloatGadget : public GadgetT
         for (unsigned int i = 0; i < floatEncoding.numBitsExponent; i++)
         {
             baseMultipliers.emplace_back(make_variable(pb, FMT(prefix, ".baseMultipliers")));
-            multipliers.emplace_back(TernaryGadget(
-              pb, f[floatEncoding.numBitsMantissa + i], baseMultipliers[i], constants._1, FMT(prefix, ".multipliers")));
+            multipliers.emplace_back(
+              pb, f[floatEncoding.numBitsMantissa + i], baseMultipliers[i], constants._1, FMT(prefix, ".multipliers"));
         }
     }
 
@@ -1806,8 +1804,8 @@ class SelectGadget : public GadgetT
         assert(values.size() == selector.size());
         for (unsigned int i = 0; i < values.size(); i++)
         {
-            results.emplace_back(TernaryGadget(
-              pb, selector[i], values[i], (i == 0) ? _constants._0 : results.back().result(), FMT(prefix, ".results")));
+            results.emplace_back(
+              pb, selector[i], values[i], (i == 0) ? _constants._0 : results.back().result(), FMT(prefix, ".results"));
         }
     }
 
@@ -1868,7 +1866,7 @@ class ArraySelectGadget : public GadgetT
     {
         for (unsigned int i = 0; i < results.size(); i++)
         {
-            results[i].generate_r1cs_constraints();
+            results[i].generate_r1cs_constraints(false);
         }
     }
 
@@ -1983,7 +1981,7 @@ class SignedAddGadget : public GadgetT
     EqualGadget isZero;
     TernaryGadget normalizedSign;
 
-    libsnark::dual_variable_gadget<FieldT> rangeCheck;
+    RangeCheckGadget rangeCheck;
 
     SignedAddGadget(
       ProtoboardT &pb,
@@ -2036,7 +2034,7 @@ class SignedAddGadget : public GadgetT
         isZero.generate_r1cs_witness();
         normalizedSign.generate_r1cs_witness();
 
-        rangeCheck.generate_r1cs_witness_from_packed();
+        rangeCheck.generate_r1cs_witness();
     }
 
     void generate_r1cs_constraints()
@@ -2057,7 +2055,7 @@ class SignedAddGadget : public GadgetT
         isZero.generate_r1cs_constraints();
         normalizedSign.generate_r1cs_constraints();
 
-        rangeCheck.generate_r1cs_constraints(true);
+        rangeCheck.generate_r1cs_constraints();
     }
 
     const SignedVariableT result() const
@@ -2208,10 +2206,10 @@ class PowerGadget : public GadgetT
     std::vector<SignedMulDivGadget> cn;
     std::vector<SignedMulDivGadget> tn;
     std::vector<SignedAddGadget> sum;
-    std::vector<DualVariableGadget> cnRangeCheck;
+    std::vector<RangeCheckGadget> cnRangeCheck;
 
     std::unique_ptr<MulDivGadget> res;
-    std::unique_ptr<DualVariableGadget> resRangeCheck;
+    std::unique_ptr<RangeCheckGadget> resRangeCheck;
     std::unique_ptr<RequireEqualGadget> requirePositive;
 
     PowerGadget(
@@ -2299,7 +2297,7 @@ class PowerGadget : public GadgetT
           1,
           NUM_BITS_FIXED_BASE,
           FMT(prefix, ".res")));
-        resRangeCheck.reset(new DualVariableGadget(pb, res->result(), NUM_BITS_AMOUNT, FMT(prefix, ".resRangeCheck")));
+        resRangeCheck.reset(new RangeCheckGadget(pb, res->result(), NUM_BITS_AMOUNT, FMT(prefix, ".resRangeCheck")));
         requirePositive.reset(
           new RequireEqualGadget(pb, sum.back().result().sign, constants._1, FMT(prefix, ".requirePositive")));
     }

--- a/packages/loopring_v3/circuit/Gadgets/MerkleTree.h
+++ b/packages/loopring_v3/circuit/Gadgets/MerkleTree.h
@@ -23,6 +23,9 @@ class merkle_path_selector_4 : public GadgetT
     TernaryGadget child2;
     TernaryGadget child3;
 
+    // Takes as input the computed hash x,
+    // and three sibling nodes, and two bits representing x's position amongst these sibling nodes.
+    // It then sets the 'child' variables correctly according to the position of x.
     //[bit1][bit0] [child0] [child1] [child2] [child3]
     // 0 0         x         y0          y1      y2
     // 0 1         y0        x           y1      y2
@@ -37,14 +40,24 @@ class merkle_path_selector_4 : public GadgetT
       const std::string &prefix)
         : GadgetT(pb, prefix),
 
+          // bit0_or_bit1 = bit0 | bit1
           bit0_or_bit1(pb, {bit0, bit1}, FMT(prefix, ".bit0_or_bit1")),
+          // bit0_and_bit1 = bit0 & bit1
           bit0_and_bit1(pb, {bit0, bit1}, FMT(prefix, ".bit0_and_bit1")),
 
+          // if (bit0 or bit1 == 0), then child0 = x, else child0 = y0.
           child0(pb, bit0_or_bit1.result(), sideNodes[0], input, FMT(prefix, ".child0")),
+          // child1p is the value of child1 if bit 1 is 0.
+          // if (bit1 == 1), then child1 = y1, else child1 == child1p
+          // if (bit0 == 1), then child1p = x, else it equals y0.
           child1p(pb, bit0, input, sideNodes[0], FMT(prefix, ".child1p")),
           child1(pb, bit1, sideNodes[1], child1p.result(), FMT(prefix, ".child1")),
+          // child2p is the value of child2 if bit 1 is 1.
+          // if (bit1 == 1), child2 = x, else child2 = child2p
+          // if (bit0 == 1), child2p = y2, else child2p = x.
           child2p(pb, bit0, sideNodes[2], input, FMT(prefix, ".child2p")),
           child2(pb, bit1, child2p.result(), sideNodes[1], FMT(prefix, ".child2")),
+          // if (bit0 and bit1 == 1), then child3 = x, else child3 = y2
           child3(pb, bit0_and_bit1.result(), input, sideNodes[2], FMT(prefix, ".child3"))
     {
         assert(sideNodes.size() == 3);
@@ -88,6 +101,9 @@ template <typename HashT> class merkle_path_compute_4 : public GadgetT
     std::vector<merkle_path_selector_4> m_selectors;
     std::vector<HashT> m_hashers;
 
+    // in_address_bits: {0..2}[in_depth*2]
+    // in_leaf: The hashed leaf data
+    // in_path: The Merkle inclusion proof values
     merkle_path_compute_4(
       ProtoboardT &in_pb,
       const size_t in_depth,
@@ -150,6 +166,10 @@ template <typename HashT> class merkle_path_authenticator_4 : public merkle_path
   public:
     const VariableT m_expected_root;
 
+    // in_address_bits: {0..2}[in_depth*2]
+    // in_leaf: The hashed leaf data
+    // in_expected_root: The expected Merkle root value
+    // in_path: The Merkle inclusion proof values
     merkle_path_authenticator_4(
       ProtoboardT &in_pb,
       const size_t in_depth,
@@ -186,10 +206,10 @@ template <typename HashT> class merkle_path_authenticator_4 : public merkle_path
 };
 
 // Same parameters for ease of implementation in EVM
-using HashMerkleTree = Poseidon_gadget_T<5, 1, 6, 52, 4, 1>;
-using HashAccountLeaf = Poseidon_gadget_T<7, 1, 6, 52, 6, 1>;
-using HashBalanceLeaf = Poseidon_gadget_T<5, 1, 6, 52, 3, 1>;
-using HashStorageLeaf = Poseidon_gadget_T<5, 1, 6, 52, 2, 1>;
+using HashMerkleTree = Poseidon_4;
+using HashAccountLeaf = Poseidon_6;
+using HashBalanceLeaf = Poseidon_4_<3>;
+using HashStorageLeaf = Poseidon_4_<2>;
 
 using MerklePathCheckT = merkle_path_authenticator_4<HashMerkleTree>;
 using MerklePathT = merkle_path_compute_4<HashMerkleTree>;

--- a/packages/loopring_v3/circuit/Gadgets/OrderGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/OrderGadgets.h
@@ -44,7 +44,7 @@ class OrderGadget : public GadgetT
     RequireNotZeroGadget amountB_notZero;
 
     // Signature
-    Poseidon_gadget_T<12, 1, 6, 53, 11, 1> hash;
+    Poseidon_11 hash;
 
     OrderGadget( //
       ProtoboardT &pb,

--- a/packages/loopring_v3/circuit/Gadgets/OrderGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/OrderGadgets.h
@@ -129,7 +129,7 @@ class OrderGadget : public GadgetT
         hash.generate_r1cs_witness();
     }
 
-    void generate_r1cs_constraints(bool doSignatureCheck = true)
+    void generate_r1cs_constraints()
     {
         // Inputs
         storageID.generate_r1cs_constraints(true);

--- a/packages/loopring_v3/circuit/Gadgets/SignatureGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/SignatureGadgets.h
@@ -167,7 +167,7 @@ class EdDSA_HashRAM_Poseidon_gadget : public GadgetT
 {
   public:
     Poseidon_gadget_T<6, 1, 6, 52, 5, 1> m_hash_RAM; // hash_RAM = H(R, A, M)
-    libsnark::dual_variable_gadget<FieldT> hash;
+    ToBitsGadget hash;
 
     EdDSA_HashRAM_Poseidon_gadget(
       ProtoboardT &in_pb,
@@ -186,13 +186,13 @@ class EdDSA_HashRAM_Poseidon_gadget : public GadgetT
     void generate_r1cs_constraints()
     {
         m_hash_RAM.generate_r1cs_constraints();
-        hash.generate_r1cs_constraints(true);
+        hash.generate_r1cs_constraints();
     }
 
     void generate_r1cs_witness()
     {
         m_hash_RAM.generate_r1cs_witness();
-        hash.generate_r1cs_witness_from_packed();
+        hash.generate_r1cs_witness();
     }
 
     const VariableArrayT &result()

--- a/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/StorageGadgets.h
@@ -44,17 +44,6 @@ class StorageGadget : public GadgetT
     {
     }
 
-    StorageGadget( //
-      ProtoboardT &pb,
-      VariableT _data,
-      VariableT _storageID)
-        : GadgetT(pb, "storageGadget"),
-
-          data(_data),
-          storageID(_storageID)
-    {
-    }
-
     void generate_r1cs_witness(const StorageLeaf &storageLeaf)
     {
         pb.val(data) = storageLeaf.data;

--- a/packages/loopring_v3/circuit/test/OrderTests.cpp
+++ b/packages/loopring_v3/circuit/test/OrderTests.cpp
@@ -5,11 +5,7 @@
 
 TEST_CASE("Order", "[OrderGadget]")
 {
-    // We can't easily create signatures here, so disable the signature check for
-    // some tests
-    bool doSignatureCheck = true;
-
-    auto orderChecked = [&doSignatureCheck](const FieldT &_exchange, const Order &order, bool expectedSatisfied) {
+    auto orderChecked = [&](const FieldT &_exchange, const Order &order, bool expectedSatisfied) {
         protoboard<FieldT> pb;
 
         VariableT exchange = make_variable(pb, _exchange, "exchange");
@@ -18,7 +14,7 @@ TEST_CASE("Order", "[OrderGadget]")
         OrderGadget orderGadget(pb, constants, exchange, ".order");
 
         orderGadget.generate_r1cs_witness(order);
-        orderGadget.generate_r1cs_constraints(doSignatureCheck);
+        orderGadget.generate_r1cs_constraints();
 
         REQUIRE(pb.is_satisfied() == expectedSatisfied);
     };

--- a/packages/loopring_v3/test/ammUtils.ts
+++ b/packages/loopring_v3/test/ammUtils.ts
@@ -715,8 +715,8 @@ export class AmmPool {
 
     return web3.eth.abi.encodeParameter("tuple(uint256,bytes,bytes)", [
       poolTx.txType,
-      web3.utils.hexToBytes(poolTx.data),
-      web3.utils.hexToBytes(poolTx.signature ? poolTx.signature : "0x")
+      poolTx.data,
+      poolTx.signature ? poolTx.signature : "0x"
     ]);
   }
 


### PR DESCRIPTION
## Issue A: The BN254 Curve Provides Insufficient Security

We have learned that the theoretical security of ~100 bits is actually higher in practice due to the nature of that there is an TNFS attack. However, the bottleneck for attacks like that are is not computation but memory shuffles, so measuring the complexity in just arithmetic operations isn't accurate. A number of papers have tried to approach the theoretical security parameter using custom hardware to these memory shuffles, but still haven not achieved the theoretical parameter. So the practical is several bits higher than the reported parameter, even when using custom hardware.

Practically it's also just a major change that really changes the basics of what we build upon (also for doing things like the trusted setup). The  EIP which will bring BLS12-381 support has also been removed from the Berlin HF and so the earliest time it is possible to use will maybe be Summer 2021. We believe that while switching to BLS12-381 would undoubtedly be better in the long run, it is not necessary for the security of the protocol keeping in mind the expected lifetime of the protocol of two to three years.

## Suggestion 1: Use the ​emplace_back​ Method Consistently Across Gadgets

Fixed.

## Suggestion 2: Remove Unnecessary Bitness Check in ​ArraySelectGadget

As suggested, removed the check for consistency and save on a few constraints.

## Suggestion 3: Write A Comprehensive Accompanying SNARK Statement

While the documentation could certainly be improved even further, we currently don't have any immediate plans to substantially improve the already quite extensive documentation. 

## Suggestion 4: Clearly Distinguish Between Computing Witnesses and Enforcing Constraints

There were a couple of instances where a single class was used for multiple purposes and so the separation was not clear and could even be error prone. 

- DualVariableGadget: Split into DualVariableGadget, FromBitsGadget and ToBitsGadget.
- DynamicVariableGadget: Removed unused constructor
- StorageGadget: Removed unused constructor

We believe the remaining code does follow the expected separation.

## Suggestion 5: Expand Code Comments

Documentation can of course always be improved, between the design document, the statement document and the code comments documenttion is quite extensive, but we will add extra comments if the opportunity arises.

## Suggestion 6: Use Regular Integer Representation Instead of 24 Bit Floating Point Values

We use a decimal float format to represent 96-bit numbers, with the format's maximum value being 2^19*10^31 (the 5-bit exponent is also a decimal value in binary). So we go from 12 bytes uncompressed to 3 bytes compressed with a small reduction in accuracy.

So the savings are substantial, especially with the knowledge that this is for that data that is put on-chain, incurring a gas cost of 16 gas for each non-zero byte. Furthermore, all the data put on-chain also needs to be hashed using sha256, which is also very expensive in the circuits at ~20,000 constraints/32 bytes. So while the float processing is not free, it does decrease on-chain costs as well as proving costs greatly.

Also, no calculations are done on the float values, as the floats are decoded/checked for accuracy as part of the input processing. As such, using the floats in this way has no extra risks or complexity except for the mentioned decoding and accuracy checking of course.

## Suggestion 7: Expand Test Suite to Enforce Security Assumptions

The circuits are tested using our more gadget specific tests for more extensive testing of specific gadgets, but also by our more high level truffle tests, which have success and failure testing of the more complete circuit logic. 

Many tests do test with invalid data to try and bypass enforced limitations, but testing for some things is especially hard without looking at the code or making additional assumptions. Also using the Merkle tree example, we do assume Merkle trees to do what we want, and because the values in the Merkle tree can be any field element, any input is a valid input, the Merkle proof can just be valid or invalid. And any other inputs that are constrained, like the address, are inputs that should have been checked for validity elsewhere (transaction inputs).

But some things are certainly not automatically tests. For example, one easy mistake to make, but hard to detect in tests, is when variables are not correctly constrained to each other to link them together. This is probably on the most common errors in circuits just because it is so easy to overlook, but writing tests to detect this would be very hard (all gadgets would need to have their internal variables modified by some tool to detect these kinds of errors). 