### PR TITLE
[protocol3.6] AMM pool txs optimization

### DIFF
--- a/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmBlockReceiver.sol
@@ -39,14 +39,11 @@ library AmmBlockReceiver
 
         _processPoolTx(S, ctx, _block, data);
 
-        // Approve transactions
-        ctx.exchange.approveTransactions(ctx.transactionBuffer.owners, ctx.transactionBuffer.txHashes);
-
         // Update state
         S._totalSupply = ctx.totalSupply;
 
-        // Make sure we haven't consumed more transactions than expected
-        require(numTxs >= (ctx.txIdx - txIdx), "INVALID_NUM_TXS");
+        // Make sure we have consumed exactly the expected number of transactions
+        require(numTxs == (ctx.txIdx - txIdx), "INVALID_NUM_TXS");
     }
 
     function _getContext(
@@ -67,12 +64,7 @@ library AmmBlockReceiver
             poolTokenID: S.poolTokenID,
             totalSupply: S._totalSupply,
             tokens: S.tokens,
-            tokenBalancesL2: new uint96[](size),
-            transactionBuffer: AmmData.TransactionBuffer({
-                size: 0,
-                owners: new address[](size*2 + 1),
-                txHashes: new bytes32[](size*2 + 1)
-            })
+            tokenBalancesL2: new uint96[](size)
         });
     }
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -84,15 +84,6 @@ library AmmData
 
         Token[]  tokens;
         uint96[] tokenBalancesL2;
-
-        TransactionBuffer transactionBuffer;
-    }
-
-    struct TransactionBuffer
-    {
-        uint      size;
-        address[] owners;
-        bytes32[] txHashes;
     }
 
     struct State {

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -102,8 +102,6 @@ library AmmExitProcess
                 );
             }
 
-            ctx.approveTransfer(transfer);
-
             ctx.tokenBalancesL2[i] = ctx.tokenBalancesL2[i].sub(transfer.amount);
         }
 
@@ -137,8 +135,6 @@ library AmmExitProcess
             (signature.length == 0 || transfer.storageID == burnStorageID),
             "INVALID_BURN_TX_DATA"
         );
-
-        ctx.approveTransfer(transfer);
 
         // Update pool balance
         ctx.totalSupply = ctx.totalSupply.sub(transfer.amount);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -72,8 +72,6 @@ library AmmJoinProcess
                 "INVALID_JOIN_TRANSFER_TX_DATA"
             );
 
-            ctx.approveTransfer(transfer);
-
             ctx.tokenBalancesL2[i] = ctx.tokenBalancesL2[i].add(transfer.amount);
         }
 
@@ -105,8 +103,6 @@ library AmmJoinProcess
             // transfer.storageID == UNKNOWN &&
             "INVALID_MINT_TX_DATA"
         );
-
-        ctx.approveTransfer(transfer);
 
         // Update pool balance
         ctx.totalSupply = ctx.totalSupply.add(transfer.amount);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUpdateProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUpdateProcess.sol
@@ -12,7 +12,6 @@ import "./AmmUtil.sol";
 /// @title AmmUpdateProcess
 library AmmUpdateProcess
 {
-    using AmmUtil           for AmmData.TransactionBuffer;
     using TransactionReader for ExchangeData.Block;
 
     function approveAmmUpdates(
@@ -35,11 +34,6 @@ library AmmUpdateProcess
                 update.tokenWeight == ctx.tokens[i].weight,
                 "INVALID_AMM_UPDATE_TX_DATA"
             );
-
-            // Now approve this AMM update
-            update.validUntil = 0xffffffff;
-            bytes32 txHash = AmmUpdateTransaction.hashTx(ctx.exchangeDomainSeparator, update);
-            ctx.transactionBuffer.approveExchangeTransaction(address(this), txHash);
 
             ctx.tokenBalancesL2[i] = update.balance;
         }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmUtil.sol
@@ -47,32 +47,6 @@ library AmmUtil
         );
     }
 
-    function approveTransfer(
-        AmmData.Context  memory  ctx,
-        TransferTransaction.Transfer memory transfer
-        )
-        internal
-        pure
-    {
-        transfer.validUntil = 0xffffffff;
-        transfer.maxFee = transfer.fee;
-        bytes32 hash = TransferTransaction.hashTx(ctx.exchangeDomainSeparator, transfer);
-        approveExchangeTransaction(ctx.transactionBuffer, transfer.from, hash);
-    }
-
-    function approveExchangeTransaction(
-        AmmData.TransactionBuffer memory buffer,
-        address                          owner,
-        bytes32                          txHash
-        )
-        internal
-        pure
-    {
-        buffer.owners[buffer.size] = owner;
-        buffer.txHashes[buffer.size] = txHash;
-        buffer.size++;
-    }
-
     function isAlmostEqualAmount(
         uint96 amount,
         uint96 targetAmount

--- a/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
+++ b/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
@@ -97,8 +97,9 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
     {
         if (config.blockCallbacks.length > 0) {
             require(config.receivers.length > 0, "MISSING_RECEIVERS");
-            IAgentRegistry agentRegistry = IExchangeV3(target).getAgentRegistry();
+
             // Make sure the receiver is authorized to approve transactions
+            IAgentRegistry agentRegistry = IExchangeV3(target).getAgentRegistry();
             for (uint i = 0; i < config.receivers.length; i++) {
                 require(agentRegistry.isUniversalAgent(config.receivers[i]), "UNAUTHORIZED_RECEIVER");
             }
@@ -132,7 +133,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
         )
         private
     {
-        // Allocate memory to verify transactions that are approved here
+        // Allocate memory to verify transactions that are approved
         bool[][] memory preApprovedTxs = new bool[][](blocks.length);
         for (uint i = 0; i < blocks.length; i++) {
             preApprovedTxs[i] = new bool[](blocks[i].blockSize);
@@ -161,9 +162,8 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
         // Verify the approved transactions data against the auxiliary data in the block
         for (uint i = 0; i < blocks.length; i++) {
             bool[] memory _preApprovedTxs = preApprovedTxs[i];
-            ExchangeData.Block memory _block = blocks[i];
-            ExchangeData.AuxiliaryData[] memory auxiliaryData = _block.auxiliaryData;
-            for(uint j = 0; j < _block.auxiliaryData.length; j++) {
+            ExchangeData.AuxiliaryData[] memory auxiliaryData = blocks[i].auxiliaryData;
+            for(uint j = 0; j < auxiliaryData.length; j++) {
                 // Load the data from auxiliaryData, which is still encoded as calldata
                 uint txIdx;
                 bool approved;
@@ -207,6 +207,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
                 txCallback.numTxs
             );
 
+            // Now that the transactions have been verified, mark them as approved
             for (uint j = txIdx; j < txIdx + txCallback.numTxs; j++) {
                 preApprovedTxs[j] = true;
             }

--- a/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
+++ b/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
@@ -154,6 +154,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
 
         // Verify the approved transactions data against the auxiliary data in the block
         for (uint i = 0; i < blocks.length; i++) {
+            bool[] memory _preApprovedTxs = preApprovedTxs[i];
             ExchangeData.Block memory _block = blocks[i];
             ExchangeData.AuxiliaryData[] memory auxiliaryData = _block.auxiliaryData;
             for(uint j = 0; j < _block.auxiliaryData.length; j++) {
@@ -164,7 +165,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
                     txIdx := mload(add(add(32, auxiliaryData), auxOffset))
                     approved := mload(add(add(64, auxiliaryData), auxOffset))
                 }
-                require(preApprovedTxs[i][txIdx] == approved, "PRE_APPROVED_TX_MISMATCH");
+                require(_preApprovedTxs[txIdx] == approved, "PRE_APPROVED_TX_MISMATCH");
             }
         }
     }

--- a/packages/loopring_v3/contracts/aux/agents/AgentRegistry.sol
+++ b/packages/loopring_v3/contracts/aux/agents/AgentRegistry.sol
@@ -70,6 +70,7 @@ contract AgentRegistry is IAgentRegistry, AddressSet, Claimable
 
     function isUniversalAgent(address agent)
         public
+        override
         view
         returns (bool)
     {

--- a/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
@@ -48,6 +48,7 @@ library ExchangeData
     struct AuxiliaryData
     {
         uint  txIndex;
+        bool  approved;
         bytes data;
     }
 

--- a/packages/loopring_v3/contracts/core/iface/IAgentRegistry.sol
+++ b/packages/loopring_v3/contracts/core/iface/IAgentRegistry.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.7.0;
 
 interface IAgent{}
 
-interface IAgentRegistry
+abstract contract IAgentRegistry
 {
     /// @dev Returns whether an agent address is an agent of an account owner
     /// @param owner The account owner.
@@ -15,6 +15,7 @@ interface IAgentRegistry
         address agent
         )
         external
+        virtual
         view
         returns (bool);
 
@@ -27,6 +28,16 @@ interface IAgentRegistry
         address            agent
         )
         external
+        virtual
+        view
+        returns (bool);
+
+    /// @dev Returns whether an agent address is a universal agent.
+    /// @param agent The agent address
+    /// @return True if the agent address is a universal agent, else false
+    function isUniversalAgent(address agent)
+        public
+        virtual
         view
         returns (bool);
 }

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeBlocks.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeBlocks.sol
@@ -213,6 +213,12 @@ library ExchangeBlocks
                 // Each conditional transaction needs to be processed from left to right
                 require(auxiliaryData.txIndex >= minTxIndex, "AUXILIARYDATA_INVALID_ORDER");
 
+                minTxIndex = auxiliaryData.txIndex + 1;
+
+                if (auxiliaryData.approved) {
+                    continue;
+                }
+
                 // Get the transaction data
                 bytes memory txData = _block.readTransactionData(auxiliaryData.txIndex);
 
@@ -269,8 +275,6 @@ library ExchangeBlocks
                     // are not supported
                     revert("UNSUPPORTED_TX_TYPE");
                 }
-
-                minTxIndex = auxiliaryData.txIndex + 1;
             }
         }
     }

--- a/packages/loopring_v3/test/ammUtils.ts
+++ b/packages/loopring_v3/test/ammUtils.ts
@@ -458,6 +458,8 @@ export class AmmPool {
 
     const blockCallback = this.ctx.addBlockCallback(owner);
 
+    let numTxs = 0;
+
     for (let i = 0; i < this.tokens.length; i++) {
       await this.ctx.requestAmmUpdate(
         owner,
@@ -466,9 +468,9 @@ export class AmmPool {
         this.weights[i],
         { authMethod: AuthMethod.NONE }
       );
+      numTxs++;
     }
 
-    let numTxs = this.tokens.length * 2 + 1;
     if (transaction.signature === this.L2_SIGNATURE) {
       await this.ctx.requestSignatureVerification(
         transaction.owner,
@@ -538,6 +540,7 @@ export class AmmPool {
             storageID
           }
         );
+        numTxs++;
         this.tokenBalancesL2[i].iadd(amount);
         logDebug("pool join: " + amount.toString(10));
       }
@@ -557,6 +560,7 @@ export class AmmPool {
           amountToDeposit: new BN(0)
         }
       );
+      numTxs++;
       mintAmount = roundToFloatValue(mintAmount, Constants.Float24Encoding);
       poolTotal.iadd(mintAmount);
     } else if (transaction.txType === "Exit") {
@@ -604,6 +608,7 @@ export class AmmPool {
               storageID
             }
           );
+          numTxs++;
         }
 
         // Withdraw
@@ -628,6 +633,7 @@ export class AmmPool {
               transferToNew: true
             }
           );
+          numTxs++;
           this.tokenBalancesL2[i].isub(amount);
           logDebug("pool exit: " + amount.toString(10));
         }

--- a/packages/loopring_v3/test/testExchangeBlocks.ts
+++ b/packages/loopring_v3/test/testExchangeBlocks.ts
@@ -159,9 +159,9 @@ contract("Exchange", (accounts: string[]) => {
             blockVersion,
             new Array(18).fill(1)
           );
-          let timestamp = (await web3.eth.getBlock(
-            await web3.eth.getBlockNumber()
-          )).timestamp;
+          let timestamp = (
+            await web3.eth.getBlock(await web3.eth.getBlockNumber())
+          ).timestamp;
           timestamp -=
             exchangeTestUtil.TIMESTAMP_HALF_WINDOW_SIZE_IN_SECONDS + 1;
           const bs = new Bitstream();
@@ -199,9 +199,9 @@ contract("Exchange", (accounts: string[]) => {
           );
           // Timestamp too early
           {
-            let timestamp = (await web3.eth.getBlock(
-              await web3.eth.getBlockNumber()
-            )).timestamp;
+            let timestamp = (
+              await web3.eth.getBlock(await web3.eth.getBlockNumber())
+            ).timestamp;
             timestamp -=
               exchangeTestUtil.TIMESTAMP_HALF_WINDOW_SIZE_IN_SECONDS + 1;
             const bs = new Bitstream();
@@ -229,9 +229,9 @@ contract("Exchange", (accounts: string[]) => {
           }
           // Timestamp too late
           {
-            let timestamp = (await web3.eth.getBlock(
-              await web3.eth.getBlockNumber()
-            )).timestamp;
+            let timestamp = (
+              await web3.eth.getBlock(await web3.eth.getBlockNumber())
+            ).timestamp;
             timestamp +=
               exchangeTestUtil.TIMESTAMP_HALF_WINDOW_SIZE_IN_SECONDS + 15;
             const bs = new Bitstream();
@@ -269,9 +269,9 @@ contract("Exchange", (accounts: string[]) => {
             new Array(18).fill(1)
           );
           const protocolFees = await loopring.getProtocolFeeValues();
-          const timestamp = (await web3.eth.getBlock(
-            await web3.eth.getBlockNumber()
-          )).timestamp;
+          const timestamp = (
+            await web3.eth.getBlock(await web3.eth.getBlockNumber())
+          ).timestamp;
           // Invalid taker protocol fee
           {
             const bs = new Bitstream();
@@ -416,7 +416,8 @@ contract("Exchange", (accounts: string[]) => {
                   blocks[0].blockInfoData
                 );
                 onchainBlocks[0].auxiliaryData.push([
-                  99,
+                  0,
+                  false,
                   web3.utils.hexToBytes("0x")
                 ]);
               }

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1872,6 +1872,20 @@ export class ExchangeTestUtil {
     return callbackConfig;
   }
 
+  public setPreApprovedTransactions(blocks: Block[]) {
+    for (const block of blocks) {
+      for (const blockCallback of block.callbacks) {
+        for (let i = 0; i < blockCallback.numTxs; i++) {
+          for (const auxiliaryData of block.auxiliaryData) {
+            if (auxiliaryData[0] === Number(blockCallback.txIdx) + i) {
+              auxiliaryData[1] = true;
+            }
+          }
+        }
+      }
+    }
+  }
+
   public getOnchainBlock(
     blockType: number,
     blockSize: number,
@@ -2001,6 +2015,8 @@ export class ExchangeTestUtil {
       block.proof = this.readProof(proofFilename);
       // console.log(proof);
     }
+
+    this.setPreApprovedTransactions(blocks);
 
     // Prepare block data
     const onchainBlocks: OnchainBlock[] = [];
@@ -2399,23 +2415,23 @@ export class ExchangeTestUtil {
       if (transaction.txType === "Transfer") {
         if (transaction.type > 0) {
           const encodedTransferData = this.getTransferAuxData(transaction);
-          auxiliaryData.push([i, encodedTransferData]);
+          auxiliaryData.push([i, false, encodedTransferData]);
         }
       } else if (transaction.txType === "Withdraw") {
         const encodedWithdrawalData = this.getWithdrawalAuxData(transaction);
-        auxiliaryData.push([i, encodedWithdrawalData]);
+        auxiliaryData.push([i, false, encodedWithdrawalData]);
       } else if (transaction.txType === "Deposit") {
-        auxiliaryData.push([i, "0x"]);
+        auxiliaryData.push([i, false, "0x"]);
       } else if (transaction.txType === "AccountUpdate") {
         if (transaction.type > 0) {
           const encodedAccountUpdateData = this.getAccountUpdateAuxData(
             transaction
           );
-          auxiliaryData.push([i, encodedAccountUpdateData]);
+          auxiliaryData.push([i, false, encodedAccountUpdateData]);
         }
       } else if (transaction.txType === "AmmUpdate") {
         const encodedAmmUpdateData = this.getAmmUpdateAuxData(transaction);
-        auxiliaryData.push([i, encodedAmmUpdateData]);
+        auxiliaryData.push([i, false, encodedAmmUpdateData]);
       }
     }
     logDebug("numConditionalTransactions: " + auxiliaryData.length);

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -2016,6 +2016,7 @@ export class ExchangeTestUtil {
       // console.log(proof);
     }
 
+    // Set pool transactions as approved
     this.setPreApprovedTransactions(blocks);
 
     // Prepare block data


### PR DESCRIPTION
Only change for the relayer is that the AMM transactions verified in the pool contracts need to have `approved = true` in `AuxiliaryData`, and otherwise `approved = false`. `bool  approved` is a new field in `AuxiliaryData`.

This seems to save around 25% of the gas cost of a join/exit.