### PR TITLE
[protocol 3.6] Compression benchmarks

### DIFF
--- a/packages/loopring_v3.js/src/compression.ts
+++ b/packages/loopring_v3.js/src/compression.ts
@@ -79,9 +79,10 @@ export function decompress(data: string) {
 
 export function compressLZ(
   input: string,
+  minNumZeros: number = 42,
   speed: CompressionSpeed = CompressionSpeed.MEDIUM
 ) {
-  const minGasSavedForReplacement = GAS_COST_NONZERO_BYTE * 40;
+  const minGasSavedForReplacement = GAS_COST_NONZERO_BYTE * minNumZeros;
   const minLengthReplacement = Math.floor(
     minGasSavedForReplacement / GAS_COST_NONZERO_BYTE
   );
@@ -262,10 +263,10 @@ export function decompressLZ(input: string) {
 
 export function compressZeros(
   input: string,
+  minNumZeros: Number = 42,
   speed: CompressionSpeed = CompressionSpeed.MEDIUM
 ) {
-  const minNumZeros = 20;
-  const maxLength = 2**16-1;
+  const maxLength = 2 ** 16 - 1;
 
   const stream = new Bitstream(input);
   assert(stream.length() > 0, "cannot compress empty input");
@@ -283,22 +284,23 @@ export function compressZeros(
 
   const writeLiterals = (numData: number, numZeros: number) => {
     // Make sure no length is longer than `maxLength`
-    const numDataWriteLoops = Math.floor((numData + maxLength) / (maxLength + 1));
-      for (let i = 0; i < numDataWriteLoops - 1; i++)
-      {
-        compressed.addNumber(maxLength, 2);
-        compressed.addNumber(0, 2);
-        for (let i = 0; i < maxLength; i++) {
-          compressed.addNumber(data[previousPos + i], 1);
-        }
-        previousPos += maxLength;
-        numData -= maxLength;
+    const numDataWriteLoops = Math.floor(
+      (numData + maxLength) / (maxLength + 1)
+    );
+    for (let i = 0; i < numDataWriteLoops - 1; i++) {
+      compressed.addNumber(maxLength, 2);
+      compressed.addNumber(0, 2);
+      for (let i = 0; i < maxLength; i++) {
+        compressed.addNumber(data[previousPos + i], 1);
       }
-      compressed.addNumber(numData, 2);
-      compressed.addNumber(numZeros, 2);
-      for (let i = 0; i < numData; i++) {
-         compressed.addNumber(data[previousPos + i], 1);
-      }
+      previousPos += maxLength;
+      numData -= maxLength;
+    }
+    compressed.addNumber(numData, 2);
+    compressed.addNumber(numZeros, 2);
+    for (let i = 0; i < numData; i++) {
+      compressed.addNumber(data[previousPos + i], 1);
+    }
   };
 
   while (pos < dataLength) {

--- a/packages/loopring_v3/contracts/test/LzDecompressorContract.sol
+++ b/packages/loopring_v3/contracts/test/LzDecompressorContract.sol
@@ -14,4 +14,13 @@ contract LzDecompressorContract {
     {
         return LzDecompressor.decompress(data);
     }
+
+    function benchmark(
+        bytes calldata data
+        )
+        external
+        returns (bytes memory)
+    {
+        return LzDecompressor.decompress(data);
+    }
 }

--- a/packages/loopring_v3/contracts/test/ZeroDecompressorContract.sol
+++ b/packages/loopring_v3/contracts/test/ZeroDecompressorContract.sol
@@ -14,4 +14,13 @@ contract ZeroDecompressorContract {
     {
         return ZeroDecompressor.decompress(data, 0);
     }
+
+    function benchmark(
+        bytes calldata data
+        )
+        external
+        returns (bytes memory)
+    {
+        return ZeroDecompressor.decompress(data, 0);
+    }
 }

--- a/packages/loopring_v3/test/testDebugTools.ts
+++ b/packages/loopring_v3/test/testDebugTools.ts
@@ -4,6 +4,7 @@ import { AmmPool } from "./ammUtils";
 import { Constants } from "loopringV3.js";
 import { ExchangeTestUtil, OnchainBlock } from "./testExchangeUtil";
 import { BlockCallback, GasTokenConfig } from "./types";
+import { calculateCalldataCost, compressZeros } from "loopringV3.js";
 
 contract("Exchange", (accounts: string[]) => {
   let ctx: ExchangeTestUtil;
@@ -19,6 +20,46 @@ contract("Exchange", (accounts: string[]) => {
 
   describe("Debug Tools", function() {
     this.timeout(0);
+
+    it.skip("submitBlocks tx data compressor", async () => {
+      const data = "";
+
+      //console.log("original gas cost: " + calculateCalldataCost(data));
+
+      const decodedInput = web3.eth.abi.decodeParameters(
+        [
+          "bool",
+          "bytes",
+          {
+            "struct CallbackConfig": {
+              "struct BlockCallback[]": {
+                blockIdx: "uint16",
+                "struct TxCallback[]": {
+                  txIdx: "uint16",
+                  numTxs: "uint16",
+                  receiverIdx: "uint16",
+                  data: "bytes"
+                }
+              },
+              receivers: "address[]"
+            }
+          }
+        ],
+        "0x" + data.slice(2 + 4 * 2)
+      );
+
+      const ctx = new ExchangeTestUtil();
+      await ctx.initialize(accounts);
+
+      const encodedData = await ctx.getSubmitBlocksWithCallbacks({
+        isDataCompressed: true,
+        data: compressZeros(decodedInput[1]),
+        callbackConfig: decodedInput[2]
+      });
+
+      //console.log("new gas cost: " + calculateCalldataCost(encodedData));
+      console.log(encodedData);
+    });
 
     it.skip("submitBlocks tx data", async () => {
       const blockDirectory = "./blocks/";


### PR DESCRIPTION
I saw that we don't make use yet of data compression on mainnet. I did some tests on actual blocks submitted on mainnet to find good parameters for realistic data.

I also used Tenderly on a few blocks to simulate how much gas would have been spend if compression would have been used. I found that ~50k gas is saved per block. Pretty nice for something that doesn't need much work for the relayer to implement (just call `compressZeros` on the block data and set `isDataCompressed` to true when calling `submitBlocksWithCallbacks`).

This doesn't need any additional contract changes, the currently deployed contracts already support this.