### PR TITLE
[Protocol 3] only allow owner to call `initialize` in DefaultDepositContract

### DIFF
--- a/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol
+++ b/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol
@@ -52,6 +52,7 @@ contract DefaultDepositContract is IDepositContract, Claimable
         address _exchange
         )
         external
+        onlyOwner
     {
         require(
             exchange == address(0) && _exchange != address(0),


### PR DESCRIPTION
This PR is created based on the feedback from turbo3696@gmail.com:


The contract  DefaultDepositContract [https://github.com/Loopring/protocols/blob/Loopring_3.6.0/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol] can lose ownership due to improper access control.

Vulnerability:
The function named  initialize [https://github.com/Loopring/protocols/blob/c918b164d30f7b9a3d948225f09b635257b06844/packages/loopring_v3/contracts/core/impl/DefaultDepositContract.sol#L51] can be used by attacker to claim ownership and set arbitrary exchange address.
Scenario:

1.Attacker sees the contract being deployed.
2.Calls initialize function immediately and claims the ownership.
    This function can also be front-run.

