### PR TITLE
[protocol 3] Addded option for increased trading fees

### DIFF
--- a/packages/loopring_v3.js/src/constants.ts
+++ b/packages/loopring_v3.js/src/constants.ts
@@ -17,6 +17,8 @@ export class Constants {
 
   static readonly MAX_AMOUNT = new BN(2).pow(new BN(96)).sub(new BN(1));
 
+  static readonly FEE_MULTIPLIER = 50;
+
   static readonly Float24Encoding: FloatEncoding = {
     numBitsExponent: 5,
     numBitsMantissa: 19,

--- a/packages/loopring_v3.js/src/request_processors/spot_trade_processor.ts
+++ b/packages/loopring_v3.js/src/request_processors/spot_trade_processor.ts
@@ -65,11 +65,17 @@ export class SpotTradeProcessor {
 
     // Further extraction of packed data
     const limitMaskA = orderDataA & 0b10000000;
-    const feeBipsA = orderDataA & 0b00111111;
+    const feeBipsMultiplierFlagA = orderDataA & 0b01000000;
+    const feeBipsA =
+      (orderDataA & 0b00111111) *
+      (feeBipsMultiplierFlagA ? Constants.FEE_MULTIPLIER : 1);
     const fillAmountBorSA = limitMaskA > 0;
 
     const limitMaskB = orderDataB & 0b10000000;
-    const feeBipsB = orderDataB & 0b00111111;
+    const feeBipsMultiplierFlagB = orderDataB & 0b01000000;
+    const feeBipsB =
+      (orderDataB & 0b00111111) *
+      (feeBipsMultiplierFlagB ? Constants.FEE_MULTIPLIER : 1);
     const fillAmountBorSB = limitMaskB > 0;
 
     // Decode the float values

--- a/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
@@ -346,11 +346,11 @@ class SpotTradeCircuit : public BaseTransactionCircuit
           fillS_B.bits(),
 
           orderA.fillAmountBorS.bits,
-          VariableArrayT(1, state.constants._0),
-          orderA.feeBips.bits,
+          orderA.feeBipsMultiplierFlag.bits,
+          orderA.feeBipsData.bits,
           orderB.fillAmountBorS.bits,
-          VariableArrayT(1, state.constants._0),
-          orderB.feeBips.bits,
+          orderB.feeBipsMultiplierFlag.bits,
+          orderB.feeBipsData.bits,
         });
     }
 };

--- a/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/MathGadgets.h
@@ -21,8 +21,7 @@ namespace Loopring
 
 // All Poseidon permutations used
 using Poseidon_2 = Poseidon_gadget_T<3, 1, 6, 51, 2, 1>;
-template <unsigned n_outputs>
-using Poseidon_4_ = Poseidon_gadget_T<5, 1, 6, 52, n_outputs, 1>;
+template <unsigned n_outputs> using Poseidon_4_ = Poseidon_gadget_T<5, 1, 6, 52, n_outputs, 1>;
 using Poseidon_4 = Poseidon_4_<4>;
 using Poseidon_5 = Poseidon_gadget_T<6, 1, 6, 52, 5, 1>;
 using Poseidon_6 = Poseidon_gadget_T<7, 1, 6, 52, 6, 1>;
@@ -70,6 +69,7 @@ class Constants : public GadgetT
     const VariableT txTypeSpotTrade;
     const VariableT txTypeTransfer;
     const VariableT txTypeWithdrawal;
+    const VariableT feeMultiplier;
 
     const VariableArrayT zeroAccount;
 
@@ -105,6 +105,7 @@ class Constants : public GadgetT
             make_variable(pb, ethsnarks::FieldT(int(TransactionType::Transfer)), FMT(prefix, ".txTypeTransfer"))),
           txTypeWithdrawal(
             make_variable(pb, ethsnarks::FieldT(int(TransactionType::Withdrawal)), FMT(prefix, ".txTypeWithdrawal"))),
+          feeMultiplier(make_variable(pb, ethsnarks::FieldT(FEE_MULTIPLIER), FMT(prefix, ".feeMultiplier"))),
 
           zeroAccount(NUM_BITS_ACCOUNT, _0)
     {
@@ -161,13 +162,14 @@ class Constants : public GadgetT
         pb.add_r1cs_constraint(
           ConstraintT(txTypeWithdrawal, FieldT::one(), ethsnarks::FieldT(int(TransactionType::Withdrawal))),
           ".txTypeWithdrawal");
+        pb.add_r1cs_constraint(
+          ConstraintT(feeMultiplier, FieldT::one(), ethsnarks::FieldT(FEE_MULTIPLIER)), ".feeMultiplier");
     }
 };
 
 class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
 {
   public:
-
     DualVariableGadget( //
       ProtoboardT &pb,
       const size_t width,
@@ -205,7 +207,6 @@ class DualVariableGadget : public libsnark::dual_variable_gadget<FieldT>
 class ToBitsGadget : public libsnark::dual_variable_gadget<FieldT>
 {
   public:
-
     ToBitsGadget( //
       ProtoboardT &pb,
       const VariableT &value,
@@ -213,7 +214,6 @@ class ToBitsGadget : public libsnark::dual_variable_gadget<FieldT>
       const std::string &prefix)
         : libsnark::dual_variable_gadget<FieldT>(pb, value, width, prefix)
     {
-
     }
 
     void generate_r1cs_witness()
@@ -232,14 +232,12 @@ typedef ToBitsGadget RangeCheckGadget;
 class FromBitsGadget : public libsnark::dual_variable_gadget<FieldT>
 {
   public:
-
     FromBitsGadget( //
       ProtoboardT &pb,
       const VariableArrayT &bits,
       const std::string &prefix)
         : libsnark::dual_variable_gadget<FieldT>(pb, bits, prefix)
     {
-
     }
 
     void generate_r1cs_witness()

--- a/packages/loopring_v3/circuit/Gadgets/SignatureGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/SignatureGadgets.h
@@ -372,7 +372,8 @@ class SignatureVerifier : public GadgetT
     {
         for (unsigned int i = 0; i < sig_s.size(); i++)
         {
-            libsnark::generate_boolean_r1cs_constraint<ethsnarks::FieldT>(pb, sig_s[i], FMT(annotation_prefix, ".bitness"));
+            libsnark::generate_boolean_r1cs_constraint<ethsnarks::FieldT>(
+              pb, sig_s[i], FMT(annotation_prefix, ".bitness"));
         }
         signatureVerifier.generate_r1cs_constraints();
         valid.generate_r1cs_constraints();

--- a/packages/loopring_v3/circuit/Utils/Constants.h
+++ b/packages/loopring_v3/circuit/Utils/Constants.h
@@ -20,7 +20,8 @@ static const unsigned int NUM_BITS_TOKEN = TREE_DEPTH_TOKENS * 2;
 static const unsigned int NUM_BITS_STORAGEID = 32;
 static const unsigned int NUM_BITS_TIMESTAMP = 32;
 static const unsigned int NUM_BITS_NONCE = 32;
-static const unsigned int NUM_BITS_BIPS = 6;
+static const unsigned int NUM_BITS_BIPS = 12; // ceil(log2(2**NUM_BITS_BIPS_DA * FEE_MULTIPLIER))
+static const unsigned int NUM_BITS_BIPS_DA = 6;
 static const unsigned int NUM_BITS_PROTOCOL_FEE_BIPS = 8;
 static const unsigned int NUM_BITS_TYPE = 8;
 static const unsigned int NUM_STORAGE_SLOTS = 16384; // 2**NUM_BITS_STORAGE_ADDRESS
@@ -35,6 +36,7 @@ static const char *EMPTY_TRADE_HISTORY = "65927491675782344981534105642433692294
 static const char *MAX_AMOUNT = "79228162514264337593543950335"; // 2^96 - 1
 static const char *FIXED_BASE = "1000000000000000000";           // 10^18
 static const unsigned int NUM_BITS_FIXED_BASE = 60;              // ceil(log2(10^18))
+static const unsigned int FEE_MULTIPLIER = 50;
 
 struct FloatEncoding
 {

--- a/packages/loopring_v3/circuit/test/OrderTests.cpp
+++ b/packages/loopring_v3/circuit/test/OrderTests.cpp
@@ -101,9 +101,9 @@ TEST_CASE("Order", "[OrderGadget]")
         SECTION("feeBips > maxFeeBips")
         {
             Order _order = order;
-            for (unsigned int maxFeeBips = 0; maxFeeBips < pow(2, NUM_BITS_BIPS); maxFeeBips += 3)
+            for (unsigned int maxFeeBips = 0; maxFeeBips < pow(2, NUM_BITS_BIPS_DA); maxFeeBips += 3)
             {
-                for (unsigned int feeBips = 0; feeBips < pow(2, NUM_BITS_BIPS); feeBips += 3)
+                for (unsigned int feeBips = 0; feeBips < pow(2, NUM_BITS_BIPS_DA); feeBips += 3)
                 {
                     _order.maxFeeBips = maxFeeBips;
                     _order.feeBips = feeBips;
@@ -111,6 +111,37 @@ TEST_CASE("Order", "[OrderGadget]")
                     orderChecked(exchange, _order, expectedSatisfied);
                 }
             }
+            unsigned int feeBipsLimit = pow(2, NUM_BITS_BIPS_DA) * FEE_MULTIPLIER;
+            for (unsigned int maxFeeBips = 0; maxFeeBips < feeBipsLimit; maxFeeBips += 150)
+            {
+                for (unsigned int feeBips = 0; feeBips < feeBipsLimit; feeBips += 150)
+                {
+                    _order.maxFeeBips = maxFeeBips;
+                    _order.feeBips = feeBips;
+                    bool expectedSatisfied = (feeBips <= maxFeeBips);
+                    orderChecked(exchange, _order, expectedSatisfied);
+                }
+            }
+
+            _order.maxFeeBips = 1002;
+            _order.feeBips = 1000;
+            orderChecked(exchange, _order, true);
+
+            _order.maxFeeBips = 200;
+            _order.feeBips = 103;
+            orderChecked(exchange, _order, false);
+
+            _order.maxFeeBips = feeBipsLimit - 1;
+            _order.feeBips = feeBipsLimit - 1;
+            orderChecked(exchange, _order, true);
+
+            _order.maxFeeBips = feeBipsLimit;
+            _order.feeBips = feeBipsLimit;
+            orderChecked(exchange, _order, false);
+
+            _order.maxFeeBips = feeBipsLimit - FEE_MULTIPLIER;
+            _order.feeBips = feeBipsLimit - FEE_MULTIPLIER;
+            orderChecked(exchange, _order, true);
         }
         SECTION("tokenS == tokenB")
         {

--- a/packages/loopring_v3/test/testExchangeRingSettlement.ts
+++ b/packages/loopring_v3/test/testExchangeRingSettlement.ts
@@ -69,6 +69,58 @@ contract("Exchange", (accounts: string[]) => {
       await verify();
     });
 
+    it("High fee trade", async () => {
+      const ringA: SpotTrade = {
+        orderA: {
+          tokenS: "WETH",
+          tokenB: "GTO",
+          amountS: new BN(web3.utils.toWei("100", "ether")),
+          amountB: new BN(web3.utils.toWei("200", "ether")),
+          maxFeeBips: 100
+        },
+        orderB: {
+          tokenS: "GTO",
+          tokenB: "WETH",
+          amountS: new BN(web3.utils.toWei("200", "ether")),
+          amountB: new BN(web3.utils.toWei("100", "ether")),
+          maxFeeBips: 30
+        },
+        expected: {
+          orderA: { filledFraction: 1.0, spread: new BN(0) },
+          orderB: { filledFraction: 1.0 }
+        }
+      };
+      const ringB: SpotTrade = {
+        orderA: {
+          tokenS: "WETH",
+          tokenB: "GTO",
+          amountS: new BN(web3.utils.toWei("100", "ether")),
+          amountB: new BN(web3.utils.toWei("200", "ether")),
+          maxFeeBips: 63 * 50
+        },
+        orderB: {
+          tokenS: "GTO",
+          tokenB: "WETH",
+          amountS: new BN(web3.utils.toWei("200", "ether")),
+          amountB: new BN(web3.utils.toWei("100", "ether")),
+          maxFeeBips: 63
+        },
+        expected: {
+          orderA: { filledFraction: 1.0, spread: new BN(0) },
+          orderB: { filledFraction: 1.0 }
+        }
+      };
+
+      await exchangeTestUtil.setupRing(ringA);
+      await exchangeTestUtil.setupRing(ringB);
+      await exchangeTestUtil.sendRing(ringA);
+      await exchangeTestUtil.sendRing(ringB);
+
+      await exchangeTestUtil.submitTransactions();
+
+      await verify();
+    });
+
     it("Matchable (orderA < orderB)", async () => {
       const ring: SpotTrade = {
         orderA: {


### PR DESCRIPTION
#2334 

Currently I have set the multiplier to `50`, so now it's also possible to set the fee up to 31.5% in steps of 0.5%. But is easy to change if some other value would make more sense.

All inputs to the circuit remains, it's just that `feeBips` values `> 0.63%` will automatically enable the new mode so the passed in `feeBips` values need to be multiples of `0.5%`.