### PR TITLE
[Protocol 3.7] Additional renaming suggestions

### DIFF
--- a/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
@@ -19,7 +19,7 @@ import "./IBridge.sol";
 
 /// @title  Bridge implementation
 /// @author Brecht Devos - <brecht@loopring.org>
-contract Bridge is IBatchDepositor, ReentrancyGuard, Claimable
+contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
 {
     using AddressUtil       for address;
     using AddressUtil       for address payable;
@@ -177,9 +177,9 @@ contract Bridge is IBatchDepositor, ReentrancyGuard, Claimable
 
     // Allows withdrawing from pending transfers that are at least MAX_AGE_PENDING_TRANSFER old.
     function withdrawFromPendingBatchDeposit(
-        uint                            batchID,
+        uint                        batchID,
         InternalL2Transfer[] memory transfers,
-        uint[]                   memory indices
+        uint[]               memory indices
         )
         external
         nonReentrant

--- a/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
@@ -143,9 +143,9 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         payable
         override
     {
-        L2Transfer[][] memory _deposits = new L2Transfer[][](1);
-        _deposits[0] = deposits;
-        _batchDeposit(msg.sender,_deposits);
+        L2Transfer[][] memory _transfers = new L2Transfer[][](1);
+        _transfers[0] = deposits;
+        _batchDeposit(msg.sender,_transfers);
     }
 
     function onReceiveTransactions(
@@ -292,9 +292,9 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         uint16 tokenID;
         L2Transfer memory transfer;
         for (uint n = 0; n < transfers.length; n++) {
-            L2Transfer[] memory _deposits = transfers[n];
-            for (uint i = 0; i < _deposits.length; i++) {
-                transfer = _deposits[i];
+            L2Transfer[] memory _transfers = transfers[n];
+            for (uint i = 0; i < _transfers.length; i++) {
+                transfer = _transfers[i];
                 if(token != transfer.token) {
                     token = transfer.token;
                     tokenIdx = 0;
@@ -329,7 +329,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
             if (tokens[i].token == address(0)) {
                 require(tokens[i].amount == msg.value || from == address(this), "INVALID_ETH_DEPOSIT");
             }
-            _deposit(from, tokens[i].token, uint96(tokens[i].amount));
+            _transfer(from, tokens[i].token, uint96(tokens[i].amount));
         }
 
         // Store the transfers so they can be processed later
@@ -611,7 +611,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         emit Transfers(batchID, transfers, from);
     }
 
-    function _deposit(
+    function _transfer(
         address from,
         address token,
         uint96  amount
@@ -652,7 +652,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         }
 
         // Execute the logic using a delegate so no extra transfers are needed
-        txData = _getConnectorCallData(ctx,IBridge.processCalls.selector, allCalls, n);
+        txData = _getConnectorCallData(ctx, IBridge.processCalls.selector, allCalls, n);
         (success, returnData) = call.connector.fastDelegatecall(call.gasLimit, txData);
 
         if (success) {

--- a/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
@@ -14,12 +14,14 @@ import "../../lib/MathUint96.sol";
 import "../../lib/ReentrancyGuard.sol";
 import "../../lib/TransferUtil.sol";
 
+import "../access/ITransactionReceiver.sol";
+
 import "./IBridge.sol";
 
 
 /// @title  Bridge implementation
 /// @author Brecht Devos - <brecht@loopring.org>
-contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
+contract Bridge is IBatchDeposit, ITransactionReceiver, ReentrancyGuard, Claimable
 {
     using AddressUtil       for address;
     using AddressUtil       for address payable;
@@ -153,6 +155,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         bytes calldata /*callbackData*/
         )
         external
+        override
         onlyFromExchangeOwner
     {
         // Get the offset to txsData in the calldata

--- a/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
@@ -34,9 +34,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
     // - uint96  amount : 12 bytes
     // - uint16  tokenID:  2 bytes
     event Transfers           (uint batchID, bytes transfers, address from);
-
     event ConnectorCallResult (address connector, bool success, bytes reason);
-
     event ConnectorTrusted    (address connector, bool trusted);
 
     struct InternalL2Transfer
@@ -243,7 +241,7 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
         }
     }
 
-    function setConnectorTrusted(
+    function trustConnector(
         address connector,
         bool    trusted
         )

--- a/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/Bridge.sol
@@ -123,8 +123,8 @@ contract Bridge is IBatchDeposit, ReentrancyGuard, Claimable
     }
 
     constructor(
-        IExchangeV3      _exchange,
-        uint32           _accountID
+        IExchangeV3 _exchange,
+        uint32     _accountID
         )
     {
         exchange = _exchange;

--- a/packages/loopring_v3/contracts/aux/bridge/IBatchDeposit.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/IBatchDeposit.sol
@@ -13,7 +13,7 @@ struct L2Transfer
 
 /// @title  IBatchDeposit interface
 /// @author Brecht Devos - <brecht@loopring.org>
-interface IBatchDepositor
+interface IBatchDeposit
 {
     /// @dev Optimized L1 -> L2 path. Allows doing many deposits in an efficient way.
     ///

--- a/packages/loopring_v3/contracts/aux/bridge/IBatchDepositor.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/IBatchDepositor.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+
+struct L2Transfer
+{
+    address owner;
+    address token;
+    uint96  amount;
+}
+
+/// @title  IBatchDeposit interface
+/// @author Brecht Devos - <brecht@loopring.org>
+interface IBatchDepositor
+{
+    /// @dev Optimized L1 -> L2 path. Allows doing many deposits in an efficient way.
+    ///
+    ///      Every normal deposit to Loopring exchange does a real L1 token transfer
+    ///      and stores some data on-chain costing ~65k gas.
+    ///      This function batches all deposits togeter and only does a single exchange
+    ///      deposit for each distinct token. All deposits are then handled by L2 transfers
+    ///      instead of L1 transfers, which makes them much cheaper.
+    ///
+    ///      The sender will send the funds to Loopring exchange, so just like with normal
+    ///      deposits the sender first has to approve token transfers on the deposit contract.
+    ///
+    /// @param transfers The L2 transfers from Bridge to owners
+    function batchDeposit(L2Transfer[] calldata transfers)
+        external
+        payable;
+}

--- a/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
@@ -24,7 +24,7 @@ struct BridgeCallGroup
 }
 
 
-/// @title  IBridgeConnector interface
+/// @title  IBridge interface
 /// @author Brecht Devos - <brecht@loopring.org>
 interface IBridge
 {

--- a/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
@@ -3,7 +3,7 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
-import "./IBatchDepositor.sol";
+import "./IBatchDeposit.sol";
 
 
 struct BridgeCall
@@ -48,7 +48,7 @@ interface IBridge
     ///     uniswap the allowd slippage, for mass migration the destination address,...).
     ///     In some cases the interaction results in new tokens that the user wants to receive back on L2. To allow this
     ///     the function returns a list of transfers that need to be done from the bridge back to the users (which would
-    ///     be similar to just calling IatchDepositor.batchDeposit(), but by returning the list here more optimizations are possible
+    ///     be similar to just calling IBatchDeposit.batchDeposit(), but by returning the list here more optimizations are possible
     ///     between different connector calls).
     ///
     /// @param groups The groups of bridge calls to process

--- a/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/IBridge.sol
@@ -3,6 +3,9 @@
 pragma solidity ^0.7.0;
 pragma experimental ABIEncoderV2;
 
+import "./IBatchDepositor.sol";
+
+
 struct BridgeCall
 {
     address owner;
@@ -20,37 +23,10 @@ struct BridgeCallGroup
     BridgeCall[] calls;
 }
 
-struct BridgeTransfer
-{
-    address owner;
-    address token;
-    uint96  amount;
-}
-
-/// @title  IBridge interface
-/// @author Brecht Devos - <brecht@loopring.org>
-interface IBridge
-{
-    /// @dev Optimized L1 -> L2 path. Allows doing many deposits in an efficient way.
-    ///
-    ///      Every normal deposit to Loopring exchange does a real L1 token transfer
-    ///      and stores some data on-chain costing ~65k gas.
-    ///      This function batches all deposits togeter and only does a single exchange
-    ///      deposit for each distinct token. All deposits are then handled by L2 transfers
-    ///      instead of L1 transfers, which makes them much cheaper.
-    ///
-    ///      The sender will send the funds to Loopring exchange, so just like with normal
-    ///      deposits the sender first has to approve token transfers on the deposit contract.
-    ///
-    /// @param transfers The L2 transfers from Bridge to owners
-    function batchDeposit(BridgeTransfer[] calldata transfers)
-        external
-        payable;
-}
 
 /// @title  IBridgeConnector interface
 /// @author Brecht Devos - <brecht@loopring.org>
-interface IBridgeConnector
+interface IBridge
 {
     /// @dev Optimized L2 -> L1 (-> L2) path. Allows interacting with L1 dApps in an efficient way.
     ///
@@ -72,14 +48,14 @@ interface IBridgeConnector
     ///     uniswap the allowd slippage, for mass migration the destination address,...).
     ///     In some cases the interaction results in new tokens that the user wants to receive back on L2. To allow this
     ///     the function returns a list of transfers that need to be done from the bridge back to the users (which would
-    ///     be similar to just calling IBridge.batchDeposit(), but by returning the list here more optimizations are possible
+    ///     be similar to just calling IatchDepositor.batchDeposit(), but by returning the list here more optimizations are possible
     ///     between different connector calls).
     ///
     /// @param groups The groups of bridge calls to process
     function processCalls(BridgeCallGroup[] calldata groups)
         external
         payable
-        returns (BridgeTransfer[] memory);
+        returns (L2Transfer[] memory);
 
     /// @dev Returns a rough estimate of the gas cost to do `processCalls`. At least this much gas needs to be
     ///      provided by the caller of `processCalls` before the BridgeCalls of users are allowed to be used.

--- a/packages/loopring_v3/contracts/test/TestMigrationBridge.sol
+++ b/packages/loopring_v3/contracts/test/TestMigrationBridge.sol
@@ -10,7 +10,7 @@ import "../lib/ERC20.sol";
 import "../lib/ERC20SafeTransfer.sol";
 import "../lib/MathUint.sol";
 import "../thirdparty/SafeCast.sol";
-import "../aux/bridge/IBatchDepositor.sol";
+import "../aux/bridge/IBatchDeposit.sol";
 import "../aux/bridge/IBridge.sol";
 
 
@@ -35,11 +35,11 @@ contract TestMigrationBridge is IBridge
 
     IExchangeV3        public immutable exchange;
     IDepositContract   public immutable depositContract;
-    IBatchDepositor    public immutable batchDepositor;
+    IBatchDeposit    public immutable batchDepositor;
 
     constructor(
         IExchangeV3     _exchange,
-        IBatchDepositor _batchDepositor
+        IBatchDeposit _batchDepositor
         )
     {
         exchange = _exchange;

--- a/packages/loopring_v3/contracts/test/TestMigrationBridge.sol
+++ b/packages/loopring_v3/contracts/test/TestMigrationBridge.sol
@@ -38,7 +38,7 @@ contract TestMigrationBridge is IBridge
     IBatchDeposit    public immutable batchDepositor;
 
     constructor(
-        IExchangeV3     _exchange,
+        IExchangeV3   _exchange,
         IBatchDeposit _batchDepositor
         )
     {

--- a/packages/loopring_v3/contracts/test/TestSwappperBridge.sol
+++ b/packages/loopring_v3/contracts/test/TestSwappperBridge.sol
@@ -14,7 +14,7 @@ import "../aux/bridge/IBridge.sol";
 
 
 /// @author Brecht Devos - <brecht@loopring.org>
-contract TestSwappperBridgeConnector is IBridgeConnector
+contract TestSwappperBridge is IBridge
 {
     using AddressUtil       for address payable;
     using ERC20SafeTransfer for address;
@@ -43,13 +43,13 @@ contract TestSwappperBridgeConnector is IBridgeConnector
         external
         payable
         override
-        returns (BridgeTransfer[] memory)
+        returns (L2Transfer[] memory)
     {
         uint numTransfers = 0;
         for (uint g = 0; g < groups.length; g++) {
             numTransfers += groups[g].calls.length;
         }
-        BridgeTransfer[] memory transfers = new BridgeTransfer[](numTransfers);
+        L2Transfer[] memory transfers = new L2Transfer[](numTransfers);
         uint transferIdx = 0;
 
         BridgeCall memory bridgeCall;
@@ -112,14 +112,14 @@ contract TestSwappperBridgeConnector is IBridgeConnector
             for (uint i = 0; i < calls.length; i++) {
                 if (valid[i]) {
                     // Give equal share to all valid calls
-                    transfers[transferIdx++] = BridgeTransfer({
+                    transfers[transferIdx++] = L2Transfer({
                         owner: calls[i].owner,
                         token: settings.tokenOut,
                         amount: (uint(calls[i].amount).mul(amountOut) / amountIn).toUint96()
                     });
                 } else {
                     // Just transfer the tokens back
-                    transfers[transferIdx++] = BridgeTransfer({
+                    transfers[transferIdx++] = L2Transfer({
                         owner: calls[i].owner,
                         token: calls[i].token,
                         amount: calls[i].amount

--- a/packages/loopring_v3/test/testBridge.ts
+++ b/packages/loopring_v3/test/testBridge.ts
@@ -900,19 +900,19 @@ contract("Bridge", (accounts: string[]) => {
     it("Bridge calls", async () => {
       const bridge = await setupBridge();
 
-      await bridge.contract.setConnectorTrusted(
+      await bridge.contract.trustConnector(
         swappperBridgeConnectorA.address,
         true
       );
-      await bridge.contract.setConnectorTrusted(
+      await bridge.contract.trustConnector(
         swappperBridgeConnectorB.address,
         true
       );
-      await bridge.contract.setConnectorTrusted(
+      await bridge.contract.trustConnector(
         failingSwappperBridgeConnector.address,
         true
       );
-      await bridge.contract.setConnectorTrusted(
+      await bridge.contract.trustConnector(
         migrationBridgeConnector.address,
         true
       );


### PR DESCRIPTION
Basically rename `IBridge` to `IBatchDeposit`, `IBridgeConnector` to `IBridge`. Previously IBridgeConnector can trust addresses as connectors, which is confusing.

@Brechtpd let me know if you like these renaming ideas.



Another improvement of the Bridge design is to extract the common logic inside the `processCalls` funciton. As you can see inside this PR, TestSwappperBridge and TestMigrationBridge have a lot of duplicate code inside the `processCalls` funciton. Maybe we should define another virtual function to handle Bridge specific logic, for example `processSingleCall`, then `processCalls` can simply call this new method. If the common logic should be overridden in a custom Bridge, we can make `processCalls` virtual as well.