### PR TITLE
Amm v2 - AssetManager fix

### DIFF
--- a/packages/loopring_v3.js/src/exchange_v3.ts
+++ b/packages/loopring_v3.js/src/exchange_v3.ts
@@ -626,7 +626,7 @@ export class ExchangeV3 {
 
     // Get the block data from the transaction data
     //const submitBlocksFunctionSignature = "0x8dadd3af"; // submitBlocks
-    const submitBlocksFunctionSignature = "0xc39ce618"; // submitBlocksWithCallbacks
+    const submitBlocksFunctionSignature = "0xfbb404ab"; // submitBlocksWithCallbacks
 
     const transaction = await this.web3.eth.getTransaction(
       event.transactionHash

--- a/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
+++ b/packages/loopring_v3/circuit/Circuits/SpotTradeCircuit.h
@@ -201,10 +201,30 @@ class SpotTradeCircuit : public BaseTransactionCircuit
           vfills_B_A(pb, orderA.amm.packed, fillS_B.value(), state.constants._0, FMT(prefix, ".vfills_B_A")),
           vfills_S_B(pb, orderB.amm.packed, fillS_B.value(), state.constants._0, FMT(prefix, ".vfills_S_B")),
           vfills_B_B(pb, orderB.amm.packed, fillS_A.value(), state.constants._0, FMT(prefix, ".vfills_B_B")),
-          update_vbalanceS_A(pb, state.accountA.balanceS.weightAMM, vfills_S_A.result(), NUM_BITS_AMOUNT, FMT(prefix, ".update_vbalanceS_A")),
-          update_vbalanceB_A(pb, state.accountA.balanceB.weightAMM, vfills_B_A.result(), NUM_BITS_AMOUNT, FMT(prefix, ".update_vbalanceB_A")),
-          update_vbalanceS_B(pb, state.accountB.balanceS.weightAMM, vfills_S_B.result(), NUM_BITS_AMOUNT, FMT(prefix, ".update_vbalanceS_B")),
-          update_vbalanceB_B(pb, state.accountB.balanceB.weightAMM, vfills_B_B.result(), NUM_BITS_AMOUNT, FMT(prefix, ".update_vbalanceB_B")),
+          update_vbalanceS_A(
+            pb,
+            state.accountA.balanceS.weightAMM,
+            vfills_S_A.result(),
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".update_vbalanceS_A")),
+          update_vbalanceB_A(
+            pb,
+            state.accountA.balanceB.weightAMM,
+            vfills_B_A.result(),
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".update_vbalanceB_A")),
+          update_vbalanceS_B(
+            pb,
+            state.accountB.balanceS.weightAMM,
+            vfills_S_B.result(),
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".update_vbalanceS_B")),
+          update_vbalanceB_B(
+            pb,
+            state.accountB.balanceB.weightAMM,
+            vfills_B_B.result(),
+            NUM_BITS_AMOUNT,
+            FMT(prefix, ".update_vbalanceB_B")),
 
           validateAMM(
             pb,

--- a/packages/loopring_v3/circuit/Gadgets/AccountGadgets.h
+++ b/packages/loopring_v3/circuit/Gadgets/AccountGadgets.h
@@ -335,7 +335,6 @@ class DynamicBalanceGadget : public DynamicVariableGadget
     }
 };
 
-
 } // namespace Loopring
 
 #endif

--- a/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 Loopring Technology Limited.
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "./IAmmController.sol";
 import "../amm/LoopringAmmPool.sol";
@@ -19,7 +20,13 @@ contract AmplifiedAmmController is IAmmController, Claimable
 
     uint public constant AMPLIFICATION_FACTOR_BASE = (10 ** 18);
 
+    uint public constant MIN_CURVE_CHANGE_DELAY   = 7 days;
+    uint public constant CURVE_CHANGE_AUTH_WINDOW = 7 days;
+
     mapping(address => uint) public amplificationFactors;
+
+    mapping(address => uint) public curveChangeAuthorization;
+
 
     function getInitialVirtualBalances(
         uint96[] memory joinAmounts
@@ -37,44 +44,96 @@ contract AmplifiedAmmController is IAmmController, Claimable
         return vTokenBalancesL2;
     }
 
-    function getVirtualBalances(
-        uint96[] memory tokenBalancesL2,
-        uint96[] memory /*vTokenBalancesL2*/
+   function authorizeVirtualBalances(
+        uint96[] memory balances,
+        uint96[] memory /*vBalancesOld*/,
+        uint96[] memory vBalancesNew,
+        bytes    memory /*data*/
         )
         external
-        view
         override
-        returns (uint96[] memory)
+        returns (bool)
     {
-        // Only allow updating the virtual balances if the AF = 1
-        require(getAmplificationFactor(msg.sender) == AMPLIFICATION_FACTOR_BASE, "INVALID_OPERATION");
+        address pool = msg.sender;
 
-        // Just set the virtual balances to the actual balances
-        uint96[] memory vTokenBalancesL2 = new uint96[](tokenBalancesL2.length);
-        for (uint i = 0; i < tokenBalancesL2.length; i++) {
-            vTokenBalancesL2[i] = tokenBalancesL2[i];
+        // Check if a curve change was explicitly authorized
+        if (consumeCurveChangeAuthorized(pool)) {
+            return true;
         }
-        return vTokenBalancesL2;
+
+        // Special case: Always allow updating the virtual balances if the AF = 1
+        if (getAmplificationFactor(pool) == AMPLIFICATION_FACTOR_BASE) {
+            for (uint i = 0; i < balances.length; i++) {
+                if(vBalancesNew[i] != balances[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    function authorizeCurveChange(address pool)
+        external
+        onlyOwner
+    {
+        curveChangeAuthorization[pool] = block.timestamp + MIN_CURVE_CHANGE_DELAY;
     }
 
     function setAmplificationFactor(
-        address amm,
+        address pool,
         uint    amplificationFactor
         )
         external
         onlyOwner
     {
-        amplificationFactors[amm] = amplificationFactor;
+        amplificationFactors[pool] = amplificationFactor;
     }
 
-    function getAmplificationFactor(address amm)
+    function getAmplificationFactor(address pool)
         public
         view
         returns (uint amplificationFactor)
     {
-        amplificationFactor = amplificationFactors[amm];
+        amplificationFactor = amplificationFactors[pool];
         if (amplificationFactor == 0) {
             amplificationFactor = AMPLIFICATION_FACTOR_BASE;
         }
+    }
+
+    function setupPool(
+        LoopringAmmPool pool,
+        AmmData.PoolConfig calldata config
+        )
+        external
+        onlyOwner
+    {
+        pool.setupPool(config);
+    }
+
+    function enterExitMode(
+        LoopringAmmPool pool,
+        bool enabled
+        )
+        external
+        onlyOwner
+    {
+        pool.enterExitMode(enabled);
+    }
+
+    // == Internal Functions ==
+
+    function consumeCurveChangeAuthorized(address pool)
+        internal
+        returns (bool)
+    {
+        uint timestamp = curveChangeAuthorization[pool];
+        bool authorized = (timestamp <= block.timestamp) && (block.timestamp <= timestamp + MIN_CURVE_CHANGE_DELAY);
+
+        // Remove authorization
+        delete curveChangeAuthorization[pool];
+
+        return authorized;
     }
 }

--- a/packages/loopring_v3/contracts/amm/IAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/IAmmController.sol
@@ -18,14 +18,17 @@ interface IAmmController
 
     /// @dev Called by the pool contract when a SET_VIRTUAL_BALANCES operation is done
     ///      on the pool.
-    /// @param tokenBalancesL2 The balances in the pool
-    /// @param vTokenBalancesL2 The current virtual balances in the pool
-    /// @return The new virtual balances in the pool
-    function getVirtualBalances(
-        uint96[] memory tokenBalancesL2,
-        uint96[] memory vTokenBalancesL2
+    /// @param balances The balances in the pool
+    /// @param vBalancesOld The current virtual balances in the pool
+    /// @param vBalancesNew The new virtual balances in the pool
+    /// @param data Custom data
+    /// @return True if vBalancesNew can be used, else false
+    function authorizeVirtualBalances(
+        uint96[] memory balances,
+        uint96[] memory vBalancesOld,
+        uint96[] memory vBalancesNew,
+        bytes    memory data
         )
         external
-        view
-        returns (uint96[] memory);
+        returns (bool);
 }

--- a/packages/loopring_v3/contracts/amm/IAssetManager.sol
+++ b/packages/loopring_v3/contracts/amm/IAssetManager.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+
+
+/// @author Brecht Devos - <brecht@loopring.org>
+interface IAssetManager
+{}

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -107,6 +107,7 @@ contract LoopringAmmPool is
         external
         onlyFromController
     {
+        require(state.exitMode != enabled, "INVALID_STATE");
         state.exitMode = enabled;
     }
 

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -79,6 +79,7 @@ contract LoopringAmmPool is
         bool           _joinsDisabled
     )
     {
+        require(_controller != IAmmController(0), "ZERO_ADDRESS");
         controller = _controller;
         assetManager = _assetManager;
         joinsDisabled = _joinsDisabled;
@@ -98,7 +99,15 @@ contract LoopringAmmPool is
         external
         nonReentrant
     {
+        require(state.accountID == 0 || msg.sender == address(controller), "UNAUTHORIZED");
         state.setupPool(config);
+    }
+
+    function enterExitMode(bool enabled)
+        external
+        onlyFromController
+    {
+        state.exitMode = enabled;
     }
 
     // Anyone is able to shut down the pool when requests aren't being processed any more.
@@ -113,7 +122,6 @@ contract LoopringAmmPool is
 
     function shutdownByController()
         external
-        payable
         onlyWhenOnline
         nonReentrant
         onlyFromController

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -211,7 +211,7 @@ contract LoopringAmmPool is
     function getBalanceL1(
         address token
         )
-        external
+        public
         view
         returns (uint96)
     {

--- a/packages/loopring_v3/contracts/amm/libamm/AmmAssetManagement.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmAssetManagement.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../lib/ERC20.sol";
+import "../../lib/MathUint.sol";
+import "../../lib/TransferUtil.sol";
+import "./AmmData.sol";
+
+
+/// @title AmmAssetManagement
+library AmmAssetManagement
+{
+    using TransferUtil      for address;
+
+    function deposit(
+        AmmData.State storage S,
+        address               token,
+        uint96                amount
+        )
+        public
+    {
+        if (amount == 0) {
+            return;
+        }
+        uint ethValue = 0;
+        if (token == address(0)) {
+            ethValue = amount;
+        } else {
+            ERC20(token).approve(address(S.exchange.getDepositContract()), amount);
+        }
+        S.exchange.deposit{value: ethValue}(
+            address(this),
+            address(this),
+            token,
+            amount,
+            new bytes(0)
+        );
+    }
+
+    function transferOut(
+        AmmData.State storage /*S*/,
+        address               to,
+        address               token,
+        uint                  amount
+        )
+        public
+    {
+        token.transferOut(to, amount);
+    }
+}

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -122,9 +122,9 @@ library AmmData
         string symbol;
         uint   _totalSupply;
 
-        mapping(address => uint) balanceOf;
-        mapping(address => mapping(address => uint)) allowance;
-        mapping(address => uint) nonces;
+        mapping (address => uint)                      balanceOf;
+        mapping (address => mapping (address => uint)) allowance;
+        mapping (address => uint)                      nonces;
 
         // AMM pool state variables
         IAmmSharedConfig sharedConfig;
@@ -149,6 +149,7 @@ library AmmData
         mapping (bytes32 => bool) approvedTx;
 
         mapping (address => uint96) balancesL1;
-        bool exitMode;
+
+        bool        exitMode;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -6,6 +6,7 @@ pragma experimental ABIEncoderV2;
 import "../../core/iface/ExchangeData.sol";
 import "../../core/iface/IExchangeV3.sol";
 import "../IAmmController.sol";
+import "../IAssetManager.sol";
 import "./IAmmSharedConfig.sol";
 
 
@@ -83,7 +84,7 @@ library AmmData
 
     struct Settings {
         IAmmController controller;
-        address        assetManager;
+        IAssetManager  assetManager;
         bool           joinsDisabled;
     }
 
@@ -139,5 +140,7 @@ library AmmData
         // A map from a user to the forced exit.
         mapping (address => PoolExit) forcedExit;
         mapping (bytes32 => bool) approvedTx;
+
+        mapping (address => uint96) balancesL1;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -58,6 +58,12 @@ library AmmData
         uint32    validUntil;
     }
 
+    struct PoolVirtualBalances
+    {
+        uint96[]  vBalancesNew;
+        bytes     data;
+    }
+
     struct PoolDeposit
     {
         uint96[]  amounts;
@@ -82,7 +88,8 @@ library AmmData
         uint16  tokenID;
     }
 
-    struct Settings {
+    struct Settings
+    {
         IAmmController controller;
         IAssetManager  assetManager;
         bool           joinsDisabled;
@@ -142,5 +149,6 @@ library AmmData
         mapping (bytes32 => bool) approvedTx;
 
         mapping (address => uint96) balancesL1;
+        bool exitMode;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
@@ -30,11 +30,13 @@ library AmmDepositProcess
     {
         require(poolDeposit.amounts.length == ctx.tokens.length, "INVALID_DEPOSIT_DATA");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            address token = ctx.tokens[i].addr;
             uint96 amount = poolDeposit.amounts[i];
-            verifyDepositTx(ctx, ctx.tokens[i].tokenID, amount);
-            S.deposit(token, amount);
-            S.balancesL1[token] = S.balancesL1[token].sub(amount);
+            if (amount > 0) {
+                address token = ctx.tokens[i].addr;
+                verifyDepositTx(ctx, ctx.tokens[i].tokenID, amount);
+                S.deposit(token, amount);
+                S.balancesL1[token] = S.balancesL1[token].sub(amount);
+            }
         }
     }
 
@@ -68,7 +70,7 @@ library AmmDepositProcess
             // tokenID == tokenID &&
             packedData & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffff == (uint(ExchangeData.TransactionType.DEPOSIT) << 208) | (uint(address(this)) << 48) | (uint(ctx.accountID) << 16) | uint(tokenID) &&
             amount == txAmount,
-            "INVALID_DEPOSIT_TX_DATA"
+            "INVALID_AMM_DEPOSIT_TX_DATA"
         );
 
         ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
@@ -30,9 +30,11 @@ library AmmDepositProcess
     {
         require(poolDeposit.amounts.length == ctx.tokens.length, "INVALID_DEPOSIT_DATA");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            verifyDepositTx(ctx, ctx.tokens[i].tokenID, poolDeposit.amounts[i]);
-            S.deposit(ctx.tokens[i].addr, poolDeposit.amounts[i]);
-            S.balancesL1[ctx.tokens[i].addr] = S.balancesL1[ctx.tokens[i].addr].sub(poolDeposit.amounts[i]);
+            address token = ctx.tokens[i].addr;
+            uint96 amount = poolDeposit.amounts[i];
+            verifyDepositTx(ctx, ctx.tokens[i].tokenID, amount);
+            S.deposit(token, amount);
+            S.balancesL1[token] = S.balancesL1[token].sub(amount);
         }
     }
 
@@ -62,7 +64,7 @@ library AmmDepositProcess
         require(
             // txType == ExchangeData.TransactionType.DEPOSIT &&
             // owner == address(this) &&
-            // accountID == crx.accountID &&
+            // accountID == ctx.accountID &&
             // tokenID == tokenID &&
             packedData & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffff == (uint(ExchangeData.TransactionType.DEPOSIT) << 208) | (uint(address(this)) << 48) | (uint(ctx.accountID) << 16) | uint(tokenID) &&
             amount == txAmount,

--- a/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../lib/ERC20.sol";
+import "../../lib/MathUint96.sol";
+import "../../lib/TransferUtil.sol";
+import "./AmmAssetManagement.sol";
+import "./AmmData.sol";
+import "./AmmPoolToken.sol";
+import "./AmmStatus.sol";
+import "./AmmUtil.sol";
+import "./AmmWithdrawal.sol";
+
+
+/// @title AmmDepositProcess
+library AmmDepositProcess
+{
+    using AmmAssetManagement for AmmData.State;
+    using MathUint96         for uint96;
+    using TransferUtil       for address;
+
+    function processDeposit(
+        AmmData.State       storage S,
+        AmmData.Context     memory ctx,
+        AmmData.PoolDeposit memory poolDeposit
+        )
+        internal
+    {
+        require(poolDeposit.amounts.length == ctx.tokens.length, "INVALID_DEPOSIT_DATA");
+        for (uint i = 0; i < ctx.tokens.length; i++) {
+            verifyDepositTx(ctx, ctx.tokens[i].tokenID, poolDeposit.amounts[i]);
+            S.deposit(ctx.tokens[i].addr, poolDeposit.amounts[i]);
+            S.balancesL1[ctx.tokens[i].addr] = S.balancesL1[ctx.tokens[i].addr].sub(poolDeposit.amounts[i]);
+        }
+    }
+
+    function verifyDepositTx(
+        AmmData.Context memory ctx,
+        uint                   tokenID,
+        uint96                 amount
+        )
+        internal
+        view
+    {
+        if (amount == 0) {
+            return;
+        }
+
+        // Verify deposit data
+        // Start by reading the first 27 bytes into packedData
+        uint txsDataPtr = ctx.txsDataPtr + 27;
+        // packedData: txType (1) | owner (20) | accountID (4) | tokenID (2)
+        uint packedData;
+        uint96 txAmount;
+        assembly {
+            packedData := calldataload(txsDataPtr)
+            txAmount := calldataload(add(txsDataPtr, 12))
+        }
+
+        require(
+            // txType == ExchangeData.TransactionType.DEPOSIT &&
+            // owner == address(this) &&
+            // accountID == crx.accountID &&
+            // tokenID == tokenID &&
+            packedData & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffff == (uint(ExchangeData.TransactionType.DEPOSIT) << 208) | (uint(address(this)) << 48) | (uint(ctx.accountID) << 16) | uint(tokenID) &&
+            amount == txAmount,
+            "INVALID_DEPOSIT_TX_DATA"
+        );
+
+        ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;
+    }
+}

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -9,26 +9,26 @@ import "../../lib/EIP712.sol";
 import "../../lib/ERC20SafeTransfer.sol";
 import "../../lib/MathUint.sol";
 import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "../../lib/TransferUtil.sol";
 import "../../thirdparty/SafeCast.sol";
-import "./AmmUtil.sol";
 import "./AmmData.sol";
 import "./AmmExitRequest.sol";
 import "./AmmPoolToken.sol";
+import "./AmmSignature.sol";
+import "./AmmUtil.sol";
 
 
 /// @title AmmExitProcess
 library AmmExitProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmSignature      for bytes32;
     using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using ERC20SafeTransfer for address;
     using MathUint          for uint;
     using MathUint96        for uint96;
     using SafeCast          for uint;
-    using SignatureUtil     for bytes32;
     using TransactionReader for ExchangeData.Block;
     using TransferUtil      for address;
 
@@ -49,14 +49,18 @@ library AmmExitProcess
         bool isForcedExit = false;
 
         if (signature.length == 0) {
-            bytes32 forcedExitHash = AmmExitRequest.hash(ctx.domainSeparator, S.forcedExit[exit.owner]);
-            if (txHash == forcedExitHash) {
-                delete S.forcedExit[exit.owner];
-                S.forcedExitCount--;
-                isForcedExit = true;
+            if (S.exitMode) {
+                require(exit.fee == 0, "INVALID_FEE");
             } else {
-                require(S.approvedTx[txHash], "INVALID_ONCHAIN_APPROVAL");
-                delete S.approvedTx[txHash];
+                bytes32 forcedExitHash = AmmExitRequest.hash(ctx.domainSeparator, S.forcedExit[exit.owner]);
+                if (txHash == forcedExitHash) {
+                    delete S.forcedExit[exit.owner];
+                    S.forcedExitCount--;
+                    isForcedExit = true;
+                } else {
+                    require(S.approvedTx[txHash], "INVALID_ONCHAIN_APPROVAL");
+                    delete S.approvedTx[txHash];
+                }
             }
         } else if (signature.length == 1) {
             ctx.verifySignatureL2(exit.owner, txHash, signature);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -8,11 +8,11 @@ import "../../core/impl/libtransactions/TransferTransaction.sol";
 import "../../lib/EIP712.sol";
 import "../../lib/MathUint.sol";
 import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "../../thirdparty/SafeCast.sol";
 import "./AmmData.sol";
 import "./AmmJoinRequest.sol";
 import "./AmmPoolToken.sol";
+import "./AmmSignature.sol";
 import "./AmmUtil.sol";
 
 
@@ -20,13 +20,13 @@ import "./AmmUtil.sol";
 library AmmJoinProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmSignature      for bytes32;
     using AmmUtil           for AmmData.State;
     using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using MathUint          for uint;
     using MathUint96        for uint96;
     using SafeCast          for uint;
-    using SignatureUtil     for bytes32;
     using TransactionReader for ExchangeData.Block;
 
     // event JoinProcessed(address owner, uint96 mintAmount, uint96[] amounts);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
@@ -80,7 +80,7 @@ library AmmPoolToken
         uint256               deadline,
         bytes        calldata signature
         )
-        internal
+        public
     {
         require(deadline >= block.timestamp, 'EXPIRED');
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmSignature.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmSignature.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../lib/SignatureUtil.sol";
+
+
+/// @title AmmSignature
+library AmmSignature
+{
+    using SignatureUtil     for bytes32;
+
+    function verifySignature(
+        bytes32        signHash,
+        address        signer,
+        bytes   memory signature
+        )
+        public
+        view
+        returns (bool)
+    {
+        return signHash.verifySignature(signer, signature);
+    }
+}

--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -5,23 +5,13 @@ pragma experimental ABIEncoderV2;
 
 import "../../core/iface/IExchangeV3.sol";
 import "../../lib/EIP712.sol";
-import "../../lib/ERC20.sol";
-import "../../lib/MathUint.sol";
-import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "./AmmData.sol";
-import "./AmmPoolToken.sol";
 import "./IAmmSharedConfig.sol";
 
 
 /// @title AmmStatus
 library AmmStatus
 {
-    using AmmPoolToken      for AmmData.State;
-    using MathUint          for uint;
-    using MathUint96        for uint96;
-    using SignatureUtil     for bytes32;
-
     event Shutdown(uint timestamp);
 
     function isOnline(AmmData.State storage S)
@@ -42,26 +32,26 @@ library AmmStatus
             bytes(config.poolName).length > 0 && bytes(config.tokenSymbol).length > 0,
             "INVALID_NAME_OR_SYMBOL"
         );
+
         require(config.sharedConfig != address(0), "INVALID_SHARED_CONFIG");
         require(config.tokens.length == config.weights.length, "INVALID_DATA");
         require(config.tokens.length >= 2, "INVALID_DATA");
         require(config.exchange != address(0), "INVALID_EXCHANGE");
         require(config.accountID != 0, "INVALID_ACCOUNT_ID");
-        require(S.tokens.length == 0, "ALREADY_INITIALIZED");
 
-        S.sharedConfig = IAmmSharedConfig(config.sharedConfig);
-        IExchangeV3 exchange = IExchangeV3(config.exchange);
-        S.exchange = exchange;
-        S.exchangeOwner = exchange.owner();
-        S.exchangeDomainSeparator = exchange.getDomainSeparator();
-        S.accountID = config.accountID;
-        S.poolTokenID = exchange.getTokenID(address(this));
+        require(S._totalSupply == 0, "POOL_IN_USE");
+
         S.feeBips = config.feeBips;
         S.domainSeparator = EIP712.hash(EIP712.Domain(config.poolName, "1.0.0", address(this)));
 
         S.poolName = config.poolName;
         S.symbol = config.tokenSymbol;
+        S.shutdownTimestamp = 0;
+        S.exitMode = false;
 
+        IExchangeV3 exchange = IExchangeV3(config.exchange);
+
+        delete S.tokens;
         for (uint i = 0; i < config.tokens.length; i++) {
             address token = config.tokens[i];
             S.tokens.push(AmmData.Token({
@@ -71,16 +61,26 @@ library AmmStatus
             }));
         }
 
-        // Mint all liquidity tokens to the pool account on L2
-        S.balanceOf[address(this)] = AmmData.POOL_TOKEN_MINTED_SUPPLY;
-        S.allowance[address(this)][address(exchange.getDepositContract())] = type(uint256).max;
-        exchange.deposit(
-            address(this), // from
-            address(this), // to
-            address(this), // token
-            uint96(AmmData.POOL_TOKEN_MINTED_SUPPLY),
-            new bytes(0)
-        );
+        bool newPool = (S.accountID == 0);
+        if (newPool) {
+            S.sharedConfig = IAmmSharedConfig(config.sharedConfig);
+            S.exchange = exchange;
+            S.exchangeOwner = exchange.owner();
+            S.exchangeDomainSeparator = exchange.getDomainSeparator();
+            S.accountID = config.accountID;
+            S.poolTokenID = exchange.getTokenID(address(this));
+
+            // Mint all liquidity tokens to the pool account on L2
+            S.balanceOf[address(this)] = AmmData.POOL_TOKEN_MINTED_SUPPLY;
+            S.allowance[address(this)][address(exchange.getDepositContract())] = type(uint256).max;
+            exchange.deposit(
+                address(this), // from
+                address(this), // to
+                address(this), // token
+                uint96(AmmData.POOL_TOKEN_MINTED_SUPPLY),
+                new bytes(0)
+            );
+        }
     }
 
     // Anyone is able to shut down the pool when requests aren't being processed any more.

--- a/packages/loopring_v3/contracts/amm/libamm/AmmTransactionReceiver.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmTransactionReceiver.sol
@@ -6,25 +6,29 @@ pragma experimental ABIEncoderV2;
 import "../../core/impl/libtransactions/BlockReader.sol";
 import "../../lib/MathUint.sol";
 import "../../thirdparty/SafeCast.sol";
+import "./AmmDepositProcess.sol";
 import "./AmmData.sol";
 import "./AmmExitProcess.sol";
 import "./AmmJoinProcess.sol";
 import "./AmmPoolToken.sol";
 import "./AmmUpdateProcess.sol";
+import "./AmmWithdrawProcess.sol";
 
 
 /// @title AmmTransactionReceiver
 library AmmTransactionReceiver
 {
-    using AmmExitProcess    for AmmData.State;
-    using AmmJoinProcess    for AmmData.State;
-    using AmmPoolToken      for AmmData.State;
-    using AmmUtil           for AmmData.State;
-    using AmmUpdateProcess  for AmmData.Context;
-    using BlockReader       for bytes;
-    using MathUint          for uint;
-    using MathUint96        for uint96;
-    using SafeCast          for uint;
+    using AmmDepositProcess  for AmmData.State;
+    using AmmExitProcess     for AmmData.State;
+    using AmmJoinProcess     for AmmData.State;
+    using AmmPoolToken       for AmmData.State;
+    using AmmUtil            for AmmData.State;
+    using AmmUpdateProcess   for AmmData.State;
+    using AmmWithdrawProcess for AmmData.State;
+    using BlockReader        for bytes;
+    using MathUint           for uint;
+    using MathUint96         for uint96;
+    using SafeCast           for uint;
 
     function onReceiveTransactions(
         AmmData.State    storage  S,
@@ -101,110 +105,37 @@ library AmmTransactionReceiver
             signature.offset := add(signature.offset, 0x20)
         }
         if (txType == AmmData.PoolTxType.JOIN) {
-            ctx.approveAmmUpdates(true);
+            S.approveAmmUpdates(ctx, true);
             S.processJoin(
                 ctx,
                 abi.decode(data, (AmmData.PoolJoin)),
                 signature
             );
-            ctx.approveAmmUpdates(false);
+            S.approveAmmUpdates(ctx, false);
         } else if (txType == AmmData.PoolTxType.EXIT) {
-            ctx.approveAmmUpdates(true);
+            S.approveAmmUpdates(ctx, true);
             S.processExit(
                 ctx,
                 abi.decode(data, (AmmData.PoolExit)),
                 signature
             );
-            ctx.approveAmmUpdates(false);
+            S.approveAmmUpdates(ctx, false);
         } else if (txType == AmmData.PoolTxType.SET_VIRTUAL_BALANCES) {
-            ctx.approveAmmUpdates(true);
+            S.approveAmmUpdates(ctx, true);
             ctx.vTokenBalancesL2 = ctx.settings.controller.getVirtualBalances(ctx.tokenBalancesL2, ctx.vTokenBalancesL2);
-            ctx.approveAmmUpdates(false);
+            S.approveAmmUpdates(ctx, false);
         } else if (txType == AmmData.PoolTxType.DEPOSIT) {
-            AmmData.PoolDeposit memory poolDeposit = abi.decode(data, (AmmData.PoolDeposit));
-            require(poolDeposit.amounts.length == ctx.tokens.length, "INVALID_DEPOSIT_AMOUNTS");
-            for (uint i = 0; i < ctx.tokens.length; i++) {
-                deposit(S, ctx.tokens[i].addr, poolDeposit.amounts[i]);
-            }
-        } else if (txType == AmmData.PoolTxType.WITHDRAW) {
-            AmmData.PoolWithdrawal memory poolWithdrawal = abi.decode(data, (AmmData.PoolWithdrawal));
-            require(poolWithdrawal.amounts.length == ctx.tokens.length, "INVALID_WITHDRAWAL_AMOUNTS");
-            for (uint i = 0; i < ctx.tokens.length; i++) {
-                withdraw(ctx, ctx.tokens[i].tokenID, poolWithdrawal.amounts[i]);
-            }
+            S.processDeposit(
+                ctx,
+                abi.decode(data, (AmmData.PoolDeposit))
+            );
+         } else if (txType == AmmData.PoolTxType.WITHDRAW) {
+             S.processWithdrawal(
+                ctx,
+                abi.decode(data, (AmmData.PoolWithdrawal))
+            );
         } else {
             revert("INVALID_POOL_TX_TYPE");
         }
-    }
-
-    function deposit(
-        AmmData.State storage S,
-        address               token,
-        uint96                amount
-        )
-        internal
-    {
-        if (amount == 0) {
-            return;
-        }
-        uint ethValue = 0;
-        if (token == address(0)) {
-            ethValue = amount;
-        } else {
-            ERC20(token).approve(address(S.exchange.getDepositContract()), amount);
-        }
-        S.exchange.deposit{value: ethValue}(
-            address(this),
-            address(this),
-            token,
-            amount,
-            new bytes(0)
-        );
-    }
-
-    function withdraw(
-        AmmData.Context memory ctx,
-        uint                   tokenID,
-        uint96                 amount
-        )
-        internal
-        view
-    {
-        if (amount == 0) {
-            return;
-        }
-
-        bytes20 onchainDataHash = WithdrawTransaction.hashOnchainData(
-            0,                  // Withdrawal needs to succeed no matter the gas coast
-            address(this),      // Withdraw to this contract first
-            new bytes(0)
-        );
-
-        // Verify withdrawal data
-        // Start by reading the first 2 bytes into header
-        uint txsDataPtr = ctx.txsDataPtr + 2;
-        // header: txType (1) | type (1)
-        uint header;
-        // packedData: tokenID (2) | amount (12) | feeTokenID (2) | fee (2)
-        uint packedData;
-        bytes20 dataHash;
-        assembly {
-            header     := calldataload(    txsDataPtr     )
-            packedData := calldataload(add(txsDataPtr, 42))
-            dataHash   := and(calldataload(add(txsDataPtr, 78)), 0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000)
-        }
-        require(
-            // txType == ExchangeData.TransactionType.WITHDRAWAL &&
-            // withdrawal.type == 1 &&
-            header & 0xffff == (uint(ExchangeData.TransactionType.WITHDRAWAL) << 8) | 1 &&
-            // withdrawal.tokenID == token.tokenID &&
-            // withdrawal.amount == token.amount &&
-            // withdrawal.fee == 0,
-            packedData & 0xffffffffffffffffffffffffffff0000ffff == (uint(tokenID) << 128) | (uint(amount) << 32) &&
-            onchainDataHash == dataHash,
-            "INVALID_WITHDRAWAL_TX_DATA"
-        );
-
-        ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
@@ -28,8 +28,10 @@ library AmmWithdrawProcess
         require(ctx.settings.assetManager != IAssetManager(0), "CANNOT_WITHDRAW_FROM_POOL");
         require(poolWithdrawal.amounts.length == ctx.tokens.length, "INVALID_WITHDRAWAL_AMOUNTS");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, poolWithdrawal.amounts[i]);
-            S.balancesL1[ctx.tokens[i].addr] = S.balancesL1[ctx.tokens[i].addr].add(poolWithdrawal.amounts[i]);
+            address token = ctx.tokens[i].addr;
+            uint96 amount = poolWithdrawal.amounts[i];
+            verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, amount);
+            S.balancesL1[token] = S.balancesL1[token].add(amount);
         }
     }
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../lib/ERC20.sol";
+import "../../lib/MathUint96.sol";
+import "../../lib/TransferUtil.sol";
+import "./AmmData.sol";
+import "./AmmPoolToken.sol";
+import "./AmmStatus.sol";
+import "./AmmUtil.sol";
+
+
+/// @title AmmWithdrawProcess
+library AmmWithdrawProcess
+{
+    using MathUint96        for uint96;
+    using TransferUtil      for address;
+
+    function processWithdrawal(
+        AmmData.State          storage S,
+        AmmData.Context        memory ctx,
+        AmmData.PoolWithdrawal memory poolWithdrawal
+        )
+        internal
+    {
+        require(ctx.settings.assetManager != IAssetManager(0), "CANNOT_WITHDRAW_FROM_POOL");
+        require(poolWithdrawal.amounts.length == ctx.tokens.length, "INVALID_WITHDRAWAL_AMOUNTS");
+        for (uint i = 0; i < ctx.tokens.length; i++) {
+            verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, poolWithdrawal.amounts[i]);
+            S.balancesL1[ctx.tokens[i].addr] = S.balancesL1[ctx.tokens[i].addr].add(poolWithdrawal.amounts[i]);
+        }
+    }
+
+    function verifyWithdrawalTx(
+        AmmData.Context memory ctx,
+        uint                   tokenID,
+        uint96                 amount
+        )
+        internal
+        view
+    {
+        if (amount == 0) {
+            return;
+        }
+
+        bytes20 onchainDataHash = WithdrawTransaction.hashOnchainData(
+            0,                  // Withdrawal needs to succeed no matter the gas coast
+            address(this),      // Withdraw to this contract first
+            new bytes(0)
+        );
+
+        // Verify withdrawal data
+        // Start by reading the first 2 bytes into header
+        uint txsDataPtr = ctx.txsDataPtr + 2;
+        // header: txType (1) | type (1)
+        uint header;
+        // packedData: tokenID (2) | amount (12) | feeTokenID (2) | fee (2)
+        uint packedData;
+        bytes20 dataHash;
+        assembly {
+            header     := calldataload(    txsDataPtr     )
+            packedData := calldataload(add(txsDataPtr, 42))
+            dataHash   := and(calldataload(add(txsDataPtr, 78)), 0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000)
+        }
+
+        require(
+            // txType == ExchangeData.TransactionType.WITHDRAWAL &&
+            // withdrawal.type == 1 &&
+            header & 0xffff == (uint(ExchangeData.TransactionType.WITHDRAWAL) << 8) | 1 &&
+            // withdrawal.tokenID == token.tokenID &&
+            // withdrawal.amount == token.amount &&
+            // withdrawal.fee == 0,
+            packedData & 0xffffffffffffffffffffffffffff0000ffff == (uint(tokenID) << 128) | (uint(amount) << 32) &&
+            onchainDataHash == dataHash,
+            "INVALID_WITHDRAWAL_TX_DATA"
+        );
+
+        ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;
+    }
+}

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
@@ -28,10 +28,12 @@ library AmmWithdrawProcess
         require(ctx.settings.assetManager != IAssetManager(0), "CANNOT_WITHDRAW_FROM_POOL");
         require(poolWithdrawal.amounts.length == ctx.tokens.length, "INVALID_WITHDRAWAL_AMOUNTS");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            address token = ctx.tokens[i].addr;
             uint96 amount = poolWithdrawal.amounts[i];
-            verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, amount);
-            S.balancesL1[token] = S.balancesL1[token].add(amount);
+            if (amount > 0) {
+                address token = ctx.tokens[i].addr;
+                verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, amount);
+                S.balancesL1[token] = S.balancesL1[token].add(amount);
+            }
         }
     }
 
@@ -76,7 +78,7 @@ library AmmWithdrawProcess
             // withdrawal.fee == 0,
             packedData & 0xffffffffffffffffffffffffffff0000ffff == (uint(tokenID) << 128) | (uint(amount) << 32) &&
             onchainDataHash == dataHash,
-            "INVALID_WITHDRAWAL_TX_DATA"
+            "INVALID_AMM_WITHDRAWAL_TX_DATA"
         );
 
         ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;

--- a/packages/loopring_v3/contracts/aux/access/DelayedTransaction.sol
+++ b/packages/loopring_v3/contracts/aux/access/DelayedTransaction.sol
@@ -110,11 +110,11 @@ abstract contract DelayedTransaction is IDelayedTransaction, ReentrancyGuard
     {
         // First cache all transactions ids of the transactions we will remove
         uint[] memory transactionIds = new uint[](pendingTransactions.length);
-        for(uint i = 0; i < pendingTransactions.length; i++) {
+        for (uint i = 0; i < pendingTransactions.length; i++) {
             transactionIds[i] = pendingTransactions[i].id;
         }
         // Now remove all delayed transactions
-        for(uint i = 0; i < transactionIds.length; i++) {
+        for (uint i = 0; i < transactionIds.length; i++) {
             cancelTransactionInternal(transactionIds[i]);
         }
     }

--- a/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
+++ b/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
@@ -48,7 +48,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
     {
         TransactionReceiverCallback[] callbacks;
         address[]                     receivers;
-        bool                          before;
+        bool                          beforeBlockSubmission;
     }
 
     struct SubmitBlocksCallback
@@ -144,7 +144,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
             IExchangeV3(target).flashDeposit(flashDeposits);
         }
 
-        if (txReceiverCallbacks.before) {
+        if (txReceiverCallbacks.beforeBlockSubmission) {
             // Do transaction verifying blocks callbacks
             _verifyTransactions(blocks, txReceiverCallbacks);
         }
@@ -152,7 +152,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
         // Submit blocks
         target.fastCallAndVerify(gasleft(), 0, decompressed);
 
-        if (!txReceiverCallbacks.before) {
+        if (!txReceiverCallbacks.beforeBlockSubmission) {
             // Do transaction verifying blocks callbacks
             _verifyTransactions(blocks, txReceiverCallbacks);
         }

--- a/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
+++ b/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
@@ -48,6 +48,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
     {
         TransactionReceiverCallback[] callbacks;
         address[]                     receivers;
+        bool                          before;
     }
 
     struct SubmitBlocksCallback
@@ -143,11 +144,18 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
             IExchangeV3(target).flashDeposit(flashDeposits);
         }
 
+        if (txReceiverCallbacks.before) {
+            // Do transaction verifying blocks callbacks
+            _verifyTransactions(blocks, txReceiverCallbacks);
+        }
+
         // Submit blocks
         target.fastCallAndVerify(gasleft(), 0, decompressed);
 
-        // Do transaction verifying blocks callbacks
-        _verifyTransactions(blocks, txReceiverCallbacks);
+        if (!txReceiverCallbacks.before) {
+            // Do transaction verifying blocks callbacks
+            _verifyTransactions(blocks, txReceiverCallbacks);
+        }
 
         // Do post blocks callbacks
         _processCallbacks(submitBlocksCallbacks, false);
@@ -202,7 +210,7 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
             uint txIdx;
             bool approved;
             uint auxOffset;
-            for(uint j = 0; j < auxiliaryData.length; j++) {
+            for (uint j = 0; j < auxiliaryData.length; j++) {
                 // Load the data from auxiliaryData, which is still encoded as calldata
                 assembly {
                     // Offset to auxiliaryData[j]

--- a/packages/loopring_v3/contracts/aux/access/SelectorBasedAccessManager.sol
+++ b/packages/loopring_v3/contracts/aux/access/SelectorBasedAccessManager.sol
@@ -20,7 +20,7 @@ contract SelectorBasedAccessManager is Claimable
     );
 
     address public immutable target;
-    mapping(address => mapping(bytes4 => bool)) public permissions;
+    mapping (address => mapping (bytes4 => bool)) public permissions;
 
     modifier withAccess(bytes4 selector)
     {

--- a/packages/loopring_v3/contracts/aux/bridge/BatchDepositor.sol
+++ b/packages/loopring_v3/contracts/aux/bridge/BatchDepositor.sol
@@ -56,7 +56,7 @@ abstract contract BatchDepositor is IBatchDepositor, ReentrancyGuard
     IDepositContract   public immutable depositContract;
 
     mapping (uint => mapping (bytes32 => uint)) public pendingDeposits;
-    mapping (uint => mapping(uint => bool))     public withdrawn;
+    mapping (uint => mapping (uint => bool))    public withdrawn;
     // token -> tokenID
     mapping (address => uint16)                 public cachedTokenIDs;
     uint                                        public batchIDGenerator;
@@ -193,10 +193,10 @@ abstract contract BatchDepositor is IBatchDepositor, ReentrancyGuard
             IBatchDepositor.Deposit[] memory _deposits = depositsList[i];
             for (uint j = 0; j < _deposits.length; j++) {
                 deposit = _deposits[j];
-                if(token != deposit.token) {
+                if (token != deposit.token) {
                     token = deposit.token;
                     tokenIdx = 0;
-                    while(tokenIdx < numDistinctTokens && tokens[tokenIdx].token != token) {
+                    while (tokenIdx < numDistinctTokens && tokens[tokenIdx].token != token) {
                         tokenIdx++;
                     }
                     if (tokenIdx == numDistinctTokens) {
@@ -223,7 +223,7 @@ abstract contract BatchDepositor is IBatchDepositor, ReentrancyGuard
         }
 
         // Do a normal deposit per token
-        for(uint i = 0; i < numDistinctTokens; i++) {
+        for (uint i = 0; i < numDistinctTokens; i++) {
             if (tokens[i].token == address(0)) {
                 require(tokens[i].amount == msg.value || from == address(this), "INVALID_ETH_DEPOSIT");
             }

--- a/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
+++ b/packages/loopring_v3/contracts/core/iface/ExchangeData.sol
@@ -188,7 +188,7 @@ library ExchangeData
         bytes32 merkleRoot;
 
         // List of all blocks
-        mapping(uint => BlockInfo) blocks;
+        mapping (uint => BlockInfo) blocks;
         uint  numBlocks;
 
         // List of all tokens

--- a/packages/loopring_v3/contracts/lib/LPToken.sol
+++ b/packages/loopring_v3/contracts/lib/LPToken.sol
@@ -18,10 +18,10 @@ contract LPToken is ERC20
     string  public symbol;
     uint8   public decimals;
 
-    uint                                         public override totalSupply;
-    mapping(address => uint)                     public override balanceOf;
-    mapping(address => mapping(address => uint)) public override allowance;
-    mapping(address => uint)                     public nonces;
+    uint                                           public override totalSupply;
+    mapping (address => uint)                      public override balanceOf;
+    mapping (address => mapping (address => uint)) public override allowance;
+    mapping (address => uint)                      public nonces;
 
     event Approval(address indexed owner, address indexed spender, uint value);
     event Transfer(address indexed from,  address indexed to,      uint value);

--- a/packages/loopring_v3/contracts/test/LRCToken.sol
+++ b/packages/loopring_v3/contracts/test/LRCToken.sol
@@ -60,7 +60,7 @@ library SafeMath {
  */
 contract BasicToken is ERC20Basic {
     using SafeMath for uint;
-    mapping(address => uint) balances;
+    mapping (address => uint) balances;
     uint totalSupply_;
     /**
      * @dev total number of tokens in existence

--- a/packages/loopring_v3/contracts/test/LoopringAmmPoolCopy.sol
+++ b/packages/loopring_v3/contracts/test/LoopringAmmPoolCopy.sol
@@ -8,9 +8,9 @@ import "../amm/LoopringAmmPool.sol";
 /// @title LoopringAmmPool
 contract LoopringAmmPoolCopy is LoopringAmmPool {
     constructor(
-        IAmmController _defaultController,
-        address        _defaultAssetManager,
+        IAmmController _controller,
+        IAssetManager  _assetManager,
         bool           _joinsDisabled
-    ) LoopringAmmPool(_defaultController, _defaultAssetManager, _joinsDisabled)
+    ) LoopringAmmPool(_controller, _assetManager, _joinsDisabled)
     {}
 }

--- a/packages/loopring_v3/contracts/test/TestAssetManager.sol
+++ b/packages/loopring_v3/contracts/test/TestAssetManager.sol
@@ -6,14 +6,30 @@ import "../lib/Claimable.sol";
 import "../lib/MathUint.sol";
 import "../lib/TransferUtil.sol";
 import "../amm/LoopringAmmPool.sol";
+import "../amm/IAssetManager.sol";
 
 /// @author Brecht Devos - <brecht@loopring.org>
-contract TestAssetManager is Claimable
+contract TestAssetManager is IAssetManager, Claimable
 {
     using MathUint         for uint;
     using TransferUtil     for address;
 
     mapping(address => mapping(address => uint)) public poolBalances;
+
+    function getBalances(
+        address          pool,
+        address[] memory tokens
+        )
+        external
+        view
+        returns (uint[] memory)
+    {
+        uint[] memory balances = new uint[](tokens.length);
+        for (uint i = 0; i < tokens.length; i++) {
+            balances[i] = poolBalances[address(pool)][tokens[i]];
+        }
+        return balances;
+    }
 
     function withdraw(
         LoopringAmmPool pool,
@@ -55,7 +71,7 @@ contract TestAssetManager is Claimable
         require(!pool.isOnline(), "POOL_NOT_OFFLINE");
 
         uint amount = poolBalances[address(pool)][token];
-        poolBalances[address(pool)][token] = 0;
+        delete poolBalances[address(pool)][token];
 
         token.transferOut(address(pool), amount);
     }

--- a/packages/loopring_v3/contracts/test/TestAssetManager.sol
+++ b/packages/loopring_v3/contracts/test/TestAssetManager.sol
@@ -8,13 +8,14 @@ import "../lib/TransferUtil.sol";
 import "../amm/LoopringAmmPool.sol";
 import "../amm/IAssetManager.sol";
 
+
 /// @author Brecht Devos - <brecht@loopring.org>
 contract TestAssetManager is IAssetManager, Claimable
 {
     using MathUint         for uint;
     using TransferUtil     for address;
 
-    mapping(address => mapping(address => uint)) public poolBalances;
+    mapping (address => mapping (address => uint)) public poolBalances;
 
     function getBalances(
         address          pool,

--- a/packages/loopring_v3/contracts/test/TestAssetManager.sol
+++ b/packages/loopring_v3/contracts/test/TestAssetManager.sol
@@ -20,7 +20,7 @@ contract TestAssetManager is IAssetManager, Claimable
         address          pool,
         address[] memory tokens
         )
-        external
+        public
         view
         returns (uint[] memory)
     {

--- a/packages/loopring_v3/contracts/test/TestMigrationBridgeConnector.sol
+++ b/packages/loopring_v3/contracts/test/TestMigrationBridgeConnector.sol
@@ -76,7 +76,7 @@ contract TestMigrationBridgeConnector is IBridgeConnector
                 require(txs[i].token == settings.token, "WRONG_TOKEN_IN_GROUP");
 
                 address to = bridgeCall.owner;
-                if(bridgeCall.userData.length == 32) {
+                if (bridgeCall.userData.length == 32) {
                     UserSettings memory userSettings = abi.decode(bridgeCall.userData, (UserSettings));
                     to = userSettings.to;
                 }

--- a/packages/loopring_v3/contracts/test/TestSwappperBridgeConnector.sol
+++ b/packages/loopring_v3/contracts/test/TestSwappperBridgeConnector.sol
@@ -82,7 +82,7 @@ contract TestSwappperBridgeConnector is IBridgeConnector
             uint ammountInInvalid = 0;
             for (uint i = 0; i < txs.length; i++) {
                 bridgeTx = txs[i];
-                if(valid[i] && bridgeTx.userData.length == 32) {
+                if (valid[i] && bridgeTx.userData.length == 32) {
                     UserSettings memory userSettings = abi.decode(bridgeTx.userData, (UserSettings));
                     uint userAmountOut = uint(bridgeTx.amount).mul(amountOut) / amountInExpected;
                     if (userAmountOut < userSettings.minAmountOut) {

--- a/packages/loopring_v3/contracts/thirdparty/MockContract.sol
+++ b/packages/loopring_v3/contracts/thirdparty/MockContract.sol
@@ -86,17 +86,17 @@ contract MockContract is MockInterface {
 	bytes4 public constant SENTINEL_ANY_MOCKS = hex"01";
 
 	// A linked list allows easy iteration and inclusion checks
-	mapping(bytes32 => bytes) calldataMocks;
-	mapping(bytes => MockType) calldataMockTypes;
-	mapping(bytes => bytes) calldataExpectations;
-	mapping(bytes => string) calldataRevertMessage;
-	mapping(bytes32 => uint) calldataInvocations;
+	mapping (bytes32 => bytes)   calldataMocks;
+	mapping (bytes => MockType)  calldataMockTypes;
+	mapping (bytes => bytes)     calldataExpectations;
+	mapping (bytes => string)    calldataRevertMessage;
+	mapping (bytes32 => uint)    calldataInvocations;
 
-	mapping(bytes4 => bytes4) methodIdMocks;
-	mapping(bytes4 => MockType) methodIdMockTypes;
-	mapping(bytes4 => bytes) methodIdExpectations;
-	mapping(bytes4 => string) methodIdRevertMessages;
-	mapping(bytes32 => uint) methodIdInvocations;
+	mapping (bytes4 => bytes4)   methodIdMocks;
+	mapping (bytes4 => MockType) methodIdMockTypes;
+	mapping (bytes4 => bytes)    methodIdExpectations;
+	mapping (bytes4 => string)   methodIdRevertMessages;
+	mapping (bytes32 => uint)    methodIdInvocations;
 
 	MockType fallbackMockType;
 	bytes fallbackExpectation;
@@ -261,7 +261,7 @@ contract MockContract is MockInterface {
 		bytes memory nextMock = calldataMocks[MOCKS_LIST_START];
 		bytes32 mockHash = keccak256(nextMock);
 		// We cannot compary bytes
-		while(mockHash != MOCKS_LIST_END_HASH) {
+		while (mockHash != MOCKS_LIST_END_HASH) {
 			// Reset all mock maps
 			calldataMockTypes[nextMock] = MockType.Return;
 			calldataExpectations[nextMock] = hex"";
@@ -278,7 +278,7 @@ contract MockContract is MockInterface {
 
 		// Reset all any calldataMocks
 		bytes4 nextAnyMock = methodIdMocks[SENTINEL_ANY_MOCKS];
-		while(nextAnyMock != SENTINEL_ANY_MOCKS) {
+		while (nextAnyMock != SENTINEL_ANY_MOCKS) {
 			bytes4 currentAnyMock = nextAnyMock;
 			methodIdMockTypes[currentAnyMock] = MockType.Return;
 			methodIdExpectations[currentAnyMock] = hex"";
@@ -297,7 +297,7 @@ contract MockContract is MockInterface {
 	}
 
 	function useAllGas() private {
-		while(true) {
+		while (true) {
 			bool s;
 			assembly {
 				//expensive call to EC multiply contract

--- a/packages/loopring_v3/migrations/7_deploy_amm.js
+++ b/packages/loopring_v3/migrations/7_deploy_amm.js
@@ -8,6 +8,8 @@ const AmmExitRequest = artifacts.require("AmmExitRequest");
 const AmmStatus = artifacts.require("AmmStatus");
 const AmmWithdrawal = artifacts.require("AmmWithdrawal");
 const AmmAssetManagement = artifacts.require("AmmAssetManagement");
+const AmmPoolToken = artifacts.require("AmmPoolToken");
+const AmmSignature = artifacts.require("AmmSignature");
 const AmplifiedAmmController = artifacts.require("AmplifiedAmmController");
 
 module.exports = function(deployer, network, accounts) {
@@ -15,11 +17,15 @@ module.exports = function(deployer, network, accounts) {
     deployer.then(async () => {
       await deployer.deploy(AmplifiedAmmController);
 
+      await deployer.deploy(AmmSignature);
+      await deployer.deploy(AmmPoolToken);
       await deployer.deploy(AmmAssetManagement);
       await deployer.deploy(AmmJoinRequest);
       await deployer.deploy(AmmExitRequest);
       await deployer.deploy(AmmStatus);
       await deployer.deploy(AmmWithdrawal);
+      await deployer.link(AmmSignature, LoopringAmmPool);
+      await deployer.link(AmmPoolToken, LoopringAmmPool);
       await deployer.link(AmmAssetManagement, LoopringAmmPool);
       await deployer.link(AmmJoinRequest, LoopringAmmPool);
       await deployer.link(AmmExitRequest, LoopringAmmPool);
@@ -32,6 +38,8 @@ module.exports = function(deployer, network, accounts) {
         false
       );
 
+      await deployer.link(AmmSignature, LoopringAmmPoolCopy);
+      await deployer.link(AmmPoolToken, LoopringAmmPoolCopy);
       await deployer.link(AmmAssetManagement, LoopringAmmPoolCopy);
       await deployer.link(AmmJoinRequest, LoopringAmmPoolCopy);
       await deployer.link(AmmExitRequest, LoopringAmmPoolCopy);

--- a/packages/loopring_v3/migrations/7_deploy_amm.js
+++ b/packages/loopring_v3/migrations/7_deploy_amm.js
@@ -7,6 +7,7 @@ const AmmJoinRequest = artifacts.require("AmmJoinRequest");
 const AmmExitRequest = artifacts.require("AmmExitRequest");
 const AmmStatus = artifacts.require("AmmStatus");
 const AmmWithdrawal = artifacts.require("AmmWithdrawal");
+const AmmAssetManagement = artifacts.require("AmmAssetManagement");
 const AmplifiedAmmController = artifacts.require("AmplifiedAmmController");
 
 module.exports = function(deployer, network, accounts) {
@@ -14,10 +15,12 @@ module.exports = function(deployer, network, accounts) {
     deployer.then(async () => {
       await deployer.deploy(AmplifiedAmmController);
 
+      await deployer.deploy(AmmAssetManagement);
       await deployer.deploy(AmmJoinRequest);
       await deployer.deploy(AmmExitRequest);
       await deployer.deploy(AmmStatus);
       await deployer.deploy(AmmWithdrawal);
+      await deployer.link(AmmAssetManagement, LoopringAmmPool);
       await deployer.link(AmmJoinRequest, LoopringAmmPool);
       await deployer.link(AmmExitRequest, LoopringAmmPool);
       await deployer.link(AmmStatus, LoopringAmmPool);
@@ -29,6 +32,7 @@ module.exports = function(deployer, network, accounts) {
         false
       );
 
+      await deployer.link(AmmAssetManagement, LoopringAmmPoolCopy);
       await deployer.link(AmmJoinRequest, LoopringAmmPoolCopy);
       await deployer.link(AmmExitRequest, LoopringAmmPoolCopy);
       await deployer.link(AmmStatus, LoopringAmmPoolCopy);

--- a/packages/loopring_v3/test/ammUtils.ts
+++ b/packages/loopring_v3/test/ammUtils.ts
@@ -53,6 +53,8 @@ export interface PoolExit {
 export interface PoolVirtualBalances {
   txType?: "SetVirtualBalances";
   poolAddress: string;
+  vBalances: BN[];
+  data: string;
 
   owner?: string;
   signature?: string;
@@ -509,12 +511,14 @@ export class AmmPool {
     return exit;
   }
 
-  public async setVirtualBalances() {
+  public async setVirtualBalances(vBalances: BN[], data: string = "0x") {
     const vb: PoolVirtualBalances = {
       txType: "SetVirtualBalances",
       poolAddress: this.contract.address,
       signature: "0x00",
-      owner: Constants.zeroAddress
+      owner: Constants.zeroAddress,
+      vBalances,
+      data
     };
 
     await this.process(vb, undefined);
@@ -822,11 +826,10 @@ export class AmmPool {
         )
       );
     } else if (transaction.txType === "SetVirtualBalances") {
-      // Set virtual balances
-      for (let i = 0; i < this.tokens.length; i++) {
-        this.vTokenBalancesL2[i] = this.tokenBalancesL2[i]
-          .mul(this.amplificationFactor)
-          .div(this.AMPLIFICATION_FACTOR_BASE);
+      const poolVirtualBalances = transaction;
+      this.vTokenBalancesL2 = poolVirtualBalances.vBalances;
+      for (const vBalance of poolVirtualBalances.vBalances) {
+        logDebug("setVirtualBalance: " + vBalance.toString(10));
       }
     } else if (transaction.txType === "Deposit") {
       const deposit = transaction;
@@ -918,6 +921,19 @@ export class AmmPool {
     );
   }
 
+  public static getPoolSetVirtualBalancesAuxData(
+    poolVirtualBalances: PoolVirtualBalances
+  ) {
+    const vBalances: string[] = [];
+    for (const vBalance of poolVirtualBalances.vBalances) {
+      vBalances.push(vBalance.toString(10));
+    }
+    return web3.eth.abi.encodeParameter("tuple(uint96[],bytes)", [
+      vBalances,
+      poolVirtualBalances.data
+    ]);
+  }
+
   public static getPoolDepositAuxData(deposit: PoolDeposit) {
     const amounts: string[] = [];
     for (const amount of deposit.amounts) {
@@ -955,7 +971,7 @@ export class AmmPool {
     } else if (transaction.txType === "SetVirtualBalances") {
       poolTx = {
         txType: PoolTransactionType.SET_VIRTUAL_BALANCES,
-        data: "0x",
+        data: this.getPoolSetVirtualBalancesAuxData(transaction),
         signature: transaction.signature
       };
     } else if (transaction.txType === "Deposit") {

--- a/packages/loopring_v3/test/ammUtils.ts
+++ b/packages/loopring_v3/test/ammUtils.ts
@@ -292,7 +292,8 @@ export class AmmPool {
     vTokenBalancesL2: BN[],
     feeBips: number,
     amplificationFactor: BN,
-    controller?: any
+    controllerAddress?: string,
+    assetManagerAddress?: string
   ) {
     this.sharedConfig = sharedConfig;
     this.feeBips = feeBips;
@@ -302,14 +303,16 @@ export class AmmPool {
 
     this.totalSupply = new BN(0);
 
-    const controllerAddress = controller
-      ? controller.address
+    controllerAddress = controllerAddress
+      ? controllerAddress
       : Constants.zeroAddress;
+
+    console.log("controllerAddress: " + controllerAddress);
 
     const AmmPool = artifacts.require("LoopringAmmPool");
     this.contract = await AmmPool.new(
       controllerAddress,
-      "0x" + "00".repeat(20),
+      assetManagerAddress,
       false
     );
 
@@ -520,7 +523,7 @@ export class AmmPool {
   }
 
   public async deposit(amounts: BN[]) {
-    /*const deposit: PoolDeposit = {
+    const deposit: PoolDeposit = {
       txType: "Deposit",
       poolAddress: this.contract.address,
       amounts: amounts,
@@ -530,28 +533,7 @@ export class AmmPool {
 
     await this.process(deposit, undefined);
 
-    return deposit;*/
-
-    const _amounts: string[] = [];
-    for (let i = 0; i < amounts.length; i++) {
-      _amounts[i] = amounts[i].toString(10);
-    }
-
-    await this.ctx.addCallback(
-      this.contract.address,
-      this.contract.contract.methods.depositAssetsToL2(_amounts).encodeABI(),
-      true
-    );
-
-    for (let i = 0; i < this.tokens.length; i++) {
-      if (!amounts[i].isZero()) {
-        await this.ctx.requestDeposit(
-          this.contract.address,
-          this.tokens[i],
-          amounts[i]
-        );
-      }
-    }
+    return deposit;
   }
 
   public async withdraw(amounts: BN[]) {

--- a/packages/loopring_v3/test/testAMMPool.ts
+++ b/packages/loopring_v3/test/testAMMPool.ts
@@ -41,7 +41,9 @@ contract("LoopringAmmPool", (accounts: string[]) => {
     assetManager?: any
   ) => {
     controller = controller ? controller : ammController;
-    const assetManagerAddress = assetManager ? assetManager.address : Constants.zeroAddress;
+    const assetManagerAddress = assetManager
+      ? assetManager.address
+      : Constants.zeroAddress;
 
     const feeBipsAMM = 30;
     const tokens = ["WETH", "GTO"];
@@ -586,7 +588,10 @@ contract("LoopringAmmPool", (accounts: string[]) => {
       await ctx.submitTransactions(16);
 
       await pool.prePoolTransactions();
-      await pool.setVirtualBalances();
+
+      // Set virtual balances to the actual balances
+      const balances = await pool.getBalancesL2();
+      await pool.setVirtualBalances(balances);
 
       await ctx.submitTransactions(16);
       await ctx.submitPendingBlocks();
@@ -1076,9 +1081,7 @@ contract("LoopringAmmPool", (accounts: string[]) => {
               "INVALID_CHALLENGE"
             );
 
-            const maxForcedExitAge = (
-              await sharedConfig.maxForcedExitAge()
-            ).toNumber();
+            const maxForcedExitAge = (await sharedConfig.maxForcedExitAge()).toNumber();
             // Wait
             await ctx.advanceBlockTimestamp(maxForcedExitAge - 100);
 

--- a/packages/loopring_v3/test/testAMMPool.ts
+++ b/packages/loopring_v3/test/testAMMPool.ts
@@ -12,7 +12,8 @@ contract("LoopringAmmPool", (accounts: string[]) => {
   let sharedConfig: any;
   let agentRegistry: any;
   let registryOwner: string;
-  let ammController: string;
+  let ammController: any;
+  let assetManager: any;
 
   let ownerA: string;
   let ownerB: string;
@@ -36,9 +37,11 @@ contract("LoopringAmmPool", (accounts: string[]) => {
 
   const setupDefaultPool = async (
     amplificationFactor = new BN(web3.utils.toWei("1", "ether")),
-    controller?: any
+    controller?: any,
+    assetManager?: any
   ) => {
     controller = controller ? controller : ammController;
+    const assetManagerAddress = assetManager ? assetManager.address : Constants.zeroAddress;
 
     const feeBipsAMM = 30;
     const tokens = ["WETH", "GTO"];
@@ -64,7 +67,8 @@ contract("LoopringAmmPool", (accounts: string[]) => {
       weights,
       feeBipsAMM,
       amplificationFactor,
-      controller
+      controller.address,
+      assetManagerAddress
     );
 
     if (controller) {
@@ -109,6 +113,9 @@ contract("LoopringAmmPool", (accounts: string[]) => {
 
     const amplifiedAmmController = artifacts.require("AmplifiedAmmController");
     ammController = await amplifiedAmmController.new();
+
+    const TestAssetManager = artifacts.require("TestAssetManager");
+    assetManager = await TestAssetManager.new();
   });
 
   after(async () => {
@@ -587,7 +594,11 @@ contract("LoopringAmmPool", (accounts: string[]) => {
     });
 
     it("Manage pool assets", async () => {
-      const pool = await setupDefaultPool();
+      const pool = await setupDefaultPool(
+        new BN(web3.utils.toWei("1", "ether")),
+        undefined,
+        assetManager
+      );
 
       const amounts = [
         new BN(web3.utils.toWei("10000", "ether")),

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1867,11 +1867,13 @@ export class ExchangeTestUtil {
     interface TransactionReceiverCallbacks {
       callbacks: OnchainBlockCallback[];
       receivers: string[];
+      before: boolean;
     }
 
     const transactionReceiverCallbacks: TransactionReceiverCallbacks = {
       callbacks: [],
-      receivers: []
+      receivers: [],
+      before: true
     };
 
     //console.log("Block callbacks: ");

--- a/packages/loopring_v3/test/testExchangeUtil.ts
+++ b/packages/loopring_v3/test/testExchangeUtil.ts
@@ -1867,13 +1867,13 @@ export class ExchangeTestUtil {
     interface TransactionReceiverCallbacks {
       callbacks: OnchainBlockCallback[];
       receivers: string[];
-      before: boolean;
+      beforeBlockSubmission: boolean;
     }
 
     const transactionReceiverCallbacks: TransactionReceiverCallbacks = {
       callbacks: [],
       receivers: [],
-      before: true
+      beforeBlockSubmission: true
     };
 
     //console.log("Block callbacks: ");


### PR DESCRIPTION
#2432

Okay, I implemented this in a way that doesn't work twice now, so hopefully the third time is the charm.

So the main problem is that joins/exits need to work on the actual balances in the pool, which (if an AssetManager is set) could be both on L2 and L1. 

The other problem is to correctly implement this, because L1 transactions like deposit/withdraw and L2 transactions do not automatically sync up correctly because of a number of reasons. For example, let's say we process 3 pool transactions in a block:
1. An exit
1. A withdrawal
1. Another exit

What are the pool balances? For 1) it would be the balances as reported on L2. For 3) however it would be the balances on L2 + the newly withdrawn funds in 2). But the funds withdrawn in 2) could either be already in the pool contract (when the block is submitted before the callback) or not yet in the pool contract (the block is submitted after the callback). So only depending on the actual token balances on L1 is not reliable because we do not know what the balances are for each L2 transaction because it depends on when withdrawals/deposits are handled on L2. The same problem is true for deposits (and could be even worse because the deposit may keep on pending).

And so I think the only way to do this correctly is to keep track of the balances deposited/withdrawn to/from the pool in exactly the same order they are done on L2. For that we use `mapping (address => uint96) balancesL1;` and so we just need to add this value to the L2 balances to get the correct balance in the pool. Because these values need to be updated next to their L2 counterparts deposits are now also required to be done with the `PoolTxType.DEPOSIT` pool instruction.

The pool contracts will only watch the `balancesL1` values. The AssetManager is allowed to update these values when required. It's not really possible to have fully dynamic L1 balances (e.g. always up to date with latest interest) because these values need to be deterministic when the operator processes joins/exits. And so by just updating the `balancesL1` at certain expected intervals also makes sure the relayer can count on them being the same when needed.

To make the deposits work as other L2 transactions on L2 (do a deposit and also see the transaction the block in the pool contract) I have made it possible again to do the `txReceiverCallbacks` before the block is submitted again.

I _think_ this works correctly now, but I'll have to think about it some more to make sure.
