### PR TITLE
Amm v2 - Exit mode and pool reuse

### DIFF
--- a/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
@@ -20,7 +20,13 @@ contract AmplifiedAmmController is IAmmController, Claimable
 
     uint public constant AMPLIFICATION_FACTOR_BASE = (10 ** 18);
 
+    uint public constant MIN_CURVE_CHANGE_DELAY   = 7 days;
+    uint public constant CURVE_CHANGE_AUTH_WINDOW = 7 days;
+
     mapping(address => uint) public amplificationFactors;
+
+    mapping(address => uint) public curveChangeAuthorization;
+
 
     function getInitialVirtualBalances(
         uint96[] memory joinAmounts
@@ -38,42 +44,59 @@ contract AmplifiedAmmController is IAmmController, Claimable
         return vTokenBalancesL2;
     }
 
-    function getVirtualBalances(
-        uint96[] memory tokenBalancesL2,
-        uint96[] memory /*vTokenBalancesL2*/
+   function authorizeVirtualBalances(
+        uint96[] memory balances,
+        uint96[] memory /*vBalancesOld*/,
+        uint96[] memory vBalancesNew,
+        bytes    memory /*data*/
         )
         external
-        view
         override
-        returns (uint96[] memory)
+        returns (bool)
     {
-        // Only allow updating the virtual balances if the AF = 1
-        require(getAmplificationFactor(msg.sender) == AMPLIFICATION_FACTOR_BASE, "INVALID_OPERATION");
+        address pool = msg.sender;
 
-        // Just set the virtual balances to the actual balances
-        uint96[] memory vTokenBalancesL2 = new uint96[](tokenBalancesL2.length);
-        for (uint i = 0; i < tokenBalancesL2.length; i++) {
-            vTokenBalancesL2[i] = tokenBalancesL2[i];
+        // Check if a curve change was explicitly authorized
+        if (consumeCurveChangeAuthorized(pool)) {
+            return true;
         }
-        return vTokenBalancesL2;
+
+        // Special case: Always allow updating the virtual balances if the AF = 1
+        if (getAmplificationFactor(pool) == AMPLIFICATION_FACTOR_BASE) {
+            for (uint i = 0; i < balances.length; i++) {
+                if(vBalancesNew[i] != balances[i]) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        return false;
+    }
+
+    function authorizeCurveChange(address pool)
+        external
+        onlyOwner
+    {
+        curveChangeAuthorization[pool] = block.timestamp + MIN_CURVE_CHANGE_DELAY;
     }
 
     function setAmplificationFactor(
-        address amm,
+        address pool,
         uint    amplificationFactor
         )
         external
         onlyOwner
     {
-        amplificationFactors[amm] = amplificationFactor;
+        amplificationFactors[pool] = amplificationFactor;
     }
 
-    function getAmplificationFactor(address amm)
+    function getAmplificationFactor(address pool)
         public
         view
         returns (uint amplificationFactor)
     {
-        amplificationFactor = amplificationFactors[amm];
+        amplificationFactor = amplificationFactors[pool];
         if (amplificationFactor == 0) {
             amplificationFactor = AMPLIFICATION_FACTOR_BASE;
         }
@@ -89,10 +112,28 @@ contract AmplifiedAmmController is IAmmController, Claimable
         pool.setupPool(config);
     }
 
-    function enableExitMode(LoopringAmmPool pool)
+    function enterExitMode(
+        LoopringAmmPool pool,
+        bool enabled
+        )
         external
         onlyOwner
     {
-        pool.enableExitMode();
+        pool.enterExitMode(enabled);
+    }
+
+    // == Internal Functions ==
+
+    function consumeCurveChangeAuthorized(address pool)
+        internal
+        returns (bool)
+    {
+        uint timestamp = curveChangeAuthorization[pool];
+        bool authorized = (timestamp <= block.timestamp) && (block.timestamp <= timestamp + MIN_CURVE_CHANGE_DELAY);
+
+        // Remove authorization
+        delete curveChangeAuthorization[pool];
+
+        return authorized;
     }
 }

--- a/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
@@ -77,4 +77,11 @@ contract AmplifiedAmmController is IAmmController, Claimable
             amplificationFactor = AMPLIFICATION_FACTOR_BASE;
         }
     }
+
+    function enableExitMode(LoopringAmmPool pool)
+        external
+        onlyOwner
+    {
+        pool.enableExitMode();
+    }
 }

--- a/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/AmplifiedAmmController.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2017 Loopring Technology Limited.
 pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
 
 import "./IAmmController.sol";
 import "../amm/LoopringAmmPool.sol";
@@ -76,6 +77,16 @@ contract AmplifiedAmmController is IAmmController, Claimable
         if (amplificationFactor == 0) {
             amplificationFactor = AMPLIFICATION_FACTOR_BASE;
         }
+    }
+
+    function setupPool(
+        LoopringAmmPool pool,
+        AmmData.PoolConfig calldata config
+        )
+        external
+        onlyOwner
+    {
+        pool.setupPool(config);
     }
 
     function enableExitMode(LoopringAmmPool pool)

--- a/packages/loopring_v3/contracts/amm/IAmmController.sol
+++ b/packages/loopring_v3/contracts/amm/IAmmController.sol
@@ -18,14 +18,17 @@ interface IAmmController
 
     /// @dev Called by the pool contract when a SET_VIRTUAL_BALANCES operation is done
     ///      on the pool.
-    /// @param tokenBalancesL2 The balances in the pool
-    /// @param vTokenBalancesL2 The current virtual balances in the pool
-    /// @return The new virtual balances in the pool
-    function getVirtualBalances(
-        uint96[] memory tokenBalancesL2,
-        uint96[] memory vTokenBalancesL2
+    /// @param balances The balances in the pool
+    /// @param vBalancesOld The current virtual balances in the pool
+    /// @param vBalancesNew The new virtual balances in the pool
+    /// @param data Custom data
+    /// @return True if vBalancesNew can be used, else false
+    function authorizeVirtualBalances(
+        uint96[] memory balances,
+        uint96[] memory vBalancesOld,
+        uint96[] memory vBalancesNew,
+        bytes    memory data
         )
         external
-        view
-        returns (uint96[] memory);
+        returns (bool);
 }

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -79,6 +79,7 @@ contract LoopringAmmPool is
         bool           _joinsDisabled
     )
     {
+        require(_controller != IAmmController(0), "ZERO_ADDRESS");
         controller = _controller;
         assetManager = _assetManager;
         joinsDisabled = _joinsDisabled;
@@ -102,11 +103,11 @@ contract LoopringAmmPool is
         state.setupPool(config);
     }
 
-    function enableExitMode()
+    function enterExitMode(bool enabled)
         external
         onlyFromController
     {
-        state.exitMode = true;
+        state.exitMode = enabled;
     }
 
     // Anyone is able to shut down the pool when requests aren't being processed any more.

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -101,6 +101,13 @@ contract LoopringAmmPool is
         state.setupPool(config);
     }
 
+    function enableExitMode()
+        external
+        onlyFromController
+    {
+        state.exitMode = true;
+    }
+
     // Anyone is able to shut down the pool when requests aren't being processed any more.
     function shutdown(address exitOwner)
         external
@@ -113,7 +120,6 @@ contract LoopringAmmPool is
 
     function shutdownByController()
         external
-        payable
         onlyWhenOnline
         nonReentrant
         onlyFromController

--- a/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
+++ b/packages/loopring_v3/contracts/amm/LoopringAmmPool.sol
@@ -98,6 +98,7 @@ contract LoopringAmmPool is
         external
         nonReentrant
     {
+        require(state.accountID == 0 || msg.sender == address(controller), "UNAUTHORIZED");
         state.setupPool(config);
     }
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -142,5 +142,6 @@ library AmmData
         mapping (bytes32 => bool) approvedTx;
 
         mapping (address => uint96) balancesL1;
+        bool exitMode;
     }
 }

--- a/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmData.sol
@@ -58,6 +58,12 @@ library AmmData
         uint32    validUntil;
     }
 
+    struct PoolVirtualBalances
+    {
+        uint96[]  vBalancesNew;
+        bytes     data;
+    }
+
     struct PoolDeposit
     {
         uint96[]  amounts;
@@ -82,7 +88,8 @@ library AmmData
         uint16  tokenID;
     }
 
-    struct Settings {
+    struct Settings
+    {
         IAmmController controller;
         IAssetManager  assetManager;
         bool           joinsDisabled;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmDepositProcess.sol
@@ -30,11 +30,13 @@ library AmmDepositProcess
     {
         require(poolDeposit.amounts.length == ctx.tokens.length, "INVALID_DEPOSIT_DATA");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            address token = ctx.tokens[i].addr;
             uint96 amount = poolDeposit.amounts[i];
-            verifyDepositTx(ctx, ctx.tokens[i].tokenID, amount);
-            S.deposit(token, amount);
-            S.balancesL1[token] = S.balancesL1[token].sub(amount);
+            if (amount > 0) {
+                address token = ctx.tokens[i].addr;
+                verifyDepositTx(ctx, ctx.tokens[i].tokenID, amount);
+                S.deposit(token, amount);
+                S.balancesL1[token] = S.balancesL1[token].sub(amount);
+            }
         }
     }
 
@@ -68,7 +70,7 @@ library AmmDepositProcess
             // tokenID == tokenID &&
             packedData & 0xffffffffffffffffffffffffffffffffffffffffffffffffffffff == (uint(ExchangeData.TransactionType.DEPOSIT) << 208) | (uint(address(this)) << 48) | (uint(ctx.accountID) << 16) | uint(tokenID) &&
             amount == txAmount,
-            "INVALID_DEPOSIT_TX_DATA"
+            "INVALID_AMM_DEPOSIT_TX_DATA"
         );
 
         ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -9,26 +9,26 @@ import "../../lib/EIP712.sol";
 import "../../lib/ERC20SafeTransfer.sol";
 import "../../lib/MathUint.sol";
 import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "../../lib/TransferUtil.sol";
 import "../../thirdparty/SafeCast.sol";
-import "./AmmUtil.sol";
 import "./AmmData.sol";
 import "./AmmExitRequest.sol";
 import "./AmmPoolToken.sol";
+import "./AmmSignature.sol";
+import "./AmmUtil.sol";
 
 
 /// @title AmmExitProcess
 library AmmExitProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmSignature      for bytes32;
     using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using ERC20SafeTransfer for address;
     using MathUint          for uint;
     using MathUint96        for uint96;
     using SafeCast          for uint;
-    using SignatureUtil     for bytes32;
     using TransactionReader for ExchangeData.Block;
     using TransferUtil      for address;
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmExitProcess.sol
@@ -49,14 +49,18 @@ library AmmExitProcess
         bool isForcedExit = false;
 
         if (signature.length == 0) {
-            bytes32 forcedExitHash = AmmExitRequest.hash(ctx.domainSeparator, S.forcedExit[exit.owner]);
-            if (txHash == forcedExitHash) {
-                delete S.forcedExit[exit.owner];
-                S.forcedExitCount--;
-                isForcedExit = true;
+            if (S.exitMode) {
+                require(exit.fee == 0, "INVALID_FEE");
             } else {
-                require(S.approvedTx[txHash], "INVALID_ONCHAIN_APPROVAL");
-                delete S.approvedTx[txHash];
+                bytes32 forcedExitHash = AmmExitRequest.hash(ctx.domainSeparator, S.forcedExit[exit.owner]);
+                if (txHash == forcedExitHash) {
+                    delete S.forcedExit[exit.owner];
+                    S.forcedExitCount--;
+                    isForcedExit = true;
+                } else {
+                    require(S.approvedTx[txHash], "INVALID_ONCHAIN_APPROVAL");
+                    delete S.approvedTx[txHash];
+                }
             }
         } else if (signature.length == 1) {
             ctx.verifySignatureL2(exit.owner, txHash, signature);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmJoinProcess.sol
@@ -8,11 +8,11 @@ import "../../core/impl/libtransactions/TransferTransaction.sol";
 import "../../lib/EIP712.sol";
 import "../../lib/MathUint.sol";
 import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "../../thirdparty/SafeCast.sol";
 import "./AmmData.sol";
 import "./AmmJoinRequest.sol";
 import "./AmmPoolToken.sol";
+import "./AmmSignature.sol";
 import "./AmmUtil.sol";
 
 
@@ -20,13 +20,13 @@ import "./AmmUtil.sol";
 library AmmJoinProcess
 {
     using AmmPoolToken      for AmmData.State;
+    using AmmSignature      for bytes32;
     using AmmUtil           for AmmData.State;
     using AmmUtil           for AmmData.Context;
     using AmmUtil           for uint96;
     using MathUint          for uint;
     using MathUint96        for uint96;
     using SafeCast          for uint;
-    using SignatureUtil     for bytes32;
     using TransactionReader for ExchangeData.Block;
 
     // event JoinProcessed(address owner, uint96 mintAmount, uint96[] amounts);

--- a/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmPoolToken.sol
@@ -80,7 +80,7 @@ library AmmPoolToken
         uint256               deadline,
         bytes        calldata signature
         )
-        internal
+        public
     {
         require(deadline >= block.timestamp, 'EXPIRED');
 

--- a/packages/loopring_v3/contracts/amm/libamm/AmmSignature.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmSignature.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "../../lib/SignatureUtil.sol";
+
+
+/// @title AmmSignature
+library AmmSignature
+{
+    using SignatureUtil     for bytes32;
+
+    function verifySignature(
+        bytes32        signHash,
+        address        signer,
+        bytes   memory signature
+        )
+        public
+        view
+        returns (bool)
+    {
+        return signHash.verifySignature(signer, signature);
+    }
+}

--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -5,23 +5,13 @@ pragma experimental ABIEncoderV2;
 
 import "../../core/iface/IExchangeV3.sol";
 import "../../lib/EIP712.sol";
-import "../../lib/ERC20.sol";
-import "../../lib/MathUint.sol";
-import "../../lib/MathUint96.sol";
-import "../../lib/SignatureUtil.sol";
 import "./AmmData.sol";
-import "./AmmPoolToken.sol";
 import "./IAmmSharedConfig.sol";
 
 
 /// @title AmmStatus
 library AmmStatus
 {
-    using AmmPoolToken      for AmmData.State;
-    using MathUint          for uint;
-    using MathUint96        for uint96;
-    using SignatureUtil     for bytes32;
-
     event Shutdown(uint timestamp);
 
     function isOnline(AmmData.State storage S)

--- a/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmStatus.sol
@@ -42,26 +42,26 @@ library AmmStatus
             bytes(config.poolName).length > 0 && bytes(config.tokenSymbol).length > 0,
             "INVALID_NAME_OR_SYMBOL"
         );
+
         require(config.sharedConfig != address(0), "INVALID_SHARED_CONFIG");
         require(config.tokens.length == config.weights.length, "INVALID_DATA");
         require(config.tokens.length >= 2, "INVALID_DATA");
         require(config.exchange != address(0), "INVALID_EXCHANGE");
         require(config.accountID != 0, "INVALID_ACCOUNT_ID");
-        require(S.tokens.length == 0, "ALREADY_INITIALIZED");
 
-        S.sharedConfig = IAmmSharedConfig(config.sharedConfig);
-        IExchangeV3 exchange = IExchangeV3(config.exchange);
-        S.exchange = exchange;
-        S.exchangeOwner = exchange.owner();
-        S.exchangeDomainSeparator = exchange.getDomainSeparator();
-        S.accountID = config.accountID;
-        S.poolTokenID = exchange.getTokenID(address(this));
+        require(S._totalSupply == 0, "POOL_IN_USE");
+
         S.feeBips = config.feeBips;
         S.domainSeparator = EIP712.hash(EIP712.Domain(config.poolName, "1.0.0", address(this)));
 
         S.poolName = config.poolName;
         S.symbol = config.tokenSymbol;
+        S.shutdownTimestamp = 0;
+        S.exitMode = false;
 
+        IExchangeV3 exchange = IExchangeV3(config.exchange);
+
+        delete S.tokens;
         for (uint i = 0; i < config.tokens.length; i++) {
             address token = config.tokens[i];
             S.tokens.push(AmmData.Token({
@@ -71,16 +71,26 @@ library AmmStatus
             }));
         }
 
-        // Mint all liquidity tokens to the pool account on L2
-        S.balanceOf[address(this)] = AmmData.POOL_TOKEN_MINTED_SUPPLY;
-        S.allowance[address(this)][address(exchange.getDepositContract())] = type(uint256).max;
-        exchange.deposit(
-            address(this), // from
-            address(this), // to
-            address(this), // token
-            uint96(AmmData.POOL_TOKEN_MINTED_SUPPLY),
-            new bytes(0)
-        );
+        bool newPool = (S.accountID == 0);
+        if (newPool) {
+            S.sharedConfig = IAmmSharedConfig(config.sharedConfig);
+            S.exchange = exchange;
+            S.exchangeOwner = exchange.owner();
+            S.exchangeDomainSeparator = exchange.getDomainSeparator();
+            S.accountID = config.accountID;
+            S.poolTokenID = exchange.getTokenID(address(this));
+
+            // Mint all liquidity tokens to the pool account on L2
+            S.balanceOf[address(this)] = AmmData.POOL_TOKEN_MINTED_SUPPLY;
+            S.allowance[address(this)][address(exchange.getDepositContract())] = type(uint256).max;
+            exchange.deposit(
+                address(this), // from
+                address(this), // to
+                address(this), // token
+                uint96(AmmData.POOL_TOKEN_MINTED_SUPPLY),
+                new bytes(0)
+            );
+        }
     }
 
     // Anyone is able to shut down the pool when requests aren't being processed any more.

--- a/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
+++ b/packages/loopring_v3/contracts/amm/libamm/AmmWithdrawProcess.sol
@@ -28,10 +28,12 @@ library AmmWithdrawProcess
         require(ctx.settings.assetManager != IAssetManager(0), "CANNOT_WITHDRAW_FROM_POOL");
         require(poolWithdrawal.amounts.length == ctx.tokens.length, "INVALID_WITHDRAWAL_AMOUNTS");
         for (uint i = 0; i < ctx.tokens.length; i++) {
-            address token = ctx.tokens[i].addr;
             uint96 amount = poolWithdrawal.amounts[i];
-            verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, amount);
-            S.balancesL1[token] = S.balancesL1[token].add(amount);
+            if (amount > 0) {
+                address token = ctx.tokens[i].addr;
+                verifyWithdrawalTx(ctx, ctx.tokens[i].tokenID, amount);
+                S.balancesL1[token] = S.balancesL1[token].add(amount);
+            }
         }
     }
 
@@ -76,7 +78,7 @@ library AmmWithdrawProcess
             // withdrawal.fee == 0,
             packedData & 0xffffffffffffffffffffffffffff0000ffff == (uint(tokenID) << 128) | (uint(amount) << 32) &&
             onchainDataHash == dataHash,
-            "INVALID_WITHDRAWAL_TX_DATA"
+            "INVALID_AMM_WITHDRAWAL_TX_DATA"
         );
 
         ctx.txsDataPtr += ExchangeData.TX_DATA_AVAILABILITY_SIZE;

--- a/packages/loopring_v3/migrations/7_deploy_amm.js
+++ b/packages/loopring_v3/migrations/7_deploy_amm.js
@@ -8,6 +8,7 @@ const AmmExitRequest = artifacts.require("AmmExitRequest");
 const AmmStatus = artifacts.require("AmmStatus");
 const AmmWithdrawal = artifacts.require("AmmWithdrawal");
 const AmmAssetManagement = artifacts.require("AmmAssetManagement");
+const AmmPoolToken = artifacts.require("AmmPoolToken");
 const AmplifiedAmmController = artifacts.require("AmplifiedAmmController");
 
 module.exports = function(deployer, network, accounts) {
@@ -15,11 +16,13 @@ module.exports = function(deployer, network, accounts) {
     deployer.then(async () => {
       await deployer.deploy(AmplifiedAmmController);
 
+      await deployer.deploy(AmmPoolToken);
       await deployer.deploy(AmmAssetManagement);
       await deployer.deploy(AmmJoinRequest);
       await deployer.deploy(AmmExitRequest);
       await deployer.deploy(AmmStatus);
       await deployer.deploy(AmmWithdrawal);
+      await deployer.link(AmmPoolToken, LoopringAmmPool);
       await deployer.link(AmmAssetManagement, LoopringAmmPool);
       await deployer.link(AmmJoinRequest, LoopringAmmPool);
       await deployer.link(AmmExitRequest, LoopringAmmPool);
@@ -32,6 +35,7 @@ module.exports = function(deployer, network, accounts) {
         false
       );
 
+      await deployer.link(AmmPoolToken, LoopringAmmPoolCopy);
       await deployer.link(AmmAssetManagement, LoopringAmmPoolCopy);
       await deployer.link(AmmJoinRequest, LoopringAmmPoolCopy);
       await deployer.link(AmmExitRequest, LoopringAmmPoolCopy);

--- a/packages/loopring_v3/migrations/7_deploy_amm.js
+++ b/packages/loopring_v3/migrations/7_deploy_amm.js
@@ -9,6 +9,7 @@ const AmmStatus = artifacts.require("AmmStatus");
 const AmmWithdrawal = artifacts.require("AmmWithdrawal");
 const AmmAssetManagement = artifacts.require("AmmAssetManagement");
 const AmmPoolToken = artifacts.require("AmmPoolToken");
+const AmmSignature = artifacts.require("AmmSignature");
 const AmplifiedAmmController = artifacts.require("AmplifiedAmmController");
 
 module.exports = function(deployer, network, accounts) {
@@ -16,12 +17,14 @@ module.exports = function(deployer, network, accounts) {
     deployer.then(async () => {
       await deployer.deploy(AmplifiedAmmController);
 
+      await deployer.deploy(AmmSignature);
       await deployer.deploy(AmmPoolToken);
       await deployer.deploy(AmmAssetManagement);
       await deployer.deploy(AmmJoinRequest);
       await deployer.deploy(AmmExitRequest);
       await deployer.deploy(AmmStatus);
       await deployer.deploy(AmmWithdrawal);
+      await deployer.link(AmmSignature, LoopringAmmPool);
       await deployer.link(AmmPoolToken, LoopringAmmPool);
       await deployer.link(AmmAssetManagement, LoopringAmmPool);
       await deployer.link(AmmJoinRequest, LoopringAmmPool);
@@ -35,6 +38,7 @@ module.exports = function(deployer, network, accounts) {
         false
       );
 
+      await deployer.link(AmmSignature, LoopringAmmPoolCopy);
       await deployer.link(AmmPoolToken, LoopringAmmPoolCopy);
       await deployer.link(AmmAssetManagement, LoopringAmmPoolCopy);
       await deployer.link(AmmJoinRequest, LoopringAmmPoolCopy);

--- a/packages/loopring_v3/test/ammUtils.ts
+++ b/packages/loopring_v3/test/ammUtils.ts
@@ -53,6 +53,8 @@ export interface PoolExit {
 export interface PoolVirtualBalances {
   txType?: "SetVirtualBalances";
   poolAddress: string;
+  vBalances: BN[];
+  data: string;
 
   owner?: string;
   signature?: string;
@@ -509,12 +511,14 @@ export class AmmPool {
     return exit;
   }
 
-  public async setVirtualBalances() {
+  public async setVirtualBalances(vBalances: BN[], data: string = "0x") {
     const vb: PoolVirtualBalances = {
       txType: "SetVirtualBalances",
       poolAddress: this.contract.address,
       signature: "0x00",
-      owner: Constants.zeroAddress
+      owner: Constants.zeroAddress,
+      vBalances,
+      data
     };
 
     await this.process(vb, undefined);
@@ -822,11 +826,10 @@ export class AmmPool {
         )
       );
     } else if (transaction.txType === "SetVirtualBalances") {
-      // Set virtual balances
-      for (let i = 0; i < this.tokens.length; i++) {
-        this.vTokenBalancesL2[i] = this.tokenBalancesL2[i]
-          .mul(this.amplificationFactor)
-          .div(this.AMPLIFICATION_FACTOR_BASE);
+      const poolVirtualBalances = transaction;
+      this.vTokenBalancesL2 = poolVirtualBalances.vBalances;
+      for (const vBalance of poolVirtualBalances.vBalances) {
+        logDebug("setVirtualBalance: " + vBalance.toString(10));
       }
     } else if (transaction.txType === "Deposit") {
       const deposit = transaction;
@@ -918,6 +921,19 @@ export class AmmPool {
     );
   }
 
+  public static getPoolSetVirtualBalancesAuxData(
+    poolVirtualBalances: PoolVirtualBalances
+  ) {
+    const vBalances: string[] = [];
+    for (const vBalance of poolVirtualBalances.vBalances) {
+      vBalances.push(vBalance.toString(10));
+    }
+    return web3.eth.abi.encodeParameter("tuple(uint96[],bytes)", [
+      vBalances,
+      poolVirtualBalances.data
+    ]);
+  }
+
   public static getPoolDepositAuxData(deposit: PoolDeposit) {
     const amounts: string[] = [];
     for (const amount of deposit.amounts) {
@@ -955,7 +971,7 @@ export class AmmPool {
     } else if (transaction.txType === "SetVirtualBalances") {
       poolTx = {
         txType: PoolTransactionType.SET_VIRTUAL_BALANCES,
-        data: "0x",
+        data: this.getPoolSetVirtualBalancesAuxData(transaction),
         signature: transaction.signature
       };
     } else if (transaction.txType === "Deposit") {

--- a/packages/loopring_v3/test/testAMMPool.ts
+++ b/packages/loopring_v3/test/testAMMPool.ts
@@ -41,7 +41,9 @@ contract("LoopringAmmPool", (accounts: string[]) => {
     assetManager?: any
   ) => {
     controller = controller ? controller : ammController;
-    const assetManagerAddress = assetManager ? assetManager.address : Constants.zeroAddress;
+    const assetManagerAddress = assetManager
+      ? assetManager.address
+      : Constants.zeroAddress;
 
     const feeBipsAMM = 30;
     const tokens = ["WETH", "GTO"];
@@ -586,7 +588,10 @@ contract("LoopringAmmPool", (accounts: string[]) => {
       await ctx.submitTransactions(16);
 
       await pool.prePoolTransactions();
-      await pool.setVirtualBalances();
+
+      // Set virtual balances to the actual balances
+      const balances = await pool.getBalancesL2();
+      await pool.setVirtualBalances(balances);
 
       await ctx.submitTransactions(16);
       await ctx.submitPendingBlocks();
@@ -1076,9 +1081,7 @@ contract("LoopringAmmPool", (accounts: string[]) => {
               "INVALID_CHALLENGE"
             );
 
-            const maxForcedExitAge = (
-              await sharedConfig.maxForcedExitAge()
-            ).toNumber();
+            const maxForcedExitAge = (await sharedConfig.maxForcedExitAge()).toNumber();
             // Wait
             await ctx.advanceBlockTimestamp(maxForcedExitAge - 100);
 


### PR DESCRIPTION
#2449

Allows the controller to enter exit mode, which allows the operator to exit users from the pool if no fee needs to be paid.
Also allows the controller to re-use the pool with different tokens when the supply is `0`.

I used the controller as the authorized address because pools currently don't have an owner and exit mode/pool re-using a pool even with no supply may not work for all types of pools.

Made `permit` public to make the Pool contract smaller because the contract size was too large.