### PR TITLE
[discussion only] Is this a bug?

### DIFF
--- a/packages/hebao_v2/contracts/base/WalletFactory.sol
+++ b/packages/hebao_v2/contracts/base/WalletFactory.sol
@@ -113,19 +113,21 @@ contract WalletFactory
     {
         require(config.owner != address(0), "INVALID_OWNER");
 
-        bytes memory encodedRequest = abi.encode(
-            CREATE_WALLET_TYPEHASH,
-            config.owner,
-            keccak256(abi.encodePacked(config.guardians)),
-            config.quota,
-            config.inheritor,
-            config.feeRecipient,
-            config.feeToken,
-            config.feeAmount,
-            salt
+        bytes memory encodedRequestHash = keccak256(
+            abi.encode(
+                CREATE_WALLET_TYPEHASH,
+                config.owner,
+                keccak256(abi.encodePacked(config.guardians)),
+                config.quota,
+                config.inheritor,
+                config.feeRecipient,
+                config.feeToken,
+                config.feeAmount,
+                salt
+            )
         );
 
-        bytes32 signHash = EIP712.hashPacked(DOMAIN_SEPERATOR, encodedRequest);
+        bytes32 signHash = EIP712.hashPacked(DOMAIN_SEPERATOR, encodedRequestHash);
         require(signHash.verifySignature(config.owner, config.signature), "INVALID_SIGNATURE");
     }
 


### PR DESCRIPTION
I noticed we may have more inconsistency in computing hashes. For example, in MetaTxLib.sol, we have:

```solidity
    function validateMetaTx(
        Wallet  storage wallet,
        bytes32 DOMAIN_SEPARATOR,
        MetaTx  memory  metaTx
        )
        public
        view
        returns (bytes32)
    {
        bytes memory encoded = abi.encode(
            META_TX_TYPEHASH,
            metaTx.to,
            metaTx.nonce,
            metaTx.gasToken,
            metaTx.gasPrice,
            metaTx.gasLimit,
            metaTx.gasOverhead,
            metaTx.feeReceipt,
            metaTx.requiresSuccess,
            keccak256(metaTx.data)
        );
        bytes32 metaTxHash = EIP712.hashPacked(DOMAIN_SEPARATOR, encoded);
        require(metaTxHash.verifySignature(wallet.owner, metaTx.signature), "METATX_INVALID_SIGNATURE");
        return metaTxHash;
    }
```
For other social-approval based transactions, we also do not have an `keccak256` call wrapping `abi.encode`.


Which approach is the correct one?