### PR TITLE
[hebaoV2] Hash more data in wallet address

### DIFF
--- a/packages/hebao_v2/contracts/base/SmartWallet.sol
+++ b/packages/hebao_v2/contracts/base/SmartWallet.sol
@@ -139,6 +139,14 @@ contract SmartWallet is ILoopringWalletV2, ERC1271, IERC165, ERC721Holder, ERC11
 
         // Pay for the wallet creation using wallet funds
         if (feeRecipient != address(0) && feeAmount > 0) {
+            if (quota != 0) {
+                wallet.checkAndAddToSpent(
+                    priceOracle,
+                    feeToken,
+                    feeAmount
+                );
+            }
+
             ERC20Lib.transfer(feeToken, feeRecipient, feeAmount);
         }
     }

--- a/packages/hebao_v2/contracts/base/WalletDeploymentLib.sol
+++ b/packages/hebao_v2/contracts/base/WalletDeploymentLib.sol
@@ -35,8 +35,11 @@ contract WalletDeploymentLib
     }
 
     function computeWalletSalt(
-        address owner,
-        uint    salt
+        address          owner,
+        address[] memory guardians,
+        uint             quota,
+        address          inheritor,
+        uint             salt
         )
         public
         pure
@@ -46,35 +49,56 @@ contract WalletDeploymentLib
             abi.encodePacked(
                 WALLET_CREATION,
                 owner,
+                keccak256(abi.encodePacked(guardians)),
+                quota,
+                inheritor,
                 salt
             )
         );
     }
 
     function _deploy(
-        address owner,
-        uint    salt
+        address          owner,
+        address[] memory guardians,
+        uint             quota,
+        address          inheritor,
+        uint             salt
         )
         internal
         returns (address payable wallet)
     {
         wallet = Create2.deploy(
-            computeWalletSalt(owner, salt),
+            computeWalletSalt(
+                owner,
+                guardians,
+                quota,
+                inheritor,
+                salt
+            ),
             getWalletCode()
         );
     }
 
     function _computeWalletAddress(
-        address owner,
-        uint    salt,
-        address deployer
+        address          owner,
+        address[] memory guardians,
+        uint             quota,
+        address          inheritor,
+        uint             salt,
+        address          deployer
         )
         internal
         view
         returns (address)
     {
         return Create2.computeAddress(
-            computeWalletSalt(owner, salt),
+            computeWalletSalt(
+                owner,
+                guardians,
+                quota,
+                inheritor,
+                salt
+            ),
             getWalletCode(),
             deployer
         );

--- a/packages/hebao_v2/contracts/base/WalletFactory.sol
+++ b/packages/hebao_v2/contracts/base/WalletFactory.sol
@@ -61,7 +61,13 @@ contract WalletFactory is WalletDeploymentLib
         require(feeAmount <= config.maxFeeAmount, "INVALID_FEE_AMOUNT");
 
         _validateConfig(config);
-        wallet = _deploy(config.owner, config.salt);
+        wallet = _deploy(
+            config.owner,
+            config.guardians,
+            config.quota,
+            config.inheritor,
+            config.salt
+        );
         _initializeWallet(wallet, config, feeAmount);
     }
 
@@ -70,8 +76,11 @@ contract WalletFactory is WalletDeploymentLib
     /// @param salt A salt.
     /// @return wallet The wallet address
     function computeWalletAddress(
-        address owner,
-        uint    salt
+        address          owner,
+        address[] memory guardians,
+        uint             quota,
+        address          inheritor,
+        uint             salt
         )
         public
         view
@@ -79,6 +88,9 @@ contract WalletFactory is WalletDeploymentLib
     {
         return _computeWalletAddress(
             owner,
+            guardians,
+            quota,
+            inheritor,
             salt,
             address(this)
         );


### PR DESCRIPTION
See #2564 for discussion if this is what we want or not.

Have left the fee payment options in the signature because at wallet creation the owner won't always know what funds will be in the wallet and the gas fee when the wallet for deploying the wallet can also vary a lot over the months/years. Putting the fee data in the wallet address would of course also be possible.

Have not yet updated the tests (or agent dependencies).