### PR TITLE
[protocols3.6]callback recievers must be a universal agent

### DIFF
--- a/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
+++ b/packages/loopring_v3/contracts/aux/access/LoopringIOExchangeOwner.sol
@@ -99,6 +99,12 @@ contract LoopringIOExchangeOwner is SelectorBasedAccessManager, ERC1271, Drainab
     {
         if (config.blockCallbacks.length > 0) {
             require(config.receivers.length > 0, "MISSING_RECEIVERS");
+
+             // Make sure the receiver is authorized to approve transactions
+            IAgentRegistry agentRegistry = IExchangeV3(target).getAgentRegistry();
+            for (uint i = 0; i < config.receivers.length; i++) {
+                require(agentRegistry.isUniversalAgent(config.receivers[i]), "UNAUTHORIZED_RECEIVER");
+            }
         }
 
         require(


### PR DESCRIPTION
Just noticed that we removed the universal-agent checks in the LoopringIOExchangeOwner contract.
From my understanding, these checks are necessary. So I add it back.

I'd checked the contract we are using on mainnet, the universal-agent checks are there.  