### PR TITLE
Counterfactual NFTs

### DIFF
--- a/packages/counterfactual_nft/README.md
+++ b/packages/counterfactual_nft/README.md
@@ -25,6 +25,6 @@ Should be simple to understand for users:
 
 The NFT is now fully functional on L2 and the only cost was the NFT mint price on L2.
 
-If `baseURI != 0` it's a bit more complicated because that data is not publicly known by default before the NFT contract is created. So to be able to know how to show the NFT on L2 this data need to be made public somehow (well, at least for them to work on a general block explorer, could be part of the offchain data field in a block, but this of course also costs some gas). But the option is there if minters don't want to use the IPFS hash as the NFT ID and still have the full flexibility to store whatever data they want in the NFT ID like they can in normal NFT contracts.
+If `baseURI != 0` it's a bit more complicated because that data is not publicly known by default before the NFT contract is created. So to be able to know how to show the NFT on L2 this data needs to be made public somehow (well, at least for them to work on a general block explorer, could be part of the offchain data field in a block, but this of course also costs some gas). But the option is there if minters don't want to use the IPFS hash as the NFT ID and still have the full flexibility to store whatever data they want in the NFT ID like they can in normal NFT contracts.
 
 This is really just mainly for people that want to mint a couple of NFTs for as cheap as possible. Creators doing serious collections with thousands of NFTs will probably want to use their own contract anyway.

--- a/packages/counterfactual_nft/README.md
+++ b/packages/counterfactual_nft/README.md
@@ -1,0 +1,30 @@
+# CounterfactualNFT
+
+## Build instructions
+
+```
+yarn install
+yarn compile
+```
+
+## Test instructions
+
+```
+yarn run ganache-cli
+yarn test
+```
+
+## Usage
+
+Everybody on L2 automatically has his/her own NFT contract for free that can be used to mint NFTs. The address of this NFT contract is `NFTFactory.computeNftContractAddress(owner, baseURI)`. In the simplest case `baseURI == ""` so there is no data that needs to be shared publicly to be able to create the NFT contract by calling `NFTFactory.createNftContract(owner, baseURI)`. **Anybody** can call this function to create an NFT contract for an account. When this contract is created is not important, it just needs to be created when somebody wants to withdraw an NFT associated with this counterfactual NFT contract to L1 because it acts like a bridge between L1 and L2.
+
+Should be simple to understand for users:
+- The user puts his NFT on IPFS and gets an IPFS hash in return (per NFT!)
+- The UI calculates the counterfactual NFT token contract address and shows it as the default option to mint NFTs to for his account
+- The NFT is minted with the counterfactual NFT token contract as the token address and the IPFS hash as the NFT ID
+
+The NFT is now fully functional on L2 and the only cost was the NFT mint price on L2.
+
+If `baseURI != 0` it's a bit more complicated because that data is not publicly known by default before the NFT contract is created. So to be able to know how to show the NFT on L2 this data need to be made public somehow (well, at least for them to work on a general block explorer, could be part of the offchain data field in a block, but this of course also costs some gas). But the option is there if minters don't want to use the IPFS hash as the NFT ID and still have the full flexibility to store whatever data they want in the NFT ID like they can in normal NFT contracts.
+
+This is really just mainly for people that want to mint a couple of NFTs for as cheap as possible. Creators doing serious collections with thousands of NFTs will probably want to use their own contract anyway.

--- a/packages/counterfactual_nft/contracts/AddressSet.sol
+++ b/packages/counterfactual_nft/contracts/AddressSet.sol
@@ -25,7 +25,7 @@ contract AddressSet
         require(set.positions[addr] == 0, "ALREADY_IN_SET");
 
         if (maintainList) {
-            require(set.addresses.length == set.count, "PREVIOUSLY_NOT_MAINTAILED");
+            require(set.addresses.length == set.count, "PREVIOUSLY_NOT_MAINTAINED");
             set.addresses.push(addr);
         } else {
             require(set.addresses.length == 0, "MUST_MAINTAIN");

--- a/packages/counterfactual_nft/contracts/AddressSet.sol
+++ b/packages/counterfactual_nft/contracts/AddressSet.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.8.2;
+
+
+/// @title AddressSet
+/// @author Daniel Wang - <daniel@loopring.org>
+contract AddressSet
+{
+    struct Set
+    {
+        address[] addresses;
+        mapping (address => uint) positions;
+        uint count;
+    }
+    mapping (bytes32 => Set) private sets;
+
+    function addAddressToSet(
+        bytes32 key,
+        address addr,
+        bool    maintainList
+        ) internal
+    {
+        Set storage set = sets[key];
+        require(set.positions[addr] == 0, "ALREADY_IN_SET");
+
+        if (maintainList) {
+            require(set.addresses.length == set.count, "PREVIOUSLY_NOT_MAINTAILED");
+            set.addresses.push(addr);
+        } else {
+            require(set.addresses.length == 0, "MUST_MAINTAIN");
+        }
+
+        set.count += 1;
+        set.positions[addr] = set.count;
+    }
+
+    function removeAddressFromSet(
+        bytes32 key,
+        address addr
+        )
+        internal
+    {
+        Set storage set = sets[key];
+        uint pos = set.positions[addr];
+        require(pos != 0, "NOT_IN_SET");
+
+        delete set.positions[addr];
+        set.count -= 1;
+
+        if (set.addresses.length > 0) {
+            address lastAddr = set.addresses[set.count];
+            if (lastAddr != addr) {
+                set.addresses[pos - 1] = lastAddr;
+                set.positions[lastAddr] = pos;
+            }
+            set.addresses.pop();
+        }
+    }
+
+    function removeSet(bytes32 key)
+        internal
+    {
+        delete sets[key];
+    }
+
+    function isAddressInSet(
+        bytes32 key,
+        address addr
+        )
+        internal
+        view
+        returns (bool)
+    {
+        return sets[key].positions[addr] != 0;
+    }
+
+    function numAddressesInSet(bytes32 key)
+        internal
+        view
+        returns (uint)
+    {
+        Set storage set = sets[key];
+        return set.count;
+    }
+
+    function addressesInSet(bytes32 key)
+        internal
+        view
+        returns (address[] memory)
+    {
+        Set storage set = sets[key];
+        require(set.count == set.addresses.length, "NOT_MAINTAINED");
+        return sets[key].addresses;
+    }
+}

--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.8.2;
+
+import "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+import "./ICounterfactualNFT.sol";
+import "./AddressSet.sol";
+import "./external/IL2MintableNFT.sol";
+import "./external/IPFS.sol";
+import "./external/OwnableUpgradeable.sol";
+
+
+/**
+ * @title CounterfactualNFT
+ */
+contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradeable, OwnableUpgradeable, IL2MintableNFT, AddressSet
+{
+    event MintFromL2(
+        address owner,
+        uint256 id,
+        uint    amount,
+        address minter
+    );
+
+    bytes32 internal constant MINTERS = keccak256("__MINTERS__");
+    bytes32 internal constant DEPRECATED_MINTERS = keccak256("__DEPRECATED_MINTERS__");
+
+    address public immutable layer2Address;
+
+    modifier onlyFromLayer2
+    {
+        require(msg.sender == layer2Address, "not authorized");
+        _;
+    }
+
+    modifier onlyFromMinter
+    {
+        require(isMinter(msg.sender), "not authorized");
+        _;
+    }
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _layer2Address)
+        initializer
+    {
+        layer2Address = _layer2Address;
+        // Disable implementation contract
+        _owner = 0x000000000000000000000000000000000000dEaD;
+    }
+
+    function initialize(address owner, string memory _uri)
+        public
+        override
+    {
+        require(_owner == address(0), "ALREADY_INITIALIZED");
+        _owner = owner;
+
+        if (bytes(_uri).length != 0) {
+            _setURI(_uri);
+        }
+    }
+
+    function setURI(string memory _uri)
+        public
+        onlyOwner
+    {
+        _setURI(_uri);
+    }
+
+    function mint(
+        address       account,
+        uint256       id,
+        uint256       amount,
+        bytes  memory data
+        )
+        external
+        onlyFromMinter
+    {
+        _mint(account, id, amount, data);
+    }
+
+    function mintBatch(
+        address          to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes     memory data
+        )
+        external
+        onlyFromMinter
+    {
+        _mintBatch(to, ids, amounts, data);
+    }
+
+    function setMinter(
+        address minter,
+        bool enabled
+        )
+        external
+        onlyOwner
+    {
+        if (enabled) {
+            addAddressToSet(MINTERS, minter, true);
+            if (isAddressInSet(DEPRECATED_MINTERS, minter)) {
+                removeAddressFromSet(DEPRECATED_MINTERS, minter);
+            }
+        } else {
+            removeAddressFromSet(MINTERS, minter);
+            if (!isAddressInSet(DEPRECATED_MINTERS, minter)) {
+                addAddressToSet(DEPRECATED_MINTERS, minter, true);
+            }
+        }
+    }
+
+    function transferOwnership(address newOwner)
+        public
+        virtual
+        override
+        onlyOwner
+    {
+        require(newOwner != owner(), "INVALID_OWNER");
+        // Make sure NFTs minted by the previous owner remain valid
+        if (!isAddressInSet(DEPRECATED_MINTERS, owner())) {
+            addAddressToSet(DEPRECATED_MINTERS, owner(), true);
+        }
+        // Now transfer the ownership like usual
+        super.transferOwnership(newOwner);
+    }
+
+    function uri(uint256 tokenId)
+        public
+        view
+        virtual
+        override
+        returns (string memory)
+    {
+        string memory baseURI = super.uri(tokenId);
+        if (bytes(baseURI).length == 0) {
+            // If no base URI is set we interpret the tokenId as an IPFS hash
+            return string(
+                abi.encodePacked(
+                    "ipfs://",
+                    IPFS.encode(tokenId),
+                    "/metadata.json"
+                )
+            );
+        } else {
+            return baseURI;
+        }
+    }
+
+    // Layer 2 logic
+
+    function mintFromL2(
+        address          to,
+        uint256          id,
+        uint             amount,
+        address          minter,
+        bytes   calldata data
+        )
+        external
+        override
+        onlyFromLayer2
+    {
+        require(isMinter(minter) || isAddressInSet(DEPRECATED_MINTERS, minter), "invalid minter");
+
+        _mint(to, id, amount, data);
+        emit MintFromL2(to, id, amount, minter);
+    }
+
+    function minters()
+        public
+        view
+        override
+        returns (address[] memory)
+    {
+        address[] memory minterAddresses = addressesInSet(MINTERS);
+        address[] memory deprecatedAddresses = addressesInSet(DEPRECATED_MINTERS);
+        address[] memory mintersAndOwner = new address[](minterAddresses.length + deprecatedAddresses.length + 1);
+        uint idx = 0;
+        for (uint i = 0; i < minterAddresses.length; i++) {
+            mintersAndOwner[idx++] = minterAddresses[i];
+        }
+         for (uint i = 0; i < deprecatedAddresses.length; i++) {
+            mintersAndOwner[idx++] = deprecatedAddresses[i];
+        }
+        // Owner could already be added to the minters, but that's fine
+        mintersAndOwner[idx++] = owner();
+        return mintersAndOwner;
+    }
+
+    function isMinter(address addr)
+        public
+        view
+        returns (bool)
+    {
+        // Also allow the owner to mint NFTs to save on gas (no additional minter needs to be set)
+        return addr == owner() || isAddressInSet(MINTERS, addr);
+    }
+}

--- a/packages/counterfactual_nft/contracts/ICounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/ICounterfactualNFT.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.8.2;
+
+
+/**
+ * @title ICounterfactualNFT
+ */
+abstract contract ICounterfactualNFT
+{
+    function initialize(address owner, string memory _uri)
+        public
+        virtual;
+}

--- a/packages/counterfactual_nft/contracts/Migrations.sol
+++ b/packages/counterfactual_nft/contracts/Migrations.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.8.2;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  constructor() {
+    owner = msg.sender;
+  }
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function setCompleted(uint completed) public restricted {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) public restricted {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/packages/counterfactual_nft/contracts/NFTFactory.sol
+++ b/packages/counterfactual_nft/contracts/NFTFactory.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.8.2;
+pragma experimental ABIEncoderV2;
+
+import "./ICounterfactualNFT.sol";
+import "@openzeppelin/contracts-upgradeable/utils/Create2Upgradeable.sol";
+import "./external/CloneFactory.sol";
+
+
+/// @title NFTFactory
+/// @author Brecht Devos - <brecht@loopring.org>
+contract NFTFactory
+{
+    event NFTContractCreated (address nftContract, address owner, string baseURI);
+
+    string public constant NFT_CONTRACT_CREATION = "NFT_CONTRACT_CREATION";
+    address public immutable implementation;
+
+    constructor(
+        address _implementation
+        )
+    {
+        implementation = _implementation;
+    }
+
+    /// @dev Create a new NFT contract.
+    /// @param owner The NFT contract owner.
+    /// @param baseURI The base token URI (empty string allowed/encouraged to use IPFS mode)
+    /// @return nftContract The new NFT contract address
+    function createNftContract(
+        address            owner,
+        string    calldata baseURI
+        )
+        external
+        payable
+        returns (address nftContract)
+    {
+        // Deploy the proxy contract
+        nftContract = Create2Upgradeable.deploy(
+            0,
+            keccak256(abi.encodePacked(NFT_CONTRACT_CREATION, owner, baseURI)),
+            CloneFactory.getByteCode(implementation)
+        );
+
+        // Initialize
+        ICounterfactualNFT(nftContract).initialize(owner, baseURI);
+
+        emit NFTContractCreated(nftContract, owner, baseURI);
+    }
+
+    function computeNftContractAddress(
+        address          owner,
+        string  calldata baseURI
+        )
+        public
+        view
+        returns (address)
+    {
+        return _computeAddress(owner, baseURI);
+    }
+
+    function getNftContractCreationCode()
+        public
+        view
+        returns (bytes memory)
+    {
+        return CloneFactory.getByteCode(implementation);
+    }
+
+    function _computeAddress(
+        address          owner,
+        string  calldata baseURI
+        )
+        private
+        view
+        returns (address)
+    {
+        return Create2Upgradeable.computeAddress(
+            keccak256(abi.encodePacked(NFT_CONTRACT_CREATION, owner, baseURI)),
+            keccak256(CloneFactory.getByteCode(implementation))
+        );
+    }
+}

--- a/packages/counterfactual_nft/contracts/external/CloneFactory.sol
+++ b/packages/counterfactual_nft/contracts/external/CloneFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// This code is taken from https://eips.ethereum.org/EIPS/eip-1167
+// Modified to a library and generalized to support create/create2.
+pragma solidity ^0.8.2;
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2018 Murray Software, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//solhint-disable max-line-length
+//solhint-disable no-inline-assembly
+
+library CloneFactory {
+  function getByteCode(address target) internal pure returns (bytes memory byteCode) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      byteCode := mload(0x40)
+      mstore(byteCode, 0x37)
+
+      let clone := add(byteCode, 0x20)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+
+      mstore(0x40, add(byteCode, 0x60))
+    }
+  }
+}

--- a/packages/counterfactual_nft/contracts/external/IL2MintableNFT.sol
+++ b/packages/counterfactual_nft/contracts/external/IL2MintableNFT.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.8.2;
+
+
+interface IL2MintableNFT
+{
+    /// @dev This function is called when an NFT minted on L2 is withdrawn from Loopring.
+    ///      That means the NFTs were burned on L2 and now need to be minted on L1.
+    ///
+    ///      This function can only be called by the Loopring exchange.
+    ///
+    /// @param to The owner of the NFT
+    /// @param tokenId The token type 'id`
+    /// @param amount The amount of NFTs to mint
+    /// @param minter The minter on L2, which can be used to decide if the NFT is authentic
+    /// @param data Opaque data that can be used by the contract
+    function mintFromL2(
+        address          to,
+        uint256          tokenId,
+        uint             amount,
+        address          minter,
+        bytes   calldata data
+        )
+        external;
+
+    /// @dev Returns a list of all address that are authorized to mint NFTs on L2.
+    /// @return The list of authorized minter on L2
+    function minters()
+        external
+        view
+        returns (address[] memory);
+}

--- a/packages/counterfactual_nft/contracts/external/IPFS.sol
+++ b/packages/counterfactual_nft/contracts/external/IPFS.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+pragma experimental ABIEncoderV2;
+
+
+/// @title IPFS
+/// @author Brecht Devos - <brecht@loopring.org>
+library IPFS
+{
+    bytes constant ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+    // Encodes the 32 byte data as an IPFS v0 CID
+    function encode(uint256 data)
+        internal
+        pure
+        returns (string memory)
+    {
+        // We'll be always be encoding 34 bytes
+        bytes memory out = new bytes(46);
+
+        // Copy alphabet to memory
+        bytes memory alphabet = ALPHABET;
+
+        // We have to encode 0x1220data, which is 34 bytes and doesn't fit in a single uint256.
+        // Keep the first 32 bytes in the uint, but do the encoding as if 0x1220 was part of the data value.
+        // 0 = (0x12200000000000000000000000000000000000000000000000000000000000000000) % 58
+        out[45] = alphabet[data % 58];
+        data /= 58;
+        // 4 = (0x12200000000000000000000000000000000000000000000000000000000000000000 / 58) % 58
+        data += 4;
+        out[44] = alphabet[data % 58];
+        data /= 58;
+        // 40 = (0x12200000000000000000000000000000000000000000000000000000000000000000 / 58 / 58) % 58
+        data += 40;
+        out[43] = alphabet[data % 58];
+        data /= 58;
+
+        // Add the top bytes now there is anough space in the uint256
+        // This constant is 0x12200000000000000000000000000000000000000000000000000000000000000000 / 58 / 58 / 58
+        data += 2753676319555676466672318311740497214108679778017611511045364661305900823779;
+
+        // The rest is just simple base58 encoding
+        for (uint i = 3; i < 46; i++) {
+            out[45 - i] = alphabet[data % 58];
+            data /= 58;
+        }
+
+        return string(out);
+    }
+}

--- a/packages/counterfactual_nft/contracts/external/OwnableUpgradeable.sol
+++ b/packages/counterfactual_nft/contracts/external/OwnableUpgradeable.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+// Copied from Open-Zeppelin, changed `_owner` to public for gas optimizations.
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract OwnableUpgradeable is Initializable, ContextUpgradeable {
+    address public _owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    /**
+     * @dev Initializes the contract setting the deployer as the initial owner.
+     */
+    function __Ownable_init() internal initializer {
+        __Context_init_unchained();
+        __Ownable_init_unchained();
+    }
+
+    function __Ownable_init_unchained() internal initializer {
+        _setOwner(_msgSender());
+    }
+
+    /**
+     * @dev Returns the address of the current owner.
+     */
+    function owner() public view virtual returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(owner() == _msgSender(), "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Leaves the contract without owner. It will not be possible to call
+     * `onlyOwner` functions anymore. Can only be called by the current owner.
+     *
+     * NOTE: Renouncing ownership will leave the contract without an owner,
+     * thereby removing any functionality that is only available to the owner.
+     */
+    function renounceOwnership() public virtual onlyOwner {
+        _setOwner(address(0));
+    }
+
+    /**
+     * @dev Transfers ownership of the contract to a new account (`newOwner`).
+     * Can only be called by the current owner.
+     */
+    function transferOwnership(address newOwner) public virtual onlyOwner {
+        require(newOwner != address(0), "Ownable: new owner is the zero address");
+        _setOwner(newOwner);
+    }
+
+    function _setOwner(address newOwner) private {
+        address oldOwner = _owner;
+        _owner = newOwner;
+        emit OwnershipTransferred(oldOwner, newOwner);
+    }
+    uint256[49] private __gap;
+}

--- a/packages/counterfactual_nft/deploy.sh
+++ b/packages/counterfactual_nft/deploy.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+#yarn truffle deploy --reset  --network $NETWORK
+yarn truffle deploy --network $NETWORK
+truffle run verify CounterfactualNFT --network $NETWORK
+

--- a/packages/counterfactual_nft/flatten.sh
+++ b/packages/counterfactual_nft/flatten.sh
@@ -1,0 +1,1 @@
+./node_modules/.bin/truffle-flattener contracts/CounterfactualNFT.sol > flattened/CounterfactualNFT.sol

--- a/packages/counterfactual_nft/migrations/1_initial_migrations.js
+++ b/packages/counterfactual_nft/migrations/1_initial_migrations.js
@@ -1,0 +1,5 @@
+const Migrations = artifacts.require("./Migrations.sol")
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations)
+}

--- a/packages/counterfactual_nft/migrations/2_deploy_contracts.js
+++ b/packages/counterfactual_nft/migrations/2_deploy_contracts.js
@@ -6,15 +6,6 @@ module.exports = async (deployer, network, addresses) => {
 
   const loopringExchangeAddress = "0x0BABA1Ad5bE3a5C0a66E7ac838a129Bf948f1eA4";
 
-  let owner;
-  if (network === 'rinkeby') {
-    owner = addresses[0];
-  } else if (network === 'development') {
-    owner = addresses[0];
-  } else {
-    owner = addresses[0];
-  }
-
   await deployer.deploy(NftContract, loopringExchangeAddress, {gas: 5000000});
   const nft = await NftContract.deployed();
 

--- a/packages/counterfactual_nft/migrations/2_deploy_contracts.js
+++ b/packages/counterfactual_nft/migrations/2_deploy_contracts.js
@@ -1,0 +1,26 @@
+const NftContract = artifacts.require("./CounterfactualNFT.sol");
+const NFTFactory = artifacts.require("./NFTFactory.sol");
+
+module.exports = async (deployer, network, addresses) => {
+  console.log("Deploying to " + network);
+
+  const loopringExchangeAddress = "0x0BABA1Ad5bE3a5C0a66E7ac838a129Bf948f1eA4";
+
+  let owner;
+  if (network === 'rinkeby') {
+    owner = addresses[0];
+  } else if (network === 'development') {
+    owner = addresses[0];
+  } else {
+    owner = addresses[0];
+  }
+
+  await deployer.deploy(NftContract, loopringExchangeAddress, {gas: 5000000});
+  const nft = await NftContract.deployed();
+
+  await deployer.deploy(NFTFactory, nft.address, {gas: 5000000});
+  const factory = await NftContract.deployed();
+
+  console.log("factory address: " + factory.address);
+  console.log("implementation address: " + nft.address);
+};

--- a/packages/counterfactual_nft/package.json
+++ b/packages/counterfactual_nft/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "counterfactual-nft",
+  "version": "1.0.0",
+  "description": "CounterfactualNFT smart contracts.",
+  "private": true,
+  "main": "index.js",
+  "scripts": {
+    "ganache-cli": "ganache-cli -d -p 7545 --gasLimit=10000000",
+    "test": "DEPLOY_ALL=1 truffle test",
+    "compile": "truffle compile"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Loopring/protocols.git"
+  },
+  "license": "Apache-2.0",
+  "homepage": "https://loopring.io",
+  "dependencies": {
+    "@0x/subproviders": "^6.4.1",
+    "@openzeppelin/contracts-upgradeable": "^4.3.2",
+    "@uniswap/v3-periphery": "1.2.1",
+    "eth-gas-reporter": "^0.2.17",
+    "eth-sig-util": "^3.0.1",
+    "ethereum-waffle": "^3.0.0",
+    "opensea-js": "^1.1.5",
+    "openzeppelin-solidity": "~4.1.0",
+    "truffle": "^5.1.35",
+    "truffle-assertions": "^0.9.2",
+    "truffle-contract-size": "^2.0.1",
+    "truffle-flattener": "^1.4.2",
+    "truffle-hdwallet-provider": "1.0.17",
+    "web3": "^1.0.0-beta.34"
+  },
+  "_engines": {
+    "node": "^12.18.x",
+    "yarn": "~1.22.4"
+  },
+  "devDependencies": {
+    "eslint": "^7.22.0",
+    "ganache-cli": "6.9.1",
+    "truffle-plugin-verify": "^0.5.12"
+  },
+  "workspaces": [
+    "./*"
+  ]
+}

--- a/packages/counterfactual_nft/test/test.js
+++ b/packages/counterfactual_nft/test/test.js
@@ -1,0 +1,69 @@
+const truffleAssert = require('truffle-assertions');
+var assert = require('assert');
+const BigNumber = require('bignumber.js');
+
+const NFTFactory = artifacts.require("NFTFactory.sol");
+const CounterfactualNFT = artifacts.require("CounterfactualNFT.sol");
+
+contract("NFT", (accounts) => {
+  const ownerA = accounts[0];
+  const ownerB = accounts[1];
+  const minterA = accounts[2];
+  const minterB = accounts[3];
+  const userA = accounts[4];
+  const userB = accounts[5];
+
+  let factory;
+
+  before(async () => {
+    factory = await NFTFactory.deployed();
+  });
+
+  it("Counterfactual flow", async () => {
+    const owner = ownerA;
+    const nftTokenAddress = await factory.computeNftContractAddress(owner, "");
+
+    const tx = await factory.createNftContract(owner, "");
+    //console.log("Deployment cost: " + tx.receipt.gasUsed);
+
+    // Check if the contract was deployed to the expected address
+    truffleAssert.eventEmitted(tx, 'NFTContractCreated', (ev) => {
+      return ev.nftContract === nftTokenAddress && ev.owner === owner && ev.baseURI === "";
+    });
+
+    const nft = await CounterfactualNFT.at(nftTokenAddress);
+
+    // Owner needs to be set to the expected owner
+    assert.equal(await nft.owner(), owner, "unexpected owner");
+
+    // Owner needs to be able to mint an NFT on L1
+    const tokenID = "82074012285391930765279489314136667830573876033924668146917021887792317657586";
+    await nft.mint(userB, tokenID, "1", "0x", {from: owner});
+
+    // Check if the IPFS URI is correctly returned for the minted NFT
+    const uri = await nft.uri(tokenID);
+    assert(uri === "ipfs://QmaYyJx2RTHY7aGLSNX7xEzSYeh8SHU2eLNcVB1XXgzuv9/metadata.json", "unexpected uri");
+
+    // The owner needs to be a minter
+    assert.deepEqual(await nft.minters(), [owner], "unexpected minters");
+    assert(await nft.isMinter(owner), "owner needs to be a minter");
+
+    // Add a new minter
+    await nft.setMinter(userB, true, {from: owner});
+    assert.deepEqual(await nft.minters(), [userB, owner], "unexpected minters");
+    assert(await nft.isMinter(userB), "new minter needs to be enabled");
+
+    // Remove a minter
+    await nft.setMinter(userB, false, {from: owner});
+    assert.deepEqual(await nft.minters(), [userB, owner], "unexpected minters");
+    assert(!(await nft.isMinter(userB)), "new minter needs to be disabled");
+
+    // Transfer ownership to a new owner
+    // The old owner still needs to be a deprecated minter
+    await nft.transferOwnership(ownerB, {from: ownerA});
+    assert.equal(await nft.owner(), ownerB, "unexpected owner");
+    assert.deepEqual(await nft.minters(), [userB, ownerA, ownerB], "unexpected minters");
+    assert(!(await nft.isMinter(ownerA)), "previous owner needs to be disabled");
+    assert(await nft.isMinter(ownerB), "current owner needs to be enabled");
+  });
+});

--- a/packages/counterfactual_nft/truffle.js
+++ b/packages/counterfactual_nft/truffle.js
@@ -1,0 +1,81 @@
+const HDWalletProvider = require("truffle-hdwallet-provider");
+
+const MNEMONIC = process.env.MNEMONIC;
+const NODE_API_KEY = process.env.INFURA_KEY || process.env.ALCHEMY_KEY;
+const isInfura = !!process.env.INFURA_KEY;
+
+const needsNodeAPI =
+  process.env.npm_config_argv &&
+  (process.env.npm_config_argv.includes("rinkeby") ||
+    process.env.npm_config_argv.includes("live"));
+
+if ((!MNEMONIC || !NODE_API_KEY) && needsNodeAPI) {
+  console.error("Please set a mnemonic and ALCHEMY_KEY or INFURA_KEY.");
+  process.exit(0);
+}
+
+const rinkebyNodeUrl = isInfura
+  ? "https://rinkeby.infura.io/v3/" + NODE_API_KEY
+  : "https://eth-rinkeby.alchemyapi.io/v2/" + NODE_API_KEY;
+
+let mainnetNodeUrl = isInfura
+  ? "https://mainnet.infura.io/v3/" + NODE_API_KEY
+  : "https://eth-mainnet.alchemyapi.io/v2/" + NODE_API_KEY;
+
+
+module.exports = {
+  networks: {
+    development: {
+      host: "localhost",
+      port: 7545,
+      gas: 5000000,
+      network_id: "*", // Match any network id
+    },
+    rinkeby: {
+      provider: function () {
+        return new HDWalletProvider(MNEMONIC, rinkebyNodeUrl, 1);
+      },
+      gas: 5000000,
+      network_id: 4,
+      gasPrice: 5000000000, // 5 gwei
+    },
+    live: {
+      network_id: 1,
+      provider: function () {
+        return new HDWalletProvider(MNEMONIC, mainnetNodeUrl, 1);
+      },
+      gas: 5000000,
+      gasPrice: 101000000000, // 5 gwei
+      confirmations: 2,
+      timeoutBlocks: 200,
+      skipDryRun: false,
+      websocket: true,
+      timeoutBlocks: 50000,
+      //networkCheckTimeout: 1000000
+    },
+  },
+  mocha: {
+    reporter: "eth-gas-reporter",
+    reporterOptions: {
+      currency: "USD",
+      gasPrice: 2,
+    },
+  },
+  compilers: {
+    solc: {
+      version: "pragma",
+      settings: {
+        optimizer: {
+          enabled: true,
+          runs: 2000   // Optimize for how many times you intend to run the code
+        },
+      },
+    },
+  },
+  plugins: [
+    'truffle-plugin-verify'
+  ],
+  api_keys: {
+    etherscan: process.env.ETHERSCAN_API_KEY_FOR_VERIFICATION
+  }
+};

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeNFT.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeNFT.sol
@@ -7,6 +7,7 @@ import "../../iface/ExchangeData.sol";
 import "../../iface/IL2MintableNFT.sol";
 import "../../../thirdparty/erc1155/IERC1155.sol";
 import "../../../thirdparty/erc721/IERC721.sol";
+import "../../../lib/AddressUtil.sol";
 
 
 /// @title ExchangeNFT
@@ -14,6 +15,7 @@ import "../../../thirdparty/erc721/IERC721.sol";
 library ExchangeNFT
 {
     using ExchangeNFT for ExchangeData.State;
+    using AddressUtil for address;
 
     function deposit(
         ExchangeData.State storage S,
@@ -148,6 +150,6 @@ library ExchangeNFT
         view
         returns (bool valid)
     {
-        return (token != address(this) && token != address(S.depositContract));
+        return (token != address(this) && token != address(S.depositContract)) && token.isContract();
     }
 }

--- a/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
+++ b/packages/loopring_v3/contracts/core/impl/libexchange/ExchangeWithdrawals.sol
@@ -480,31 +480,35 @@ library ExchangeWithdrawals
         private
         returns (bool success)
     {
-        if (nft.token == nft.minter) {
-            // This is an existing thirdparty NFT contract
-            success = ExchangeNFT.withdraw(
-                S,
-                from,
-                to,
-                nft.nftType,
-                nft.token,
-                nft.nftID,
-                amount,
-                extraData,
-                gasLimit
-            );
+        if (gasLimit > 0) {
+            if (nft.token == nft.minter) {
+                // This is an existing thirdparty NFT contract
+                success = ExchangeNFT.withdraw(
+                    S,
+                    from,
+                    to,
+                    nft.nftType,
+                    nft.token,
+                    nft.nftID,
+                    amount,
+                    extraData,
+                    gasLimit
+                );
+            } else {
+                // This is an NFT contract with L2 minting support
+                success = ExchangeNFT.mintFromL2(
+                    S,
+                    to,
+                    nft.token,
+                    nft.nftID,
+                    amount,
+                    nft.minter,
+                    extraData,
+                    gasLimit
+                );
+            }
         } else {
-            // This is an inhouse NFT contract with L2 minting support
-            success = ExchangeNFT.mintFromL2(
-                S,
-                to,
-                nft.token,
-                nft.nftID,
-                amount,
-                nft.minter,
-                extraData,
-                gasLimit
-            );
+            success = false;
         }
 
         require(allowFailure || success, "NFT_TRANSFER_FAILURE");

--- a/packages/loopring_v3/contracts/test/nft/CloneFactory.sol
+++ b/packages/loopring_v3/contracts/test/nft/CloneFactory.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+// This code is taken from https://eips.ethereum.org/EIPS/eip-1167
+// Modified to a library and generalized to support create/create2.
+pragma solidity ^0.7.0;
+
+/*
+The MIT License (MIT)
+
+Copyright (c) 2018 Murray Software, LLC.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+//solhint-disable max-line-length
+//solhint-disable no-inline-assembly
+
+library CloneFactory {
+  function getByteCode(address target) internal pure returns (bytes memory byteCode) {
+    bytes20 targetBytes = bytes20(target);
+    assembly {
+      byteCode := mload(0x40)
+      mstore(byteCode, 0x37)
+
+      let clone := add(byteCode, 0x20)
+      mstore(clone, 0x3d602d80600a3d3981f3363d3d373d3d3d363d73000000000000000000000000)
+      mstore(add(clone, 0x14), targetBytes)
+      mstore(add(clone, 0x28), 0x5af43d82803e903d91602b57fd5bf30000000000000000000000000000000000)
+
+      mstore(0x40, add(byteCode, 0x60))
+    }
+  }
+}

--- a/packages/loopring_v3/contracts/test/nft/CounterfactualNFT.sol
+++ b/packages/loopring_v3/contracts/test/nft/CounterfactualNFT.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.7.0;
+
+import "../../core/iface/IL2MintableNFT.sol";
+import "../../lib/AddressSet.sol";
+import "../../lib/Ownable.sol";
+import "../../thirdparty/erc1155/ERC1155.sol";
+import "./ICounterfactualNFT.sol";
+
+
+/**
+ * @title CounterfactualNFT
+ */
+contract CounterfactualNFT is ICounterfactualNFT, ERC1155, IL2MintableNFT, Ownable, AddressSet
+{
+    event MintFromL2(
+        address owner,
+        uint256 id,
+        uint    amount,
+        address minter
+    );
+
+    bytes32 internal constant MINTERS = keccak256("__MINTERS__");
+    bytes32 internal constant DEPRECATED_MINTERS = keccak256("__DEPRECATED_MINTERS__");
+
+    address public immutable layer2Address;
+
+    modifier onlyFromLayer2
+    {
+        require(msg.sender == layer2Address, "not authorized");
+        _;
+    }
+
+    modifier onlyFromMinter
+    {
+        require(isMinter(msg.sender), "not authorized");
+        _;
+    }
+
+    constructor(address _layer2Address)
+        ERC1155("")
+    {
+        layer2Address = _layer2Address;
+        // Disable implementation contract
+        owner = 0x000000000000000000000000000000000000dEaD;
+    }
+
+    function initialize(address _owner, string memory _uri)
+        public
+        override
+    {
+        require(owner == address(0), "ALREADY_INITIALIZED");
+        owner = _owner;
+
+        if (bytes(_uri).length != 0) {
+            _setURI(_uri);
+        }
+    }
+
+    function setURI(string memory _uri)
+        public
+        onlyOwner
+    {
+        _setURI(_uri);
+    }
+
+    function mint(
+        address       account,
+        uint256       id,
+        uint256       amount,
+        bytes  memory data
+        )
+        external
+        onlyFromMinter
+    {
+        _mint(account, id, amount, data);
+    }
+
+    function setMinter(
+        address minter,
+        bool enabled
+        )
+        external
+        onlyOwner
+    {
+        if (enabled) {
+            addAddressToSet(MINTERS, minter, true);
+            if (isAddressInSet(DEPRECATED_MINTERS, minter)) {
+                removeAddressFromSet(DEPRECATED_MINTERS, minter);
+            }
+        } else {
+            removeAddressFromSet(MINTERS, minter);
+            if (!isAddressInSet(DEPRECATED_MINTERS, minter)) {
+                addAddressToSet(DEPRECATED_MINTERS, minter, true);
+            }
+        }
+    }
+
+    // Layer 2 logic
+
+    function mintFromL2(
+        address          to,
+        uint256          id,
+        uint             amount,
+        address          minter,
+        bytes   calldata data
+        )
+        external
+        override
+        onlyFromLayer2
+    {
+        require(isMinter(minter) || isAddressInSet(DEPRECATED_MINTERS, minter), "invalid minter");
+
+        _mint(to, id, amount, data);
+        emit MintFromL2(to, id, amount, minter);
+    }
+
+    function minters()
+        public
+        view
+        override
+        returns (address[] memory)
+    {
+        address[] memory minterAddresses = addressesInSet(MINTERS);
+        address[] memory deprecatedAddresses = addressesInSet(DEPRECATED_MINTERS);
+        address[] memory mintersAndOwner = new address[](minterAddresses.length + deprecatedAddresses.length + 1);
+        uint idx = 0;
+        for (uint i = 0; i < minterAddresses.length; i++) {
+            mintersAndOwner[idx++] = minterAddresses[i];
+        }
+         for (uint i = 0; i < deprecatedAddresses.length; i++) {
+            mintersAndOwner[idx++] = deprecatedAddresses[i];
+        }
+        // Owner could already be added to the minters, but that's fine
+        mintersAndOwner[idx++] = owner;
+        return mintersAndOwner;
+    }
+
+    function isMinter(address addr)
+        public
+        view
+        returns (bool)
+    {
+        // Also allow the owner to mint NFTs to save on gas (no additional minter needs to be set)
+        return addr == owner || isAddressInSet(MINTERS, addr);
+    }
+}

--- a/packages/loopring_v3/contracts/test/nft/ICounterfactualNFT.sol
+++ b/packages/loopring_v3/contracts/test/nft/ICounterfactualNFT.sol
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.7.0;
+
+
+/**
+ * @title ICounterfactualNFT
+ */
+abstract contract ICounterfactualNFT
+{
+    function initialize(address owner, string memory _uri)
+        public
+        virtual;
+}

--- a/packages/loopring_v3/contracts/test/nft/NFTFactory.sol
+++ b/packages/loopring_v3/contracts/test/nft/NFTFactory.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.7.0;
+pragma experimental ABIEncoderV2;
+
+import "./ICounterfactualNFT.sol";
+import "../../thirdparty/Create2.sol";
+import "./CloneFactory.sol";
+
+
+/// @title NFTFactory
+/// @author Brecht Devos - <brecht@loopring.org>
+contract NFTFactory
+{
+    event NFTContractCreated (address nftContract, address owner, string baseURI);
+
+    string public constant NFT_CONTRACT_CREATION = "NFT_CONTRACT_CREATION";
+    address public immutable implementation;
+
+    constructor(
+        address _implementation
+        )
+    {
+        implementation = _implementation;
+    }
+
+    /// @dev Create a new NFT contract.
+    /// @param owner The NFT contract owner.
+    /// @param baseURI The base token URI (empty string allowed/encouraged to use IPFS mode)
+    /// @return nftContract The new NFT contract address
+    function createNftContract(
+        address            owner,
+        string    calldata baseURI
+        )
+        external
+        payable
+        returns (address nftContract)
+    {
+        // Deploy the proxy contract
+        nftContract = Create2.deploy(
+            keccak256(abi.encodePacked(NFT_CONTRACT_CREATION, owner, baseURI)),
+            CloneFactory.getByteCode(implementation)
+        );
+
+        // Initialize
+        ICounterfactualNFT(nftContract).initialize(owner, baseURI);
+
+        emit NFTContractCreated(nftContract, owner, baseURI);
+    }
+
+    function computeNftContractAddress(
+        address          owner,
+        string  calldata baseURI
+        )
+        public
+        view
+        returns (address)
+    {
+        return _computeAddress(owner, baseURI);
+    }
+
+    function getNftContractCreationCode()
+        public
+        view
+        returns (bytes memory)
+    {
+        return CloneFactory.getByteCode(implementation);
+    }
+
+    function _computeAddress(
+        address          owner,
+        string  calldata baseURI
+        )
+        private
+        view
+        returns (address)
+    {
+        return Create2.computeAddress(
+            keccak256(abi.encodePacked(NFT_CONTRACT_CREATION, owner, baseURI)),
+            CloneFactory.getByteCode(implementation),
+            address(this)
+        );
+    }
+}

--- a/packages/loopring_v3/test/testExchangeNFT.ts
+++ b/packages/loopring_v3/test/testExchangeNFT.ts
@@ -9,6 +9,8 @@ contract("Exchange", (accounts: string[]) => {
   const bVerify = true;
 
   const L2MintableERC1155 = artifacts.require("L2MintableERC1155");
+  const NFTFactory = artifacts.require("NFTFactory");
+  const CounterfactualNFT = artifacts.require("CounterfactualNFT");
 
   let NFTA: any;
 
@@ -124,6 +126,96 @@ contract("Exchange", (accounts: string[]) => {
     );
     // Withdraw again, no tokens should be transferred
     await withdrawNFTOnceChecked(
+      owner,
+      token,
+      tokenID,
+      nftID,
+      nftType,
+      minter,
+      new BN(0)
+    );
+  };
+
+  const mintNFTOnceChecked = async (
+    owner: string,
+    token: string,
+    tokenID: number,
+    nftID: string,
+    nftType: NftType,
+    minter: string,
+    expectedAmount: BN
+  ) => {
+    // Check how much will be withdrawn
+    const onchainAmountWithdrawableBefore = await ctx.exchange.getAmountWithdrawableNFT(
+      owner,
+      token,
+      nftType,
+      nftID,
+      minter
+    );
+    assert(
+      onchainAmountWithdrawableBefore.eq(expectedAmount),
+      "unexpected withdrawable amount before"
+    );
+
+    await ctx.exchange.withdrawFromApprovedWithdrawalsNFT(
+      [owner],
+      [minter],
+      [nftType],
+      [token],
+      [nftID],
+      {
+        from: ctx.testContext.orderOwners[10]
+      }
+    );
+
+    // Complete amount needs to be withdrawn
+    const onchainAmountWithdrawableAfter = await ctx.exchange.getAmountWithdrawableNFT(
+      owner,
+      token,
+      nftType,
+      nftID,
+      minter
+    );
+    assert(
+      onchainAmountWithdrawableAfter.eq(new BN(0)),
+      "unexpected withdrawable amount after"
+    );
+
+    // Get the WithdrawalCompleted event
+    const event = await ctx.assertEventEmitted(
+      ctx.exchange,
+      "NftWithdrawalCompleted"
+    );
+    assert.equal(event.from, owner, "from unexpected");
+    assert.equal(event.to, owner, "to unexpected");
+    assert.equal(event.token, token, "token unexpected");
+    assert(event.nftID.eq(new BN(nftID.slice(2), 16)), "nftID should match");
+    assert.equal(event.tokenID.toNumber(), 0, "tokenID should be 0");
+    assert(event.amount.eq(expectedAmount), "amount unexpected");
+  };
+
+  const mintNFTChecked = async (
+    owner: string,
+    token: string,
+    tokenID: number,
+    nftID: string,
+    nftType: NftType,
+    minter: string,
+    expectedAmount: BN
+  ) => {
+    // Mint
+    await mintNFTOnceChecked(
+      owner,
+      token,
+      tokenID,
+      nftID,
+      nftType,
+      minter,
+      expectedAmount
+    );
+    // Mint again, no tokens should be minted
+    await mintNFTOnceChecked(
       owner,
       token,
       tokenID,
@@ -375,6 +467,95 @@ contract("Exchange", (accounts: string[]) => {
       await verify();
       await checkBalanceNFT(NFTA, ownerC, nftID, withdrawal.amount);
       await checkBalanceNFT(NFTA, ctx.exchange.address, nftID, new BN(0));
+    });
+
+    it("Counterfactual L2 minting and withdrawing", async () => {
+      const feeToken = "WETH";
+      const balance = new BN(web3.utils.toWei("100.0", "ether"));
+      const fee = new BN(web3.utils.toWei("0.1", "ether"));
+      const nftID =
+        "0x0123456789012345678901234567890123456789012345678901234567891234";
+      const nftIDBN = new BN(nftID.slice(2), 16);
+
+      // Fund some accounts
+      await ctx.deposit(ownerA, ownerA, feeToken, balance);
+
+      // Setup counterfactual NFT contract for the owner
+      const nftImplementation = await CounterfactualNFT.new(ctx.exchange.address);
+      const factory = await NFTFactory.new(nftImplementation.address);
+      const tokenAddress = await factory.computeNftContractAddress(ownerA, "");
+
+      // Mint an NFT to this contract
+      const nftMint = await ctx.mintNFT(
+        ownerA,
+        ownerA,
+        tokenAddress,
+        nftID,
+        new BN(10),
+        feeToken,
+        fee
+      );
+
+      // Try to withdraw the NFT
+      const withdrawal = await ctx.requestWithdrawal(
+        ownerA,
+        "NFT",
+        new BN(2),
+        feeToken,
+        fee,
+        {
+          authMethod: AuthMethod.EDDSA,
+          tokenID: nftMint.toTokenID,
+          nftMint: nftMint,
+          to: ownerB,
+        }
+      );
+
+      await ctx.submitTransactions(16);
+      await verify();
+
+      // Check that the withdrawal did indeed fail
+      const event = await ctx.assertEventEmitted(
+        ctx.exchange,
+        "NftWithdrawalFailed"
+      );
+      assert.equal(event.from, ownerA, "from should match");
+      assert.equal(event.to, ownerB, "to should match");
+      assert.equal(event.token, tokenAddress, "token should match");
+      assert(event.nftID.eq(nftIDBN), "nftID should match");
+      assert.equal(event.tokenID, withdrawal.tokenID, "tokenID should match");
+      assert(event.amount.eq(withdrawal.amount), "amount should match");
+
+      // Try to withdraw the NFTs manually before creating the contract
+      await expectThrow(
+        mintNFTOnceChecked(
+          ownerB,
+          tokenAddress,
+          nftMint.toTokenID,
+          nftID,
+          nftMint.nftType,
+          nftMint.minter,
+          withdrawal.amount,
+        ),
+        "NFT_TRANSFER_FAILURE"
+      );
+
+      // Now create the NFT contract so the NFT can be minted
+      await factory.createNftContract(ownerA, "");
+      const nft = await CounterfactualNFT.at(tokenAddress);
+
+      // Withdraw the NFT
+      await mintNFTChecked(
+        ownerB,
+        tokenAddress,
+        nftMint.toTokenID,
+        nftID,
+        nftMint.nftType,
+        nftMint.minter,
+        withdrawal.amount
+      );
+      // Check that the user received the NFT on L1
+      await checkBalanceNFT(nft, ownerB, nftID, withdrawal.amount);
     });
 
     it("NFT Forced withdrawal (NFT exists, correct owner)", async () => {


### PR DESCRIPTION
Adds the counterfactual NFT contracts in this repo.

These contracts get their own subfolder because they are independent but I also made simplified test versions directly in the protocol subfolder for ease of testing (and to minimize version clashing because the `pragma` mode doesn't seem supported with our currently used packages in the protocols subfolder).