### PR TITLE
Make quota calculation more robust

### DIFF
--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -33,7 +33,7 @@ contract UniswapV2PriceOracle is PriceOracle
         override
         returns (uint)
     {
-        if (amount == 0) return 0;
+        if (amount == 0 || amount == ~uint(0)) return 0;
         if (token == address(0) || token == wethAddress) return amount;
 
         address pair = factory.getPair(token, wethAddress);

--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -33,7 +33,7 @@ contract UniswapV2PriceOracle is PriceOracle
         override
         returns (uint)
     {
-        if (amount == 0 || amount == ~uint(0)) return 0;
+        if (amount == 0 || amount == type(uint).max) return 0;
         if (token == address(0) || token == wethAddress) return amount;
 
         address pair = factory.getPair(token, wethAddress);

--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -48,9 +48,9 @@ contract UniswapV2PriceOracle is PriceOracle
         }
 
         if (token < wethAddress) {
-            return amount.mul(reserve1 / reserve0);
+            return amount.mul(reserve1.mul(1000) / reserve0) / 1000;
         } else {
-            return amount.mul(reserve0 / reserve1);
+            return amount.mul(reserve0.mul(1000) / reserve1) / 1000;
         }
     }
 }

--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -15,7 +15,8 @@ contract UniswapV2PriceOracle is PriceOracle
     using MathUint   for uint;
 
     IUniswapV2Factory public immutable factory;
-    address public immutable wethAddress;
+    address public  immutable wethAddress;
+    uint    private constant  PRICE_SCALE = 1000;
 
     constructor(
         IUniswapV2Factory _factory,
@@ -48,9 +49,9 @@ contract UniswapV2PriceOracle is PriceOracle
         }
 
         if (token < wethAddress) {
-            return amount.mul(reserve1.mul(1000) / reserve0) / 1000;
+            return amount.mul(reserve1.mul(PRICE_SCALE) / reserve0) / PRICE_SCALE;
         } else {
-            return amount.mul(reserve0.mul(1000) / reserve1) / 1000;
+            return amount.mul(reserve0.mul(PRICE_SCALE) / reserve1) / PRICE_SCALE;
         }
     }
 }

--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -33,7 +33,7 @@ contract UniswapV2PriceOracle is PriceOracle
         override
         returns (uint)
     {
-        if (amount == 0 || amount == type(uint).max) return 0;
+        if (amount == 0) return 0;
         if (token == address(0) || token == wethAddress) return amount;
 
         address pair = factory.getPair(token, wethAddress);

--- a/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
+++ b/packages/hebao_v2/contracts/price/UniswapV2PriceOracle.sol
@@ -48,9 +48,9 @@ contract UniswapV2PriceOracle is PriceOracle
         }
 
         if (token < wethAddress) {
-            return amount.mul(reserve1) / reserve0;
+            return amount.mul(reserve1 / reserve0);
         } else {
-            return amount.mul(reserve0) / reserve1;
+            return amount.mul(reserve0 / reserve1);
         }
     }
 }


### PR DESCRIPTION
With the current implementation, when the amount is `~uint(0)`, the calculation in this price oracle will throw and cause the whole transaction to fail.