### PR TITLE
[counterfactual_nft] Disable minting on L1 and add creator

### DIFF
--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -11,7 +11,6 @@ import "./AddressSet.sol";
 import "./external/IL2MintableNFT.sol";
 import "./external/IPFS.sol";
 import "./external/OwnableUpgradeable.sol";
-import "./WithCreator.sol";
 
 
 /**
@@ -29,7 +28,6 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
     bytes32 internal constant MINTERS = keccak256("__MINTERS__");
     bytes32 internal constant DEPRECATED_MINTERS = keccak256("__DEPRECATED_MINTERS__");
     address public immutable layer2Address;
-
 
     modifier onlyFromLayer2
     {
@@ -180,7 +178,6 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
         for (uint i = 0; i < minterAddresses.length; i++) {
             mintersAndOwner[idx++] = minterAddresses[i];
         }
-
         for (uint i = 0; i < deprecatedAddresses.length; i++) {
             mintersAndOwner[idx++] = deprecatedAddresses[i];
         }
@@ -197,7 +194,6 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
         // Also allow the owner to mint NFTs to save on gas (no additional minter needs to be set)
         return addr == owner() || isAddressInSet(MINTERS, addr);
     }
-
 
     function uint2str(uint _i) internal pure returns (string memory _uintAsString) {
         if (_i == 0) {

--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -70,30 +70,31 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
         // in `minters` and `isMinter`.
     }
 
-    /// update at 2022-05-31: Do not allow minting on Layer 1
-    /* function mint( */
-    /*     address       account, */
-    /*     uint256       id, */
-    /*     uint256       amount, */
-    /*     bytes  memory data */
-    /*     ) */
-    /*     external */
-    /*     onlyFromMinter */
-    /* { */
-    /*     _mint(account, id, amount, data); */
-    /* } */
+    function mint(
+        address       account,
+        uint256       id,
+        uint256       amount,
+        bytes  memory data
+        )
+        external
+        virtual
+        onlyFromMinter
+    {
+        _mint(account, id, amount, data);
+    }
 
-    /* function mintBatch( */
-    /*     address          to, */
-    /*     uint256[] memory ids, */
-    /*     uint256[] memory amounts, */
-    /*     bytes     memory data */
-    /*     ) */
-    /*     external */
-    /*     onlyFromMinter */
-    /* { */
-    /*     _mintBatch(to, ids, amounts, data); */
-    /* } */
+    function mintBatch(
+        address          to,
+        uint256[] memory ids,
+        uint256[] memory amounts,
+        bytes     memory data
+        )
+        external
+        virtual
+        onlyFromMinter
+    {
+        _mintBatch(to, ids, amounts, data);
+    }
 
     function setMinter(
         address minter,

--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -219,6 +219,14 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
         }
     }
 
+       /**
+     * @dev Get the creator for a token
+     * @param _id   The token id to look up
+     */
+    function creator(uint256 _id) public view returns (address) {
+        return creators[_id];
+    }
+
     /**
      * @dev Change the creator address for given token
      * @param _to   Address of the new creator

--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -17,7 +17,7 @@ import "./WithCreator.sol";
 /**
  * @title CounterfactualNFT
  */
-contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradeable, OwnableUpgradeable, IL2MintableNFT, AddressSet, WithCreator
+contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradeable, OwnableUpgradeable, IL2MintableNFT, AddressSet
 {
     event MintFromL2(
         address owner,
@@ -158,11 +158,11 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
         )
         external
         override
+        virtual
         onlyFromLayer2
     {
         require(isMinter(minter) || isAddressInSet(DEPRECATED_MINTERS, minter), "invalid minter");
 
-        _setCreator(minter, id); // minter as creator
         _mint(to, id, amount, data);
         emit MintFromL2(to, id, amount, minter);
     }

--- a/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNFT.sol
@@ -88,17 +88,17 @@ contract CounterfactualNFT is ICounterfactualNFT, Initializable, ERC1155Upgradea
     /*     _mint(account, id, amount, data); */
     /* } */
 
-    function mintBatch(
-        address          to,
-        uint256[] memory ids,
-        uint256[] memory amounts,
-        bytes     memory data
-        )
-        external
-        onlyFromMinter
-    {
-        _mintBatch(to, ids, amounts, data);
-    }
+    /* function mintBatch( */
+    /*     address          to, */
+    /*     uint256[] memory ids, */
+    /*     uint256[] memory amounts, */
+    /*     bytes     memory data */
+    /*     ) */
+    /*     external */
+    /*     onlyFromMinter */
+    /* { */
+    /*     _mintBatch(to, ids, amounts, data); */
+    /* } */
 
     function setMinter(
         address minter,

--- a/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
@@ -40,4 +40,21 @@ contract CounterfactualNftExt is WithCreator, CounterfactualNFT
         revert("UNSUPPORTED");
     }
 
+    function mintFromL2(
+        address          to,
+        uint256          id,
+        uint             amount,
+        address          minter,
+        bytes   calldata data
+        )
+        external
+        override
+        onlyFromLayer2
+    {
+        require(isMinter(minter) || isAddressInSet(DEPRECATED_MINTERS, minter), "invalid minter");
+
+        _setCreator(minter, id);
+        _mint(to, id, amount, data);
+        emit MintFromL2(to, id, amount, minter);
+    }
 }

--- a/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+
+pragma solidity ^0.8.2;
+
+import "./WithCreator.sol";
+import "./CounterfactualNFT.sol";
+
+/**
+ * @title CounterfactualNFT
+ */
+contract CounterfactualNftExt is WithCreator, CounterfactualNFT
+{
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address _layer2Address)
+        CounterfactualNFT(_layer2Address)
+        {}
+
+    function mint(
+        address       /*account*/,
+        uint256       /*id*/,
+        uint256       /*amount*/,
+        bytes  memory /*data*/
+        )
+        external
+        override
+    {
+        revert("UNSUPPORTED");
+    }
+
+    function mintBatch(
+        address          /*to*/,
+        uint256[] memory /*ids*/,
+        uint256[] memory /*amounts*/,
+        bytes     memory /*data*/
+        )
+        external
+        override
+    {
+        revert("UNSUPPORTED");
+    }
+
+}

--- a/packages/counterfactual_nft/contracts/WithCreator.sol
+++ b/packages/counterfactual_nft/contracts/WithCreator.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2017 Loopring Technology Limited.
+pragma solidity ^0.8.2;
+
+
+/// @title AddressSet
+/// @author Freeman Zhong
+contract WithCreator {
+
+    mapping (uint256 => address) public creators;
+
+    /**
+     * @dev Change the creator address for given tokens
+     * @param _to   Address of the new creator
+     * @param _ids  Array of Token IDs to change creator
+     */
+    function setCreator(
+        address _to,
+        uint256[] memory _ids)
+        public
+    {
+        require(_to != address(0), "ERC1155Tradable#setCreator: INVALID_ADDRESS.");
+        for (uint256 i = 0; i < _ids.length; i++) {
+            uint256 id = _ids[i];
+            require(creators[id] == msg.sender, "ERC1155Tradable#creatorOnly: ONLY_CREATOR_ALLOWED");
+            creators[id] = _to;
+        }
+    }
+
+       /**
+     * @dev Get the creator for a token
+     * @param _id   The token id to look up
+     */
+    function creator(uint256 _id) public view returns (address) {
+        return creators[_id];
+    }
+
+    /**
+     * @dev Change the creator address for given token
+     * @param _to   Address of the new creator
+     * @param _id  Token IDs to change creator of
+     */
+    function _setCreator(address _to, uint256 _id) internal
+    {
+        creators[_id] = _to;
+    }
+
+}


### PR DESCRIPTION
Changes:
1. disable minting on L1
2. add creator info for token id (in order to keep compatible with opensea)