### PR TITLE
[counterfactual_nft] Minor change to avoid a code verification bug in etherscan

### DIFF
--- a/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
+++ b/packages/counterfactual_nft/contracts/CounterfactualNftExt.sol
@@ -14,7 +14,7 @@ contract CounterfactualNftExt is CounterfactualNFT, OpenseaSupport
     bool public immutable openMinting;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _layer2Address, bool _openMinting) CounterfactualNFT(_layer2Address)
+    constructor(bool _openMinting, address _layer2Address) CounterfactualNFT(_layer2Address)
     {
         openMinting = _openMinting;
     }

--- a/packages/counterfactual_nft/flatten.sh
+++ b/packages/counterfactual_nft/flatten.sh
@@ -3,7 +3,7 @@
 FLATTER_COMMAND="./node_modules/.bin/truffle-flattener"
 
 SPDX_FILTER="SPDX-License-Identifier"
-SPDX_LINE="// SPDX-License-Identifier: Apache-2.0"
+SPDX_LINE="// SPDX-License-Identifier: MIT"
 
 declare -a all_contracts=(
     "contracts/CounterfactualNftExt.sol"
@@ -20,6 +20,8 @@ do
     dest_file="$DEST/${file_name}_flat.sol"
     $FLATTER_COMMAND "../$contract" \
         | grep -v "$SPDX_FILTER" > $dest_file
+
+    (echo -e "$SPDX_LINE" && cat $dest_file ) > "${dest_file}.tmp" && mv "${dest_file}.tmp" $dest_file
 
     echo "${file_name}.sol successfully flattened, saved to ${dest_file}"
 done

--- a/packages/counterfactual_nft/flattened/CounterfactualNftExt_flat.sol
+++ b/packages/counterfactual_nft/flattened/CounterfactualNftExt_flat.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // File: contracts/IOpenseaSupport.sol
 
 // Copyright 2017 Loopring Technology Limited.
@@ -1772,7 +1773,7 @@ contract CounterfactualNftExt is CounterfactualNFT, OpenseaSupport
     bool public immutable openMinting;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
-    constructor(address _layer2Address, bool _openMinting) CounterfactualNFT(_layer2Address)
+    constructor(bool _openMinting, address _layer2Address) CounterfactualNFT(_layer2Address)
     {
         openMinting = _openMinting;
     }

--- a/packages/counterfactual_nft/flattened/NFTFactory_flat.sol
+++ b/packages/counterfactual_nft/flattened/NFTFactory_flat.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 // File: contracts/ICounterfactualNFT.sol
 
 // Copyright 2017 Loopring Technology Limited.


### PR DESCRIPTION
When the last value in the constructor is encoded to all zeros, it will trigger a bug when doing code verification in etherscan.
So I changed the order of params.