### PR TITLE
Use Memory Type Variable Instead of Storage Type Variable in Event to Save Gas

### DIFF
--- a/packages/hebao_v1/contracts/modules/ControllerImpl.sol
+++ b/packages/hebao_v1/contracts/modules/ControllerImpl.sol
@@ -64,6 +64,6 @@ contract ControllerImpl is Claimable, Controller
         require(walletFactory == address(0), "INITIALIZED_ALREADY");
         require(_walletFactory != address(0), "ZERO_ADDRESS");
         walletFactory = _walletFactory;
-        emit AddressChanged("WalletFactory", walletFactory);
+        emit AddressChanged("WalletFactory", _walletFactory);
     }
 }

--- a/packages/hebao_v1/legacy/version1.0/contracts/ControllerImpl.sol
+++ b/packages/hebao_v1/legacy/version1.0/contracts/ControllerImpl.sol
@@ -75,7 +75,7 @@ contract ControllerImpl is Claimable, Controller
     {
         require(_collectTo != address(0), "ZERO_ADDRESS");
         collectTo = _collectTo;
-        emit ValueChanged("CollectTo", collectTo);
+        emit ValueChanged("CollectTo", _collectTo);
     }
 
     function setPriceOracle(PriceOracle _priceOracle)

--- a/packages/lrc_v2/contracts/LRCFoundationIceboxContract_v2.sol
+++ b/packages/lrc_v2/contracts/LRCFoundationIceboxContract_v2.sol
@@ -143,7 +143,7 @@ contract NewLRCFoundationIceboxContract {
         lrcUnlockPerMonth = lrcInitialBalance.div(24); // 24 month
         startTime = _startTime;
 
-        emit Started(startTime);
+        emit Started(_startTime);
     }
 
     function withdraw() public onlyOwner {

--- a/packages/lrc_v2/contracts/NewLRCFoundationIceboxContract.sol
+++ b/packages/lrc_v2/contracts/NewLRCFoundationIceboxContract.sol
@@ -206,7 +206,7 @@ contract NewLRCFoundationIceboxContract is Claimable {
         lrcUnlockPerMonth = lrcInitialBalance.div(24); // 24 month
         startTime = _startTime;
 
-        emit Started(startTime);
+        emit Started(_startTime);
     }
 
     function withdraw() public onlyOwner {


### PR DESCRIPTION
Hi, we are a research group on programming languages and software engineering. We recently have conducted a systematic study about Solidity event usage, evolution, and impact, and we are attempting to build a tool to improve the practice of Solidity event use based on our findings. We have tried our prototype tool on some of the most popular GitHub Solidity repositories, and for your repository, we find a potential optimization of gas consumption arisen from event use.

The point is that when we use emit operation to store the value of a certain variable, `local memory type variable` would be preferable to `storage type (state) variable` if they hold the same value. The reason is that an extra SLOAD operation would be needed to access the variable if it is storage type, and the SLOAD operation costs 800 gas.

For your repository, we find that several event uses can be improved.